### PR TITLE
docs: update plan.md with session progress (2026-03-16)

### DIFF
--- a/.claude/agent-memory/semantic-reviewer/patterns.md
+++ b/.claude/agent-memory/semantic-reviewer/patterns.md
@@ -361,6 +361,30 @@ could leak validation error details (field names, schema shape) before being rej
 **Recurrence (54e9351):** `batchSubmitQuiz` in `batch-submit.ts` correctly continues the pattern — auth check at line 32 before `BatchSubmitInput.parse(raw)` at line 34. Pattern is holding.
 **Watch for:** any new Server Action where `.parse(raw)` appears before `getUser()` / `requireAuth()`.
 
+### current_setting('role') vs current_role confusion in trigger functions (1st occurrence)
+**First seen:** commit 6595229 (2026-03-16)
+**File:** `supabase/migrations/20260316000041_protect_users_sensitive_columns.sql` line 12
+**Pattern:** A BEFORE UPDATE trigger used `current_setting('role') = 'service_role'` to detect
+whether the caller is the Supabase service role. This is the wrong API:
+- `current_setting('role')` reads a GUC (Grand Unified Configuration) parameter named "role".
+  This GUC does not exist by default and throws `ERROR: unrecognized configuration parameter "role"`
+  unless something has explicitly SET it in the session.
+- `current_role` (or `current_user`) is the Postgres built-in that returns the active role name —
+  this is what PostgREST sets when it uses the service role key.
+The bug means the trigger throws on every UPDATE to the table, including from the service role,
+rather than allowing service-role writes through.
+**Fix:** Replace `current_setting('role')` with `current_role`.
+**Secondary pattern (SECURITY DEFINER interaction):** If a SECURITY DEFINER RPC owned by `postgres`
+needs to UPDATE sensitive columns, `current_role` inside the trigger will return `postgres`, not
+`service_role`. In that case use a session-level application flag:
+  `PERFORM set_config('app.bypass_user_trigger', 'true', true)` before the UPDATE, and check
+  `current_setting('app.bypass_user_trigger', true) = 'true'` in the trigger.
+**Watch for:** Any trigger function that inspects the caller's identity to make an allow/block
+decision. Always use `current_role` for Postgres role checks, not `current_setting('role')`.
+Also watch for `SECURITY DEFINER` RPCs that UPDATE tables with column-guarding triggers — the
+trigger sees the definer's role, not the original caller's role.
+**Status:** ISSUE — flagged in 6595229.
+
 ### submitQuizAnswer / completeQuiz — ZodError propagates uncaught (FULLY RESOLVED in commit 9d9e898)
 **First seen:** commit 23a9f10 (2026-03-12)
 **File:** `apps/web/app/app/quiz/actions.ts` — `submitQuizAnswer`, `completeQuiz` (now deleted)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -212,6 +212,15 @@
 - Issues #43, #4, #29 closed as stale (Smart Review removed), #101 already done
 - PR #181 merged
 
+**Security & dev tooling sprint (2026-03-16):**
+- PR #227: commitlint 19→20, jsdom 28→29, @types/node 20→22
+- PR #228: removed hardcoded Supabase keys from integration tests
+- PR #230: pinned all GitHub Actions to immutable commit SHAs
+- PR #231: added knip dead-code scanner (weekly cron + manual dispatch)
+- PR #232: re-tracked docs/config + fixed 7 hook bugs (guard-bash CRITICAL, review-gate, code-reviewer scope, etc.)
+- PR #245: defense-in-depth trigger on users table blocking role/org/deleted_at privilege escalation (#236)
+- 7 Dependabot PRs auto-created for SHA-pinned action bumps
+
 **Tech Debt PR #10 done (2026-03-15):** Infrastructure & Scripts:
 - CI security hardening: added `permissions: contents: read` to `ci.yml` (principle of least privilege)
 - Security auditor grep fix: improved detection of `adminClient` usage in app files (scans full file diffs, not just line context)


### PR DESCRIPTION
## Summary

Update docs/plan.md with session progress: PRs #227-#245, security trigger, knip scanner, SHA-pinned actions, hook bug fixes.

## Test plan
- [x] Docs only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added pattern documentation for role-based access control and security best practices.
  * Updated product roadmap with upcoming infrastructure hardening, validation improvements, and tooling enhancements planned for upcoming sprints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->