### PR TITLE
fix(auth): prevent login form flash on successful sign-in

### DIFF
--- a/apps/web/app/_components/login-form.tsx
+++ b/apps/web/app/_components/login-form.tsx
@@ -52,15 +52,16 @@ export function LoginForm({ initialError }: LoginFormProps) {
 
       if (authError) {
         setError(FRIENDLY_AUTH_ERRORS[authError.message] ?? 'Unable to sign in. Please try again.')
+        setLoading(false)
         return
       }
     } catch {
       setError('Unable to sign in. Please try again.')
-      return
-    } finally {
       setLoading(false)
+      return
     }
 
+    // Keep loading state active — the page is navigating away
     window.location.href = '/auth/login-complete'
   }
 


### PR DESCRIPTION
## Summary
- Keep loading state ("Signing in...") active during navigation to `/auth/login-complete` instead of resetting it in a `finally` block
- The `finally` block was calling `setLoading(false)` before `window.location.href` fired, causing the button to briefly flash back to "Sign in" and the form to appear idle — creating a transient visual glitch on every successful login

## Test plan
- [ ] Log in with valid credentials — button stays on "Signing in..." until dashboard loads
- [ ] Log in with invalid credentials — error message appears, button resets to "Sign in"
- [ ] Trigger network error — error message appears, button resets to "Sign in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading indicator behavior during authentication errors to prevent stuck loading states
  * Improved login form control flow to ensure proper state transitions through error and success scenarios
  * Login form now correctly completes authentication with proper redirect

<!-- end of auto-generated comment: release notes by coderabbit.ai -->