### PR TITLE
chore(ci): bump CI action versions

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Download previous baseline artifact
         if: steps.prev-run.outputs.run_id != ''
         id: download-baseline
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bundle-baseline
           path: /tmp/bundle-artifact

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4

--- a/.github/workflows/coverage-trend.yml
+++ b/.github/workflows/coverage-trend.yml
@@ -51,7 +51,7 @@ jobs:
         if: steps.prev-run.outputs.run_id != ''
         id: download-baseline
         continue-on-error: true
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: coverage-baseline
           merge-multiple: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -13,7 +13,7 @@ jobs:
     name: Label & Close Stale Issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           only: 'issues'
           days-before-stale: 30


### PR DESCRIPTION
## Summary
- **github/codeql-action**: patch bump within v4 (b1bff819 → 38697555, v4.34.1)
- **actions/stale**: v9 → v10 (Node 24 runtime, no input changes needed)
- **actions/download-artifact**: v4 → v8 (ESM migration, hash enforcement default)
- 8 other actions already at latest SHA — no changes needed

Part of #344.

## Test plan
- [x] CI workflows pass on this PR (codeql, stale-issues, bundle-size, coverage-trend)
- [x] No application code changed — no unit/E2E tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to newer versions for improved reliability and maintenance of CI/CD tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->