### PR TITLE
feat: Internal Exam Mode (admin-issued, single-use, audited)

### DIFF
--- a/.claude/hooks/run-security-auditor.sh
+++ b/.claude/hooks/run-security-auditor.sh
@@ -31,7 +31,10 @@ if [ "$DIFF_LINES" -gt "$MAX_DIFF_LINES" ]; then
   FILTERED_LINES=$(printf '%s' "$DIFF" | wc -l)
   if [ "$FILTERED_LINES" -gt "$MAX_DIFF_LINES" ]; then
     echo "[security-auditor] Filtered diff still large ($FILTERED_LINES lines). Truncating to $MAX_DIFF_LINES lines."
-    DIFF=$(printf '%s' "$DIFF" | head -n "$MAX_DIFF_LINES")
+    # Use awk instead of head to avoid SIGPIPE (exit 141) under `set -o pipefail`.
+    # `head -n` closes its stdin once the limit is reached, which causes the
+    # upstream `printf` to receive SIGPIPE and abort the script.
+    DIFF=$(printf '%s' "$DIFF" | awk -v max="$MAX_DIFF_LINES" 'NR <= max')
     DIFF="$DIFF
 ... (truncated — $FILTERED_LINES total lines, showing first $MAX_DIFF_LINES)"
   fi

--- a/.spec-workflow/specs/internal-exam-mode/design.md
+++ b/.spec-workflow/specs/internal-exam-mode/design.md
@@ -1,0 +1,323 @@
+# Design Document — Internal Exam Mode
+
+## Overview
+
+Internal Exam Mode adds a fourth value `'internal_exam'` to `quiz_sessions.mode`, alongside the existing `smart_review`, `quick_quiz`, `mock_exam`. It introduces one new table (`internal_exam_codes`), three new RPCs (`issue_internal_exam_code`, `start_internal_exam_session`, `void_internal_exam_code`), and extends two existing RPCs (`batch_submit_quiz`, `complete_overdue_exam_session`) to recognize the new mode.
+
+The student-facing UI clones the existing exam-session components 1:1 (timer, answer buffer, results card) by passing the new mode through unchanged. Only the badge label, the entry path (code-entry modal vs. quiz-config form), and the discard-button visibility differ. A new top-level nav item "Internal Exam" routes to a two-tab page (`Available` + `My Reports`). The admin gets a sibling `/app/admin/internal-exams` page with code-issuance + voiding + monitoring.
+
+Reports separation: the existing `/app/reports` query gains a `.neq('mode', 'internal_exam')` filter; internal-exam reports live exclusively under the new student tab and the admin page.
+
+## Steering Document Alignment
+
+### Technical Standards (`tech.md`)
+
+- All mutations via Server Actions; no API route handlers.
+- Every new RPC: `SECURITY DEFINER` + `auth.uid()` check + `SET search_path = public` + `deleted_at IS NULL` filters on every user / session / subject / exam_config lookup, including audit-event INSERT subqueries (`security.md` rule 10).
+- `mode='internal_exam'` is added to `quiz_sessions.mode` CHECK via a single forward migration (no edits to existing migration files).
+- Each new RPC migration ≤ 300 SQL lines; split if approaching the limit.
+- TypeScript strict, no `any`, Zod parse on every Server Action input.
+
+### Project Structure (`structure.md`)
+
+- New student route: `apps/web/app/app/internal-exam/` with co-located `_components/`, `_hooks/`, `actions/`.
+- New admin route: `apps/web/app/app/admin/internal-exams/` with the same sub-structure.
+- New constants module: `apps/web/lib/constants/exam-modes.ts` (centralizes `MODE_LABELS`, closes #544).
+- New migrations: `057_*` → `06x_*`, both timestamped (in `supabase/migrations/`) and numbered (in `packages/db/migrations/`).
+- Tests co-located.
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage (REUSE — no edit)
+
+| File | How |
+|---|---|
+| `apps/web/app/app/quiz/_components/exam-countdown-timer.tsx` | Mode-agnostic; passed `timeLimitSeconds`, `startedAt`, `onExpired`. |
+| `apps/web/app/app/quiz/session/_components/quiz-session.tsx` | Already accepts `mode`; pass `'internal_exam'`. |
+| `apps/web/app/app/quiz/session/_components/quiz-session-loader.tsx` | Async bootstrap unchanged. |
+| `apps/web/app/app/quiz/session/_components/quiz-session-header.tsx` | Already takes `isExam` boolean. |
+| `apps/web/app/app/quiz/session/_hooks/use-exam-state.ts` | Already mode-aware. |
+| `apps/web/app/app/quiz/session/_hooks/use-exam-answer-buffer.ts` | Mode-agnostic for exam family. |
+| `apps/web/app/app/quiz/_hooks/use-auto-submit-countdown.ts`, `use-quiz-recovery.ts`, `use-session-bootstrap.ts` | Reused as-is. |
+| `apps/web/app/app/quiz/report/_components/report-card.tsx`, `result-summary.tsx` | Used by the student internal-exam report page; the only mode-specific bit is the badge label, sourced from `MODE_LABELS`. |
+
+### Components to Extend in Place (EXTEND — small mode-aware change)
+
+| File | Change |
+|---|---|
+| `apps/web/app/app/quiz/session/_components/exam-session-header.tsx` | Replace hardcoded `"PRACTICE EXAM"` with `MODE_LABELS[mode].toUpperCase()`. |
+| `apps/web/app/app/quiz/actions/discard.ts` | Reject when session `mode = 'internal_exam'` with `error: 'cannot_discard_internal_exam'`. |
+| ~~`apps/web/app/app/quiz/actions/get-active-exam-session.ts`~~ | **Do NOT widen.** Forked into a new `getActiveInternalExamSession()` instead — see Architecture. |
+| `apps/web/app/app/reports/...` (whichever query lists session reports) | Add `.neq('mode', 'internal_exam')` to exclude internal attempts from practice/quiz reports. |
+| `apps/web/app/app/_components/nav-items.ts` | Add new top-level student item `Internal Exam` and admin item `Internal Exams`. |
+
+### RPCs to Extend in Place (latest revisions only — `CREATE OR REPLACE` in a new migration)
+
+| RPC | Latest migration | Change |
+|---|---|---|
+| `batch_submit_quiz` | `056_fix_batch_submit_audit_actor_role_softdelete.sql` | Add `internal_exam` to mode-comparison branches. **Crucial difference vs `mock_exam`:** do NOT enforce the all-questions-answered guard for `internal_exam`. Compute `passed` from `pass_mark` for both `mock_exam` and `internal_exam`. Audit event_type for `internal_exam` is `'internal_exam.completed'`. |
+| `complete_overdue_exam_session` | `052_align_overdue_threshold_grace.sql` (latest revision; 054 only touches `start_exam_session`) | Widen mode filter from `mode = 'mock_exam'` to `mode IN ('mock_exam', 'internal_exam')`. Audit event_type uses `internal_exam.expired` when applicable. |
+| `complete_empty_exam_session` | `055_align_complete_empty_audit_metadata.sql` | Same widening. (For internal exam, this only fires if zero answers + timeout — equivalent to overdue with empty buffer.) |
+| `is_admin()` | `031_admin_rls_easa_tables.sql` | **Add `AND deleted_at IS NULL` to the users lookup.** Currently soft-deleted admins still pass `is_admin()` (security gap caught in plan-critic). New migration `057a` extends the function before the new admin RPCs land. |
+
+### Integration Points
+
+- **`exam_configs` table:** reused unchanged. Internal exam draws `total_questions`, `time_limit_seconds`, `pass_mark`, and the topic distribution from the same row that practice exam uses. Issuance blocks if no enabled config exists for the subject.
+- **`quiz_sessions` table:** reused unchanged except for the CHECK extension on `mode`. Internal exam sessions populate the same `config jsonb` shape (`{question_ids, exam_config_id, pass_mark}`).
+- **`audit_events`:** new event types only; no schema change.
+
+## Architecture
+
+### Modular Design Principles
+
+- **Single File Responsibility:** one RPC per migration file (issuance / start / void), each ≤ 300 lines.
+- **Component Isolation:** student internal-exam page is composition only (≤ 80 lines); tabs are separate component files.
+- **Service Layer Separation:** code generation lives in the RPC (atomic with insert); the Server Action is a thin Zod-parsed wrapper.
+- **Utility Modularity:** `MODE_LABELS` constant + a tiny helper `isExamMode(mode): boolean` that returns true for `mock_exam` and `internal_exam`.
+
+```mermaid
+graph TD
+    A[Admin: /app/admin/internal-exams] -->|issue| B(issue_internal_exam_code RPC)
+    B --> C[(internal_exam_codes)]
+    A -->|void| D(void_internal_exam_code RPC)
+    D --> C
+    D -->|if session active| E[(quiz_sessions: end with passed=false)]
+    F[Student: /app/internal-exam Available] -->|click Start, enter code| G(start_internal_exam_session RPC)
+    G -->|validate code| C
+    G -->|create session| E
+    H[Existing /app/quiz/session UI] -->|reused| I[batch_submit_quiz RPC: extended for internal_exam]
+    I --> E
+    J[complete_overdue_exam_session RPC: extended] --> E
+    K[Student: /app/internal-exam My Reports] -->|read| E
+    L[Admin: /app/admin/internal-exams] -->|read| C
+    L --> E
+```
+
+### Reuse vs. fork decision for `get-active-exam-session.ts`
+
+The existing `getActiveExamSession()` (`apps/web/app/app/quiz/actions/get-active-exam-session.ts`) returns sessions for the practice-exam recovery banner and **does not include `mode` in its return shape**. Widening its mode filter would mix internal-exam sessions into the practice recovery banner with practice-exam copy.
+
+Decision: **FORK** into `getActiveInternalExamSession()` under `apps/web/app/app/internal-exam/actions/`. Reuse the `_overdue-helpers` module unchanged. The forked function differs only in (a) `.eq('mode', 'internal_exam')` and (b) calls `complete_overdue_exam_session` for the same RPC since that RPC is widened to support both modes (migration 063). This keeps the practice recovery banner clean and lets the internal-exam page own its own recovery UI.
+
+### Code generation algorithm
+
+```
+charset = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'   -- 32 chars, excludes 0,O,I,1
+attempt 1..5:
+  code = 8 random chars from charset
+  try INSERT into internal_exam_codes
+  if unique violation -> retry
+  else -> return code
+exhausted -> raise 'code_generation_failed'
+```
+
+Run inside the RPC. Collision probability per attempt ≈ active_codes / 32^8 (negligible).
+
+## Components and Interfaces
+
+### Migration: `057_internal_exam_codes.sql`
+- Create `internal_exam_codes` table (columns per Data Models section).
+- Indexes: `(student_id) WHERE consumed_at IS NULL AND voided_at IS NULL AND deleted_at IS NULL`; UNIQUE on `code` (case-sensitive).
+- RLS: enable. Student SELECT policy `student_id = auth.uid() AND consumed_at IS NULL AND voided_at IS NULL AND expires_at > now() AND deleted_at IS NULL`. Admin SELECT/INSERT/UPDATE/DELETE policies scoped to `organization_id` via `is_admin()`. (Practical writes go through SECURITY DEFINER RPCs — admin policies cover ad-hoc admin tooling and the void path.)
+
+### Migration: `058_extend_quiz_sessions_mode_check.sql`
+The mode CHECK in `001_initial_schema.sql:185` was declared **inline** without an explicit name, so the auto-generated constraint name varies by Postgres version. Use a `DO $$` block to look up the actual name and drop it:
+
+```sql
+DO $$
+DECLARE
+  v_constraint_name text;
+BEGIN
+  SELECT conname INTO v_constraint_name
+  FROM pg_constraint
+  WHERE conrelid = 'public.quiz_sessions'::regclass
+    AND contype = 'c'
+    AND pg_get_constraintdef(oid) ILIKE '%mode%mock_exam%';
+  IF v_constraint_name IS NULL THEN
+    RAISE EXCEPTION 'Could not locate mode CHECK constraint on quiz_sessions';
+  END IF;
+  EXECUTE format('ALTER TABLE public.quiz_sessions DROP CONSTRAINT %I', v_constraint_name);
+END $$;
+
+ALTER TABLE public.quiz_sessions
+  ADD CONSTRAINT quiz_sessions_mode_check
+  CHECK (mode IN ('smart_review', 'quick_quiz', 'mock_exam', 'internal_exam'));
+```
+
+The new constraint is given an explicit name so future migrations have a stable handle.
+
+### Migration: `059_issue_internal_exam_code_rpc.sql`
+- `issue_internal_exam_code(p_subject_id uuid, p_student_id uuid) RETURNS TABLE(code_id uuid, code text, expires_at timestamptz)`
+- SECURITY DEFINER, SET search_path = public.
+- Auth: `auth.uid()` not null + `is_admin()` true (with `deleted_at IS NULL` on the admin user lookup).
+- Scope: `p_student_id` must belong to caller's org and be a non-deleted student (role check).
+- Pre-req: an enabled non-deleted `exam_configs` row for `(org, p_subject_id)` exists.
+- Generates 8-char code (charset above), retries up to 5x on unique violation.
+- INSERTs into `internal_exam_codes` with `expires_at = now() + interval '24 hours'`, `issued_by = auth.uid()`.
+- Audit: `internal_exam.code_issued` with full subquery deleted_at filters.
+
+### Migration: `060_start_internal_exam_session_rpc.sql`
+- `start_internal_exam_session(p_code text) RETURNS TABLE(session_id, question_ids[], time_limit_seconds, total_questions, pass_mark, started_at)`
+- SECURITY DEFINER.
+- Validates code (errors as enumerated in Requirement 2.4).
+- Auto-completes any existing overdue same-subject session for this student first (mirroring `start_exam_session` behavior).
+- Builds `question_ids` per the subject's `exam_config_distributions` (same logic as `start_exam_session` — extract that select into a helper if duplicated 2x).
+- INSERTs `quiz_sessions` with `mode='internal_exam'`, `time_limit_seconds`, `config = {question_ids, exam_config_id, pass_mark}`, `started_at = now()`.
+- UPDATEs `internal_exam_codes` SET `consumed_at = now()`, `consumed_session_id = new id` WHERE id = code AND consumed_at IS NULL (race-safe via WHERE clause).
+- Audit: `internal_exam.started`.
+
+### Migration: `061_void_internal_exam_code_rpc.sql`
+- `void_internal_exam_code(p_code_id uuid, p_reason text) RETURNS TABLE(code_id uuid, session_id uuid, session_ended boolean)`
+- Admin only. Checks code state:
+  - Unconsumed → just void (UPDATE `voided_at`/`voided_by`/`void_reason`).
+  - Consumed + session active (`ended_at IS NULL`) → void code AND end session: compute score from existing `quiz_session_answers` (treat unanswered as wrong), set `passed = false` (force fail per requirement 4.2 — admin override fails the attempt regardless of score), `ended_at = now()`. Emit `internal_exam.expired` for the session, `internal_exam.code_voided` for the code.
+  - Consumed + session ended → raise `cannot_void_finished_attempt`.
+
+### Migration: `062_extend_batch_submit_for_internal_exam.sql`
+- `CREATE OR REPLACE FUNCTION batch_submit_quiz(...)` — copy latest body from `056`, adjust:
+  - All-answered guard: only when `v_mode = 'mock_exam'` (NOT `internal_exam`). Internal exam allows partial submissions.
+  - Pass computation: when `v_mode IN ('mock_exam', 'internal_exam')`, compute `v_passed`. (Was previously only `mock_exam`.)
+  - Audit event_type: `'mock_exam' → 'exam.completed'`, `'internal_exam' → 'internal_exam.completed'`, else `'quiz_session.batch_submitted'`.
+
+### Migration: `063_extend_overdue_completion_for_internal_exam.sql`
+- `CREATE OR REPLACE FUNCTION complete_overdue_exam_session(...)` — copy latest body from `054`, change `mode = 'mock_exam'` → `mode IN ('mock_exam', 'internal_exam')`. Audit event_type branches the same way.
+- Same change for `complete_empty_exam_session` (latest `055`) — included in this migration if line budget permits, else split into `064`.
+
+### Server Actions
+
+- `apps/web/app/app/admin/internal-exams/actions/issue-code.ts` — Zod parse `{ studentId, subjectId }`, `requireAdmin()`, call `issue_internal_exam_code` RPC, return `{ codeId, code, expiresAt }`. Logs error sanitized.
+- `apps/web/app/app/admin/internal-exams/actions/void-code.ts` — Zod parse `{ codeId, reason }`, `requireAdmin()`, call `void_internal_exam_code` RPC.
+- `apps/web/app/app/admin/internal-exams/queries.ts` — list issued codes (filterable), list internal-exam sessions across org.
+- `apps/web/app/app/internal-exam/actions/start-internal-exam.ts` — Zod parse `{ code }`, call `start_internal_exam_session` RPC, return session_id + redirect URL.
+- `apps/web/app/app/internal-exam/queries.ts` — list available codes for `auth.uid()` (returns subject + expiry, never the code value itself), list student's internal-exam history.
+
+### Pages and Components
+
+- **Student** `/app/internal-exam/page.tsx` (≤ 80 lines): tabs scaffold, queries the two lists.
+  - `_components/available-tab.tsx`: list of available exams + start button → opens `_components/code-entry-modal.tsx`.
+  - `_components/my-reports-tab.tsx`: list of past attempts, links to existing report page (`/app/quiz/report?id=...`).
+  - `_components/code-entry-modal.tsx`: form with code input, calls `startInternalExam` action, redirects on success.
+
+- **Admin** `/app/admin/internal-exams/page.tsx` (≤ 80 lines): tabs (Codes / Attempts).
+  - `_components/issue-code-form.tsx`: student picker + subject picker → submit → display generated code in a copy-to-clipboard panel.
+  - `_components/codes-table.tsx`: filterable list with status badges and void action.
+  - `_components/void-code-dialog.tsx`: reason input + confirm.
+  - `_components/attempts-table.tsx`: completed internal-exam sessions, drilldown to existing report page.
+
+### Constant module
+
+- `apps/web/lib/constants/exam-modes.ts`:
+  ```ts
+  export const MODE_LABELS = {
+    smart_review: 'Smart Review',
+    quick_quiz: 'Quick Quiz',
+    mock_exam: 'Practice Exam',
+    internal_exam: 'Internal Exam',
+  } as const
+  export type QuizMode = keyof typeof MODE_LABELS
+  export const EXAM_MODES = ['mock_exam', 'internal_exam'] as const
+  export const isExamMode = (m: string): m is 'mock_exam' | 'internal_exam' =>
+    (EXAM_MODES as readonly string[]).includes(m)
+  ```
+
+## Data Models
+
+### `internal_exam_codes` table
+
+```
+- id                  uuid PK default gen_random_uuid()
+- code                text NOT NULL UNIQUE             -- 8-char ABCDEFGHJKLMNPQRSTUVWXYZ23456789
+- subject_id          uuid NOT NULL FK -> subjects(id)
+- student_id          uuid NOT NULL FK -> users(id)
+- issued_by           uuid NOT NULL FK -> users(id)    -- admin
+- issued_at           timestamptz NOT NULL default now()
+- expires_at          timestamptz NOT NULL             -- issued_at + 24h
+- consumed_at         timestamptz NULL
+- consumed_session_id uuid NULL FK -> quiz_sessions(id)
+- voided_at           timestamptz NULL
+- voided_by           uuid NULL FK -> users(id)
+- void_reason         text NULL
+- organization_id     uuid NOT NULL FK -> organizations(id)
+- deleted_at          timestamptz NULL
+```
+
+CHECK: `(consumed_at IS NULL OR consumed_session_id IS NOT NULL)` — once consumed, must have a session.
+CHECK: `(voided_at IS NULL) = (voided_by IS NULL)` — both or neither.
+
+### `quiz_sessions.mode` extension
+
+CHECK constraint widened to include `'internal_exam'`. No new columns.
+
+### `quiz_sessions.config` jsonb shape (unchanged)
+
+```
+{ "question_ids": [uuid,...], "exam_config_id": uuid, "pass_mark": 1..100 }
+```
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Code not found / wrong student / expired / consumed / voided** at `start_internal_exam_session`
+   - Handling: RPC raises a domain-typed error string (e.g. `code_not_found`, `code_expired`, `code_already_used`, `code_voided`, `code_not_yours`). Server action maps to user-friendly message; never reveals whether the code exists for a different student.
+   - User Impact: modal shows "Invalid or expired code. Please contact your administrator."
+
+2. **No `exam_configs` row for subject** at `issue_internal_exam_code`
+   - Handling: RPC raises `exam_config_required`.
+   - User Impact: admin sees inline "Configure exam for this subject first" with a link to `/app/admin/exam-config`.
+
+3. **Code generation collision** (5 retries exhausted)
+   - Handling: RPC raises `code_generation_failed`. Server logs error.
+   - User Impact: "Failed to generate code, please try again." (Effectively never happens at expected scale.)
+
+4. **Concurrent code consumption** (two browser tabs hit "Start" with the same code)
+   - Handling: `UPDATE internal_exam_codes SET consumed_at = now() WHERE id = ... AND consumed_at IS NULL` — one wins, the other gets 0 affected rows and the RPC raises `code_already_used`.
+   - User Impact: second tab sees "Code already used."
+
+5. **Admin tries to void a finished attempt**
+   - Handling: RPC raises `cannot_void_finished_attempt`.
+   - User Impact: button disabled in UI when status='finished'; if forced via direct call, error toast shown.
+
+6. **Student calls discard on an internal_exam session**
+   - Handling: extended `discard.ts` rejects with `cannot_discard_internal_exam`.
+   - User Impact: button hidden in UI; defense-in-depth at server.
+
+7. **Internal exam session deadline passes without submission**
+   - Handling: extended `complete_overdue_exam_session` runs (triggered by `getActiveExamSession` recovery path on next page load).
+   - User Impact: student sees "This exam has expired and was auto-submitted" on the report page.
+
+## Testing Strategy
+
+### Unit Testing
+
+- New constants module: type-level test that every existing mode in CHECK has a label.
+- `issueCode` Server Action: Zod parsing, `requireAdmin` enforcement, RPC error mapping.
+- `voidCode` Server Action: same.
+- `startInternalExam` Server Action: same; URL-redirect destination assertion (per `agent-test-writer.md` rule 2026-04-27).
+- `discard.ts` extension: rejects when `mode='internal_exam'`.
+- `code-entry-modal`: validates code format, calls action, redirects on success, shows error on failure.
+- `available-tab` and `my-reports-tab`: render given fixture data, no live data calls.
+- Snapshot/render test for `exam-session-header` with both `mock_exam` and `internal_exam` showing correct label.
+
+### Integration Testing (SQL — `pnpm sql-tests`)
+
+- `issue_internal_exam_code`: admin OK; non-admin denied; soft-deleted student denied; missing exam_config denied; collision retry; audit row created.
+- `start_internal_exam_session`: each error code path; double-start race protected; correct question_ids built from distribution.
+- `void_internal_exam_code`: each branch (unconsumed / active / finished); audit rows; session ended with passed=false on active branch.
+- `batch_submit_quiz` extension: `internal_exam` partial submission accepted; pass/fail computed; audit event_type correct.
+- `complete_overdue_exam_session` extension: `internal_exam` mode included.
+
+### End-to-End Testing (Playwright)
+
+- **Lifecycle test (per `agent-test-writer.md` rule 2026-04-27):** admin issues code → student sees Available row → student starts via code → answers some questions → submits → lands on report with "Internal Exam" badge and pass/fail → My Reports tab lists the attempt.
+- **Refresh-resume test (per same rule):** student starts internal exam → reload mid-session → assert resume works (recovery banner or auto-resume identical to practice exam).
+- **Discard blocked:** student in active internal exam → no Discard button visible.
+- **Void during active session:** admin issues + student starts + admin voids → student's next page action returns expired/cancelled state.
+- **Reports separation:** student's existing `/app/reports` excludes internal-exam attempts; only My Reports tab shows them.
+
+### Red-team coverage (advisory — `agent-red-team` runs on push)
+
+- Cross-student code use: code issued to student A, student B authenticated, calls `start_internal_exam_session(p_code)` → must fail with generic error.
+- Admin from another org tries to void a code → must fail.
+- Direct `INSERT` on `internal_exam_codes` from student session → blocked by RLS (no student INSERT policy).
+- Direct `UPDATE` on `internal_exam_codes` from student session to clear `consumed_at` → blocked by RLS.

--- a/.spec-workflow/specs/internal-exam-mode/requirements.md
+++ b/.spec-workflow/specs/internal-exam-mode/requirements.md
@@ -1,0 +1,109 @@
+# Requirements Document — Internal Exam Mode
+
+## Introduction
+
+The school needs an **Internal Exam Mode** for graded, official assessments that count toward EASA PPL course completion. Practice Exam (already shipped, `mode='mock_exam'`) is for self-study and cannot serve as the official assessment because it has no admin gate, no per-attempt audit, and pollutes practice statistics.
+
+Internal Exam Mode introduces an admin-issued, single-use, 24-hour code that unlocks one official attempt for one specific student on one specific subject. Each issued code is one attempt; retakes require a new code. Sessions cannot be discarded. Reports for internal exams are kept fully separate from practice and quiz reports.
+
+The feature reuses the practice-exam stack (`exam_configs`, `quiz_sessions`, countdown timer, answer buffer, results card) by introducing a new mode value `internal_exam` and minimal mode-aware branching.
+
+## Alignment with Product Vision
+
+Per `docs/plan.md`, official internal assessments are a Phase 5+ requirement for ATO course delivery. This feature is a prerequisite for any "course completion" certificate the school issues, and is the foundation for a future EASA-recognised flow (out of scope here).
+
+## Requirements
+
+### Requirement 1 — Admin issues a single-use exam code
+
+**User Story:** As an admin, I want to issue a one-time exam code to a specific student for a specific subject, so that I control when and for what subject they take the official exam.
+
+#### Acceptance Criteria
+
+1. WHEN an admin opens `/app/admin/internal-exams` AND clicks "Issue code" AND selects a student + subject THEN the system SHALL generate an 8-character alphanumeric code (uppercase, excluding ambiguous characters `0`, `O`, `I`, `1`).
+2. IF no `exam_configs` row exists for the selected subject (or the row has `enabled=false` or is soft-deleted) THEN the system SHALL block issuance and display "Configure exam for this subject first" with a link to `/app/admin/exam-config`.
+3. WHEN a code is generated THEN the system SHALL store it in plaintext in `internal_exam_codes` with `expires_at = issued_at + 24 hours`, `consumed_at = NULL`, `voided_at = NULL`.
+4. WHEN issuance succeeds THEN the system SHALL display the code once in a copy-to-clipboard panel AND log an `internal_exam.code_issued` audit event with `actor_id = admin`, `student_id`, `subject_id`, `code_id`.
+5. IF an admin issues a second code for the same `(student_id, subject_id)` while a prior code is still active (unconsumed + unexpired + not voided) THEN the system SHALL allow it (each code is a separate attempt) but SHALL surface a warning "Active code already exists, expires at HH:MM".
+
+### Requirement 2 — Student starts an internal exam by entering the code
+
+**User Story:** As a student, I want to see which official exams have been issued to me and start one by entering the code I received, so that I can sit the assessment.
+
+#### Acceptance Criteria
+
+1. WHEN a student opens the new top-level nav item "Internal Exam" AND views the **Available** tab THEN the system SHALL list every code where `student_id = auth.uid()` AND `consumed_at IS NULL` AND `voided_at IS NULL` AND `expires_at > now()` AND `deleted_at IS NULL`, showing **subject name + expiry timestamp only** (the code value itself MUST NOT be displayed).
+2. WHEN the student clicks "Start" on an available row THEN the system SHALL open a modal prompting for the code value.
+3. WHEN the student submits the code THEN the system SHALL call `start_internal_exam_session(p_code)` which validates: code exists, not consumed, not voided, not expired, `student_id = auth.uid()`, code's `subject_id` matches the row clicked. On success it SHALL create a `quiz_sessions` row with `mode='internal_exam'`, mark the code consumed (`consumed_at = now()`, `consumed_session_id = new session id`), and emit an `internal_exam.started` audit event.
+4. IF validation fails THEN the system SHALL return a domain-specific error (`code_not_found`, `code_expired`, `code_already_used`, `code_voided`, `code_not_yours`) and SHALL NOT reveal whether the code exists for a different student.
+5. WHEN the session is created THEN the student SHALL be redirected to the existing exam-session UI (`/app/quiz/session?id=...`) which SHALL render the same countdown timer, answer buffer, and navigation as practice exam, with the badge label "Internal Exam" instead of "Practice Exam".
+
+### Requirement 3 — Internal exam cannot be discarded
+
+**User Story:** As the school, I want the student to be unable to abandon a started internal exam, so that every issued attempt produces a final pass/fail record.
+
+#### Acceptance Criteria
+
+1. IF the student is in an active `mode='internal_exam'` session THEN the UI SHALL NOT render any "Discard" button or other client-side abandon path.
+2. IF the existing `discard_quiz_session` (or equivalent) Server Action is called with a session whose `mode='internal_exam'` THEN it SHALL reject with error `cannot_discard_internal_exam` and SHALL NOT modify the session.
+3. WHEN the student manually submits an internal exam with fewer than `total_questions` answered THEN the system SHALL accept the submission and treat unanswered questions as incorrect (score = `correct_count / total_questions`).
+4. WHEN the session's `started_at + time_limit_seconds` deadline passes without submission THEN the existing `complete_overdue_exam_session` (extended for `internal_exam`) SHALL auto-complete the session, treating unanswered as incorrect, and emit `internal_exam.expired` audit event.
+
+### Requirement 4 — Admin can void an unfinished code or session
+
+**User Story:** As an admin, I want to void a code (and cancel its session if active), so that I can correct an erroneous issuance or terminate an in-progress attempt.
+
+#### Acceptance Criteria
+
+1. WHEN an admin clicks "Void" on an unconsumed code AND provides a reason THEN the system SHALL set `voided_at = now()`, `voided_by = admin`, `void_reason = reason` on the code row and emit `internal_exam.code_voided` audit event.
+2. WHEN an admin clicks "Void" on a code whose session is **active** (consumed but not yet ended) THEN the system SHALL void the code AND end the session with `passed = false`, `ended_at = now()`, computing score from currently-buffered answers (treat unanswered as incorrect), AND emit both `internal_exam.code_voided` and `internal_exam.expired` audit events.
+3. IF the code has been consumed AND its session is **already finished** (`ended_at IS NOT NULL`) THEN the system SHALL block the void action and display "Cannot void a finished attempt — record is final".
+4. The void RPC SHALL require `is_admin()` and `auth.uid()` checks and SHALL run with `SECURITY DEFINER SET search_path = public`.
+
+### Requirement 5 — Internal exam reports are fully separated from practice reports
+
+**User Story:** As a student and as an admin, I want internal exam attempts visible only in the Internal Exam reports tab and absent from practice/quiz reports, so that official records are not mixed with practice data.
+
+#### Acceptance Criteria
+
+1. WHEN any student or admin views existing reports under `/app/reports` THEN the system SHALL NOT include rows where `quiz_sessions.mode = 'internal_exam'`.
+2. WHEN a student opens the **My Reports** tab inside `/app/internal-exam` THEN the system SHALL list every `mode='internal_exam'` session for `student_id = auth.uid()` with: subject, attempt number (1-indexed by `started_at` per subject), started_at, ended_at, score, pass/fail badge, answered_count / total_questions.
+3. WHEN an admin opens the admin internal exam dashboard THEN the system SHALL list all `mode='internal_exam'` sessions across the org (filterable by student / subject / status).
+4. Each retake SHALL appear as a distinct row (no aggregation) — counted attempts come from distinct `quiz_sessions` rows linked to distinct `internal_exam_codes` rows.
+
+### Requirement 6 — Top-level navigation entry
+
+**User Story:** As a student, I want a clearly labelled top-level "Internal Exam" tab in the main navigation, so that I can find official exams without confusion with practice mode.
+
+#### Acceptance Criteria
+
+1. WHEN any authenticated student renders the main sidebar THEN it SHALL include a top-level item "Internal Exam" linking to `/app/internal-exam`, ordered between "Quiz" and "Reports".
+2. WHEN any authenticated admin renders the admin sidebar THEN it SHALL include a top-level item "Internal Exams" linking to `/app/admin/internal-exams`, ordered after "Exam Config".
+3. The labels for `mock_exam` and `internal_exam` SHALL come from a single `MODE_LABELS` constant in `apps/web/lib/constants/exam-modes.ts` (closes #544).
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+- Reuse existing exam components, hooks, and server actions wherever possible. New code is constrained to: code-issuance/start/void RPCs, internal-exam admin pages, internal-exam student pages, mode-aware label constant, mode filter on existing report queries.
+- File size: page.tsx ≤ 80 lines; components ≤ 150; Server Action files ≤ 100; hooks ≤ 80; SQL migrations ≤ 300.
+- No barrel files. Tests co-located.
+
+### Performance
+- Code generation collision retry budget ≤ 5 attempts before erroring; expected collision probability is negligible (8-char alphanumeric ≈ 1 in 30^8).
+- Available codes list limited to 100 rows per request (no pagination needed at expected scale).
+
+### Security
+- All new RPCs are `SECURITY DEFINER` with explicit `auth.uid()` check, `SET search_path = public`, and `deleted_at IS NULL` filters on every user/session/subject/exam_config lookup including audit-event INSERT subqueries (per `.claude/rules/security.md` rule 10).
+- `internal_exam_codes` row-level security: student SELECT limited to own rows where `consumed_at IS NULL AND voided_at IS NULL AND expires_at > now() AND deleted_at IS NULL`, with the `code` column accessible in the row but not surfaced in any UI list view (the UI selects only `id, subject_id, expires_at`); admin full access scoped to `organization_id`. INSERT/UPDATE on the table only via SECURITY DEFINER RPCs (no direct policies).
+- `mode='internal_exam'` added to `quiz_sessions.mode` CHECK constraint and to RLS where mode-discriminated.
+- Audit events: `internal_exam.code_issued`, `internal_exam.started`, `internal_exam.completed`, `internal_exam.expired`, `internal_exam.code_voided` — all with `actor_role`, `actor_id`, `subject_id`, `student_id`, `code_id` (where applicable).
+- Code values are stored plaintext (per product decision — admin must be able to look them up). Plaintext is acceptable because: codes are single-use, expire in 24h, scoped to one student, and surfaced only via admin-authenticated RPC.
+
+### Reliability
+- Code consumption is atomic: `start_internal_exam_session` performs the code-validity check, code-mark-consumed, and session-create within a single transaction (RPC runs in one statement).
+- Auto-complete on overdue: existing `complete_overdue_exam_session` extended to accept `internal_exam`. The same idempotency guarantees apply.
+
+### Usability
+- Issued code is shown in a high-contrast copy-to-clipboard panel after generation, with a notice "This code will not be shown again — copy it now."
+- Available exams tab shows expiry as relative time ("expires in 18h 22m") plus exact timestamp on hover.
+- Submission confirmation modal explicitly warns "Unanswered questions will count as incorrect" when count < total at submit time.

--- a/.spec-workflow/specs/internal-exam-mode/tasks.md
+++ b/.spec-workflow/specs/internal-exam-mode/tasks.md
@@ -1,0 +1,231 @@
+# Tasks Document — Internal Exam Mode
+
+> Order matters: schema → RPCs → server actions → UI → tests → docs. Many tasks block downstream tasks (e.g. UI work cannot start until RPCs return the right shape). Each task lists files touched, acceptance, and the requirement(s) it satisfies.
+
+## 1. Constants & types (foundation, unblocks everything)
+
+- [ ] **1.1 Add `MODE_LABELS` constant + `isExamMode` helper**
+  - File: `apps/web/lib/constants/exam-modes.ts` (new)
+  - File: `apps/web/lib/constants/exam-modes.test.ts` (new)
+  - Replace at least one hardcoded `"Practice Exam"` site (e.g. `quiz/session/_components/exam-session-header.tsx`) to prove the constant is wired (closes #544).
+  - _Requirements: 6.3_
+  - _Acceptance: type-level test asserts every value of `quiz_sessions.mode` CHECK has a label; `isExamMode('mock_exam')` and `isExamMode('internal_exam')` both true._
+
+## 2. Database — schema + RPCs (each migration is one task; SQL ≤ 300 lines per file)
+
+- [ ] **2.0 Migration `057a` — extend `is_admin()` with `deleted_at IS NULL` filter**
+  - File: `packages/db/migrations/057a_is_admin_softdelete_filter.sql` + supabase mirror
+  - `CREATE OR REPLACE FUNCTION public.is_admin()` body becomes `SELECT EXISTS (SELECT 1 FROM public.users WHERE id = auth.uid() AND role = 'admin' AND deleted_at IS NULL);`
+  - Plan-critic surfaced this as a real soft-delete bypass for admins; fixing it before adding new admin RPCs that depend on it.
+  - _Acceptance: an admin user with `deleted_at IS NOT NULL` returns `false` from `is_admin()`._
+  - _Requirements: NFR-Security_
+
+- [ ] **2.1 Migration `057` — `internal_exam_codes` table + RLS + indexes**
+  - File: `packages/db/migrations/057_internal_exam_codes.sql`
+  - File: `supabase/migrations/<ts>_internal_exam_codes.sql` (mirror)
+  - Includes: table, FK constraints, both CHECKs from design, partial index for active codes, UNIQUE on `code`, RLS enabled, student SELECT policy (own + active), admin RLS via `is_admin()` org-scoped.
+  - _Requirements: 1, 4, NFR-Security_
+
+- [ ] **2.2 Migration `058` — extend `quiz_sessions.mode` CHECK**
+  - File: `packages/db/migrations/058_extend_quiz_sessions_mode_check.sql` + supabase mirror
+  - Use the `DO $$` lookup-by-pg_constraint pattern from design.md (the original CHECK in `001_initial_schema.sql:185` is inline/unnamed so the auto-generated name varies by Postgres version).
+  - Add the new constraint with explicit name `quiz_sessions_mode_check`.
+  - _Requirements: 2, 3_
+
+- [ ] **2.3 Migration `059` — `issue_internal_exam_code()` RPC**
+  - SECURITY DEFINER, search_path=public, admin gate, deleted_at filters everywhere (including audit subquery), 8-char code generation with retry, `internal_exam.code_issued` audit.
+  - File: `packages/db/migrations/059_issue_internal_exam_code_rpc.sql` + mirror
+  - _Requirements: 1.1–1.5_
+
+- [ ] **2.4 Migration `060` — `start_internal_exam_session()` RPC**
+  - Validates code (5 enumerated error strings), auto-completes overdue same-subject session, builds question_ids from `exam_config_distributions`, atomic code consumption via WHERE-clause race guard.
+  - File: `packages/db/migrations/060_start_internal_exam_session_rpc.sql` + mirror
+  - _Requirements: 2.1–2.5_
+
+- [ ] **2.5 Migration `061` — `void_internal_exam_code()` RPC**
+  - Three branches (unconsumed / active / finished), force `passed=false` on active-void, dual audit events on active branch.
+  - File: `packages/db/migrations/061_void_internal_exam_code_rpc.sql` + mirror
+  - _Requirements: 4.1–4.4_
+
+- [ ] **2.6 Migration `062` — extend `batch_submit_quiz` for `internal_exam`**
+  - `CREATE OR REPLACE FUNCTION` from latest body in `056`. All-answered guard restricted to `mock_exam` only. Pass computation extended to `internal_exam`. Audit event_type branched.
+  - File: `packages/db/migrations/062_extend_batch_submit_for_internal_exam.sql` + mirror
+  - _Requirements: 3.3, 5.4_
+
+- [ ] **2.7 Migration `063` — extend overdue + empty completion RPCs for `internal_exam`**
+  - `CREATE OR REPLACE FUNCTION complete_overdue_exam_session(...)` based on the latest body in `052_align_overdue_threshold_grace.sql` (NOT 054 — 054 only revises `start_exam_session`).
+  - `CREATE OR REPLACE FUNCTION complete_empty_exam_session(...)` based on `055_align_complete_empty_audit_metadata.sql`.
+  - Both widened to `mode IN ('mock_exam', 'internal_exam')`. Audit event_type branched.
+  - Split into `063` + `064` if combined SQL > 300 lines.
+  - File: `packages/db/migrations/063_extend_overdue_for_internal_exam.sql` + mirror
+  - _Requirements: 3.4_
+
+- [ ] **2.8 Apply migrations + regenerate TS types**
+  - `npx supabase db push` (or equivalent) → `npx supabase gen types typescript --linked > packages/db/src/types.ts`
+  - _Acceptance: type for `quiz_sessions.mode` includes `'internal_exam'`; new RPCs appear in generated types._
+
+- [ ] **2.9 SQL integration tests for new + extended RPCs**
+  - File: `packages/db/tests/internal-exam-mode.spec.ts` (or wherever existing SQL tests live — check first)
+  - Coverage: every RPC error path, race conditions for code consumption, RLS enforcement (student cannot SELECT others' codes; cannot INSERT directly).
+  - _Requirements: NFR-Reliability, NFR-Security_
+
+## 3. Server actions
+
+- [ ] **3.1 Admin: `issueCode` action + queries**
+  - Files: `apps/web/app/app/admin/internal-exams/actions/issue-code.ts` + `.test.ts`
+  - File: `apps/web/app/app/admin/internal-exams/queries.ts` + `.test.ts`
+  - Zod parse, `requireAdmin()`, RPC call, sanitized errors per `code-style.md` §5.
+  - _Requirements: 1.1–1.5, NFR-Security_
+
+- [ ] **3.2 Admin: `voidCode` action**
+  - File: `apps/web/app/app/admin/internal-exams/actions/void-code.ts` + `.test.ts`
+  - _Requirements: 4.1–4.3_
+
+- [ ] **3.3 Student: `startInternalExam` action + queries**
+  - Files: `apps/web/app/app/internal-exam/actions/start-internal-exam.ts` + `.test.ts`
+  - File: `apps/web/app/app/internal-exam/queries.ts` + `.test.ts` — list available (subject + expiry only, NO code value), list student's history.
+  - URL-redirect destination asserted in tests (per agent-test-writer rule 2026-04-27).
+  - _Requirements: 2.1–2.5_
+
+- [ ] **3.4 Extend `discard.ts` to reject `internal_exam`**
+  - File: `apps/web/app/app/quiz/actions/discard.ts` + existing `discard.test.ts` updated
+  - Add test for the new rejection branch.
+  - _Requirements: 3.1, 3.2_
+
+- [ ] **3.5 Fork `getActiveInternalExamSession()` (do NOT widen the practice version)**
+  - File: `apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts` + `.test.ts`
+  - Mirrors `apps/web/app/app/quiz/actions/get-active-exam-session.ts` but `.eq('mode', 'internal_exam')` and reuses `_overdue-helpers` unchanged.
+  - **Do NOT modify** `quiz/actions/get-active-exam-session.ts` — keeps practice-exam recovery banner copy clean.
+  - _Requirements: 3.4 (recovery), NFR-Reliability_
+
+- [ ] **3.6 Reports filter — exclude `internal_exam` from existing reports**
+  - File: `apps/web/lib/queries/reports.ts` + existing `reports.test.ts`
+  - Add `.neq('mode', 'internal_exam')` to the session list query (verify whether the RPC `get_session_reports` already accepts a mode param; if not, filter in TS).
+  - Update test to assert internal-exam rows are excluded.
+  - _Requirements: 5.1_
+
+## 4. Frontend — admin
+
+- [ ] **4.1 Extend nav-items icon union + add admin "Internal Exams" entry**
+  - File: `apps/web/app/app/_components/nav-items.ts`
+  - The current icon union is closed (`home | file-question | bar-chart | book-open | list | users | settings | clipboard-check`). Add new icon `'shield-check'` (or equivalent) to the union; both new nav items will use it.
+  - Locate the icon-render switch in the sidebar component and add the matching case.
+  - Add `{ href: '/app/admin/internal-exams', label: 'Internal Exams', icon: 'shield-check' }` to `ADMIN_NAV_ITEMS` after Exam Config.
+  - _Requirements: 6.2_
+
+- [ ] **4.2 Admin page shell `/app/admin/internal-exams/page.tsx`**
+  - File: `page.tsx` (≤ 80 lines, composition only)
+  - Tabs: Codes / Attempts.
+  - _Requirements: 6.2_
+
+- [ ] **4.3 Issue-code form + result panel**
+  - Files: `_components/issue-code-form.tsx` + `.test.tsx`, `_components/issued-code-panel.tsx` + `.test.tsx`
+  - Student picker (existing pattern from admin/students), subject picker (existing pattern). After issue: show code in copy-to-clipboard panel with "won't be shown again" notice.
+  - _Requirements: 1.1, 1.4, NFR-Usability_
+
+- [ ] **4.4 Codes table + void dialog**
+  - Files: `_components/codes-table.tsx` + `.test.tsx`, `_components/void-code-dialog.tsx` + `.test.tsx`
+  - Status badges (active / consumed / expired / voided / finished). Void disabled for finished.
+  - _Requirements: 1, 4_
+
+- [ ] **4.5 Attempts table (admin view)**
+  - File: `_components/attempts-table.tsx` + `.test.tsx`
+  - Lists `mode='internal_exam'` sessions across org, drilldown to existing `/app/quiz/report?id=...`.
+  - _Requirements: 5.3_
+
+## 5. Frontend — student
+
+- [ ] **5.1 Student nav item "Internal Exam"**
+  - File: `apps/web/app/app/_components/nav-items.ts`
+  - Add `{ href: '/app/internal-exam', label: 'Internal Exam', icon: 'shield-check' }` to `NAV_ITEMS` between Quiz and Reports (icon already added in 4.1).
+  - _Requirements: 6.1_
+
+- [ ] **5.2 Student page shell `/app/internal-exam/page.tsx`**
+  - File: `page.tsx` (≤ 80 lines, composition only)
+  - Tabs: Available / My Reports.
+  - _Requirements: 6.1_
+
+- [ ] **5.3 Available tab + code-entry modal**
+  - Files: `_components/available-tab.tsx` + `.test.tsx`, `_components/code-entry-modal.tsx` + `.test.tsx`
+  - List rows show subject + relative + absolute expiry. Click "Start" opens modal. Modal validates code, calls action, redirects to `/app/quiz/session?id=...` on success.
+  - **MUST NOT** display code value anywhere in the list.
+  - _Requirements: 2.1, 2.2, 2.3, NFR-Security_
+
+- [ ] **5.4 My Reports tab**
+  - File: `_components/my-reports-tab.tsx` + `.test.tsx`
+  - List sessions with attempt number (1-indexed by started_at per subject), pass/fail badge, link to existing report page.
+  - _Requirements: 5.2, 5.4_
+
+- [ ] **5.5 Hide Discard button when `mode='internal_exam'`**
+  - File: locate the discard button in `quiz/session/_components/...` (Explore agent), gate render.
+  - _Requirements: 3.1_
+
+- [ ] **5.6 Update `exam-session-header` to use `MODE_LABELS`**
+  - Already done in 1.1; verify badge renders "INTERNAL EXAM" for the new mode.
+  - _Requirements: 6.3_
+
+## 6. Submission UX — partial-answer warning
+
+- [ ] **6.1 Confirm modal warns when answered < total at submit time**
+  - File: locate the existing exam-submit confirm component, add the conditional warning string for `internal_exam` mode.
+  - Test the warning string appears given a partial buffer.
+  - _Requirements: 3.3, NFR-Usability_
+
+## 7. Recovery + auto-submit verification (lifecycle E2E)
+
+- [ ] **7.1 Playwright: full lifecycle**
+  - File: `apps/web/e2e/internal-exam.spec.ts`
+  - admin issues → student starts → answers some → submits → report shows "Internal Exam" badge + pass/fail → My Reports lists it.
+  - _Requirements: 1, 2, 3.3, 5.2_
+
+- [ ] **7.2 Playwright: refresh-resume mid-session**
+  - File: `apps/web/e2e/internal-exam-resume.spec.ts`
+  - Per `agent-test-writer.md` rule 2026-04-27.
+  - _Requirements: 3.4, NFR-Reliability_
+
+- [ ] **7.3 Playwright: discard blocked + void mid-session**
+  - File: `apps/web/e2e/internal-exam-no-discard-and-void.spec.ts`
+  - _Requirements: 3.1, 4.2_
+
+- [ ] **7.4 Playwright: reports separation**
+  - File: `apps/web/e2e/internal-exam-reports-separation.spec.ts`
+  - Practice reports exclude internal; My Reports shows only internal.
+  - _Requirements: 5.1, 5.2_
+
+## 8. Red-team specs (security defense)
+
+- [ ] **8.1 Cross-student code-use rejection**
+  - File: `apps/web/e2e/redteam/internal-exam-cross-student.spec.ts`
+  - Student B attempts to start with code issued to student A.
+  - _Requirements: 2.4, NFR-Security_
+
+- [ ] **8.2 Cross-org admin void rejection**
+  - File: `apps/web/e2e/redteam/internal-exam-cross-org-void.spec.ts`
+  - _Requirements: 4.4, NFR-Security_
+
+- [ ] **8.3 Direct table-write attempts blocked by RLS**
+  - File: `apps/web/e2e/redteam/internal-exam-rls-writes.spec.ts`
+  - Student tries direct INSERT on `internal_exam_codes`; UPDATE to clear `consumed_at`. Both must fail.
+  - _Requirements: NFR-Security_
+
+## 9. Docs + memory
+
+- [ ] **9.1 Update `docs/database.md`**
+  - New table row, new RPCs, mode CHECK extension, mode-discriminated audit events, soft-delete matrix update.
+- [ ] **9.2 Update `docs/security.md`**
+  - Note `internal_exam` in the RPC inventory; cross-student code rejection rule.
+- [ ] **9.3 Update `docs/decisions.md`**
+  - Decision: code stored plaintext (rationale per requirements NFR-Security).
+  - Decision: each code = one attempt; retake = new code.
+- [ ] **9.4 Update `MEMORY.md`**
+  - Brief project-memory entry pointing to this spec; list new RPCs and tables.
+
+## 10. Closing
+
+- [ ] **10.1 Run `pnpm check`, `pnpm check-types`, `pnpm test`, `pnpm e2e:redteam` — all green**
+- [ ] **10.2 PR-level semantic review against full diff (`git diff master...HEAD`)** before push, per `agent-workflow.md § Pre-Push PR Sweep`.
+- [ ] **10.3 Update spec `tasks.md` checkboxes `[x]` after each completed task** — per `feedback_update_spec_tasks` rule.
+
+---
+
+**Estimated scope:** ~7 new migrations, ~14 new TS files, ~6 extend-in-place, ~12 new tests + 4 Playwright + 3 red-team specs. Medium-XL.

--- a/.spec-workflow/specs/internal-exam-mode/tasks.md
+++ b/.spec-workflow/specs/internal-exam-mode/tasks.md
@@ -4,7 +4,7 @@
 
 ## 1. Constants & types (foundation, unblocks everything)
 
-- [ ] **1.1 Add `MODE_LABELS` constant + `isExamMode` helper**
+- [x] **1.1 Add `MODE_LABELS` constant + `isExamMode` helper**
   - File: `apps/web/lib/constants/exam-modes.ts` (new)
   - File: `apps/web/lib/constants/exam-modes.test.ts` (new)
   - Replace at least one hardcoded `"Practice Exam"` site (e.g. `quiz/session/_components/exam-session-header.tsx`) to prove the constant is wired (closes #544).
@@ -13,46 +13,46 @@
 
 ## 2. Database — schema + RPCs (each migration is one task; SQL ≤ 300 lines per file)
 
-- [ ] **2.0 Migration `057a` — extend `is_admin()` with `deleted_at IS NULL` filter**
+- [x] **2.0 Migration `057a` — extend `is_admin()` with `deleted_at IS NULL` filter**
   - File: `packages/db/migrations/057a_is_admin_softdelete_filter.sql` + supabase mirror
   - `CREATE OR REPLACE FUNCTION public.is_admin()` body becomes `SELECT EXISTS (SELECT 1 FROM public.users WHERE id = auth.uid() AND role = 'admin' AND deleted_at IS NULL);`
   - Plan-critic surfaced this as a real soft-delete bypass for admins; fixing it before adding new admin RPCs that depend on it.
   - _Acceptance: an admin user with `deleted_at IS NOT NULL` returns `false` from `is_admin()`._
   - _Requirements: NFR-Security_
 
-- [ ] **2.1 Migration `057` — `internal_exam_codes` table + RLS + indexes**
+- [x] **2.1 Migration `057` — `internal_exam_codes` table + RLS + indexes**
   - File: `packages/db/migrations/057_internal_exam_codes.sql`
   - File: `supabase/migrations/<ts>_internal_exam_codes.sql` (mirror)
   - Includes: table, FK constraints, both CHECKs from design, partial index for active codes, UNIQUE on `code`, RLS enabled, student SELECT policy (own + active), admin RLS via `is_admin()` org-scoped.
   - _Requirements: 1, 4, NFR-Security_
 
-- [ ] **2.2 Migration `058` — extend `quiz_sessions.mode` CHECK**
+- [x] **2.2 Migration `058` — extend `quiz_sessions.mode` CHECK**
   - File: `packages/db/migrations/058_extend_quiz_sessions_mode_check.sql` + supabase mirror
   - Use the `DO $$` lookup-by-pg_constraint pattern from design.md (the original CHECK in `001_initial_schema.sql:185` is inline/unnamed so the auto-generated name varies by Postgres version).
   - Add the new constraint with explicit name `quiz_sessions_mode_check`.
   - _Requirements: 2, 3_
 
-- [ ] **2.3 Migration `059` — `issue_internal_exam_code()` RPC**
+- [x] **2.3 Migration `059` — `issue_internal_exam_code()` RPC**
   - SECURITY DEFINER, search_path=public, admin gate, deleted_at filters everywhere (including audit subquery), 8-char code generation with retry, `internal_exam.code_issued` audit.
   - File: `packages/db/migrations/059_issue_internal_exam_code_rpc.sql` + mirror
   - _Requirements: 1.1–1.5_
 
-- [ ] **2.4 Migration `060` — `start_internal_exam_session()` RPC**
+- [x] **2.4 Migration `060` — `start_internal_exam_session()` RPC**
   - Validates code (5 enumerated error strings), auto-completes overdue same-subject session, builds question_ids from `exam_config_distributions`, atomic code consumption via WHERE-clause race guard.
   - File: `packages/db/migrations/060_start_internal_exam_session_rpc.sql` + mirror
   - _Requirements: 2.1–2.5_
 
-- [ ] **2.5 Migration `061` — `void_internal_exam_code()` RPC**
+- [x] **2.5 Migration `061` — `void_internal_exam_code()` RPC**
   - Three branches (unconsumed / active / finished), force `passed=false` on active-void, dual audit events on active branch.
   - File: `packages/db/migrations/061_void_internal_exam_code_rpc.sql` + mirror
   - _Requirements: 4.1–4.4_
 
-- [ ] **2.6 Migration `062` — extend `batch_submit_quiz` for `internal_exam`**
+- [x] **2.6 Migration `062` — extend `batch_submit_quiz` for `internal_exam`**
   - `CREATE OR REPLACE FUNCTION` from latest body in `056`. All-answered guard restricted to `mock_exam` only. Pass computation extended to `internal_exam`. Audit event_type branched.
   - File: `packages/db/migrations/062_extend_batch_submit_for_internal_exam.sql` + mirror
   - _Requirements: 3.3, 5.4_
 
-- [ ] **2.7 Migration `063` — extend overdue + empty completion RPCs for `internal_exam`**
+- [x] **2.7 Migration `063` — extend overdue + empty completion RPCs for `internal_exam`**
   - `CREATE OR REPLACE FUNCTION complete_overdue_exam_session(...)` based on the latest body in `052_align_overdue_threshold_grace.sql` (NOT 054 — 054 only revises `start_exam_session`).
   - `CREATE OR REPLACE FUNCTION complete_empty_exam_session(...)` based on `055_align_complete_empty_audit_metadata.sql`.
   - Both widened to `mode IN ('mock_exam', 'internal_exam')`. Audit event_type branched.
@@ -60,7 +60,7 @@
   - File: `packages/db/migrations/063_extend_overdue_for_internal_exam.sql` + mirror
   - _Requirements: 3.4_
 
-- [ ] **2.8 Apply migrations + regenerate TS types**
+- [x] **2.8 Apply migrations + regenerate TS types**
   - `npx supabase db push` (or equivalent) → `npx supabase gen types typescript --linked > packages/db/src/types.ts`
   - _Acceptance: type for `quiz_sessions.mode` includes `'internal_exam'`; new RPCs appear in generated types._
 
@@ -71,34 +71,34 @@
 
 ## 3. Server actions
 
-- [ ] **3.1 Admin: `issueCode` action + queries**
+- [x] **3.1 Admin: `issueCode` action + queries**
   - Files: `apps/web/app/app/admin/internal-exams/actions/issue-code.ts` + `.test.ts`
   - File: `apps/web/app/app/admin/internal-exams/queries.ts` + `.test.ts`
   - Zod parse, `requireAdmin()`, RPC call, sanitized errors per `code-style.md` §5.
   - _Requirements: 1.1–1.5, NFR-Security_
 
-- [ ] **3.2 Admin: `voidCode` action**
+- [x] **3.2 Admin: `voidCode` action**
   - File: `apps/web/app/app/admin/internal-exams/actions/void-code.ts` + `.test.ts`
   - _Requirements: 4.1–4.3_
 
-- [ ] **3.3 Student: `startInternalExam` action + queries**
+- [x] **3.3 Student: `startInternalExam` action + queries**
   - Files: `apps/web/app/app/internal-exam/actions/start-internal-exam.ts` + `.test.ts`
   - File: `apps/web/app/app/internal-exam/queries.ts` + `.test.ts` — list available (subject + expiry only, NO code value), list student's history.
   - URL-redirect destination asserted in tests (per agent-test-writer rule 2026-04-27).
   - _Requirements: 2.1–2.5_
 
-- [ ] **3.4 Extend `discard.ts` to reject `internal_exam`**
+- [x] **3.4 Extend `discard.ts` to reject `internal_exam`**
   - File: `apps/web/app/app/quiz/actions/discard.ts` + existing `discard.test.ts` updated
   - Add test for the new rejection branch.
   - _Requirements: 3.1, 3.2_
 
-- [ ] **3.5 Fork `getActiveInternalExamSession()` (do NOT widen the practice version)**
+- [x] **3.5 Fork `getActiveInternalExamSession()` (do NOT widen the practice version)**
   - File: `apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts` + `.test.ts`
   - Mirrors `apps/web/app/app/quiz/actions/get-active-exam-session.ts` but `.eq('mode', 'internal_exam')` and reuses `_overdue-helpers` unchanged.
   - **Do NOT modify** `quiz/actions/get-active-exam-session.ts` — keeps practice-exam recovery banner copy clean.
   - _Requirements: 3.4 (recovery), NFR-Reliability_
 
-- [ ] **3.6 Reports filter — exclude `internal_exam` from existing reports**
+- [x] **3.6 Reports filter — exclude `internal_exam` from existing reports**
   - File: `apps/web/lib/queries/reports.ts` + existing `reports.test.ts`
   - Add `.neq('mode', 'internal_exam')` to the session list query (verify whether the RPC `get_session_reports` already accepts a mode param; if not, filter in TS).
   - Update test to assert internal-exam rows are excluded.
@@ -106,67 +106,67 @@
 
 ## 4. Frontend — admin
 
-- [ ] **4.1 Extend nav-items icon union + add admin "Internal Exams" entry**
+- [x] **4.1 Extend nav-items icon union + add admin "Internal Exams" entry**
   - File: `apps/web/app/app/_components/nav-items.ts`
   - The current icon union is closed (`home | file-question | bar-chart | book-open | list | users | settings | clipboard-check`). Add new icon `'shield-check'` (or equivalent) to the union; both new nav items will use it.
   - Locate the icon-render switch in the sidebar component and add the matching case.
   - Add `{ href: '/app/admin/internal-exams', label: 'Internal Exams', icon: 'shield-check' }` to `ADMIN_NAV_ITEMS` after Exam Config.
   - _Requirements: 6.2_
 
-- [ ] **4.2 Admin page shell `/app/admin/internal-exams/page.tsx`**
+- [x] **4.2 Admin page shell `/app/admin/internal-exams/page.tsx`**
   - File: `page.tsx` (≤ 80 lines, composition only)
   - Tabs: Codes / Attempts.
   - _Requirements: 6.2_
 
-- [ ] **4.3 Issue-code form + result panel**
+- [x] **4.3 Issue-code form + result panel**
   - Files: `_components/issue-code-form.tsx` + `.test.tsx`, `_components/issued-code-panel.tsx` + `.test.tsx`
   - Student picker (existing pattern from admin/students), subject picker (existing pattern). After issue: show code in copy-to-clipboard panel with "won't be shown again" notice.
   - _Requirements: 1.1, 1.4, NFR-Usability_
 
-- [ ] **4.4 Codes table + void dialog**
+- [x] **4.4 Codes table + void dialog**
   - Files: `_components/codes-table.tsx` + `.test.tsx`, `_components/void-code-dialog.tsx` + `.test.tsx`
   - Status badges (active / consumed / expired / voided / finished). Void disabled for finished.
   - _Requirements: 1, 4_
 
-- [ ] **4.5 Attempts table (admin view)**
+- [x] **4.5 Attempts table (admin view)**
   - File: `_components/attempts-table.tsx` + `.test.tsx`
   - Lists `mode='internal_exam'` sessions across org, drilldown to existing `/app/quiz/report?id=...`.
   - _Requirements: 5.3_
 
 ## 5. Frontend — student
 
-- [ ] **5.1 Student nav item "Internal Exam"**
+- [x] **5.1 Student nav item "Internal Exam"**
   - File: `apps/web/app/app/_components/nav-items.ts`
   - Add `{ href: '/app/internal-exam', label: 'Internal Exam', icon: 'shield-check' }` to `NAV_ITEMS` between Quiz and Reports (icon already added in 4.1).
   - _Requirements: 6.1_
 
-- [ ] **5.2 Student page shell `/app/internal-exam/page.tsx`**
+- [x] **5.2 Student page shell `/app/internal-exam/page.tsx`**
   - File: `page.tsx` (≤ 80 lines, composition only)
   - Tabs: Available / My Reports.
   - _Requirements: 6.1_
 
-- [ ] **5.3 Available tab + code-entry modal**
+- [x] **5.3 Available tab + code-entry modal**
   - Files: `_components/available-tab.tsx` + `.test.tsx`, `_components/code-entry-modal.tsx` + `.test.tsx`
   - List rows show subject + relative + absolute expiry. Click "Start" opens modal. Modal validates code, calls action, redirects to `/app/quiz/session?id=...` on success.
   - **MUST NOT** display code value anywhere in the list.
   - _Requirements: 2.1, 2.2, 2.3, NFR-Security_
 
-- [ ] **5.4 My Reports tab**
+- [x] **5.4 My Reports tab**
   - File: `_components/my-reports-tab.tsx` + `.test.tsx`
   - List sessions with attempt number (1-indexed by started_at per subject), pass/fail badge, link to existing report page.
   - _Requirements: 5.2, 5.4_
 
-- [ ] **5.5 Hide Discard button when `mode='internal_exam'`**
+- [x] **5.5 Hide Discard button when `mode='internal_exam'`**
   - File: locate the discard button in `quiz/session/_components/...` (Explore agent), gate render.
   - _Requirements: 3.1_
 
-- [ ] **5.6 Update `exam-session-header` to use `MODE_LABELS`**
+- [x] **5.6 Update `exam-session-header` to use `MODE_LABELS`**
   - Already done in 1.1; verify badge renders "INTERNAL EXAM" for the new mode.
   - _Requirements: 6.3_
 
 ## 6. Submission UX — partial-answer warning
 
-- [ ] **6.1 Confirm modal warns when answered < total at submit time**
+- [x] **6.1 Confirm modal warns when answered < total at submit time**
   - File: locate the existing exam-submit confirm component, add the conditional warning string for `internal_exam` mode.
   - Test the warning string appears given a partial buffer.
   - _Requirements: 3.3, NFR-Usability_
@@ -210,14 +210,14 @@
 
 ## 9. Docs + memory
 
-- [ ] **9.1 Update `docs/database.md`**
+- [x] **9.1 Update `docs/database.md`**
   - New table row, new RPCs, mode CHECK extension, mode-discriminated audit events, soft-delete matrix update.
-- [ ] **9.2 Update `docs/security.md`**
+- [x] **9.2 Update `docs/security.md`**
   - Note `internal_exam` in the RPC inventory; cross-student code rejection rule.
-- [ ] **9.3 Update `docs/decisions.md`**
+- [x] **9.3 Update `docs/decisions.md`**
   - Decision: code stored plaintext (rationale per requirements NFR-Security).
   - Decision: each code = one attempt; retake = new code.
-- [ ] **9.4 Update `MEMORY.md`**
+- [x] **9.4 Update `MEMORY.md`**
   - Brief project-memory entry pointing to this spec; list new RPCs and tables.
 
 ## 10. Closing

--- a/apps/web/app/app/_components/bottom-tab-bar.test.tsx
+++ b/apps/web/app/app/_components/bottom-tab-bar.test.tsx
@@ -61,4 +61,17 @@ describe('BottomTabBar', () => {
     expect(screen.getByText('Quiz').closest('a')).toHaveAttribute('href', '/app/quiz')
     expect(screen.getByText('Reports').closest('a')).toHaveAttribute('href', '/app/reports')
   })
+
+  it('renders the Internal Exam tab for students', () => {
+    renderTabBar()
+    expect(screen.getByText('Internal Exam')).toBeInTheDocument()
+  })
+
+  it('links Internal Exam tab to the correct route', () => {
+    renderTabBar()
+    expect(screen.getByText('Internal Exam').closest('a')).toHaveAttribute(
+      'href',
+      '/app/internal-exam',
+    )
+  })
 })

--- a/apps/web/app/app/_components/nav-icon.test.tsx
+++ b/apps/web/app/app/_components/nav-icon.test.tsx
@@ -1,0 +1,65 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { NavIcon } from './nav-icon'
+
+describe('NavIcon', () => {
+  it('renders an SVG for the home icon', () => {
+    const { container } = render(<NavIcon name="home" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG for the file-question icon', () => {
+    const { container } = render(<NavIcon name="file-question" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG for the bar-chart icon', () => {
+    const { container } = render(<NavIcon name="bar-chart" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG for the book-open icon', () => {
+    const { container } = render(<NavIcon name="book-open" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG for the list icon', () => {
+    const { container } = render(<NavIcon name="list" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG for the users icon', () => {
+    const { container } = render(<NavIcon name="users" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG for the settings icon', () => {
+    const { container } = render(<NavIcon name="settings" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG for the clipboard-check icon', () => {
+    const { container } = render(<NavIcon name="clipboard-check" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG for the shield-check icon', () => {
+    const { container } = render(<NavIcon name="shield-check" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('applies the supplied className to the shield-check SVG', () => {
+    const { container } = render(<NavIcon name="shield-check" className="h-6 w-6" />)
+    expect(container.querySelector('svg')).toHaveClass('h-6', 'w-6')
+  })
+
+  it('hides every icon from assistive technology', () => {
+    const { container } = render(<NavIcon name="shield-check" />)
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('applies the default size class when no className is provided', () => {
+    const { container } = render(<NavIcon name="home" />)
+    expect(container.querySelector('svg')).toHaveClass('h-5', 'w-5')
+  })
+})

--- a/apps/web/app/app/_components/nav-icon.tsx
+++ b/apps/web/app/app/_components/nav-icon.tsx
@@ -7,6 +7,7 @@ type IconName =
   | 'users'
   | 'settings'
   | 'clipboard-check'
+  | 'shield-check'
 type NavIconProps = { name: IconName; className?: string }
 
 export function NavIcon({ name, className = 'h-5 w-5' }: NavIconProps) {
@@ -147,6 +148,22 @@ export function NavIcon({ name, className = 'h-5 w-5' }: NavIconProps) {
           <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
           <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
           <path d="m9 14 2 2 4-4" />
+        </svg>
+      )
+    case 'shield-check':
+      return (
+        <svg
+          className={className}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+          <path d="m9 12 2 2 4-4" />
         </svg>
       )
     default:

--- a/apps/web/app/app/_components/nav-icon.tsx
+++ b/apps/web/app/app/_components/nav-icon.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 type IconName =
   | 'home'
   | 'file-question'
@@ -10,163 +12,88 @@ type IconName =
   | 'shield-check'
 type NavIconProps = { name: IconName; className?: string }
 
+const ICON_PATHS: Record<IconName, ReactNode> = {
+  home: (
+    <>
+      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+      <polyline points="9 22 9 12 15 12 15 22" />
+    </>
+  ),
+  'file-question': (
+    <>
+      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+      <polyline points="14 2 14 8 20 8" />
+      <path d="M10 13a2 2 0 1 1 4 0c0 1-1 1.5-2 2" />
+      <line x1="12" y1="18" x2="12.01" y2="18" />
+    </>
+  ),
+  'bar-chart': (
+    <>
+      <line x1="18" y1="20" x2="18" y2="10" />
+      <line x1="12" y1="20" x2="12" y2="4" />
+      <line x1="6" y1="20" x2="6" y2="14" />
+    </>
+  ),
+  'book-open': (
+    <>
+      <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+      <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+    </>
+  ),
+  list: (
+    <>
+      <line x1="8" y1="6" x2="21" y2="6" />
+      <line x1="8" y1="12" x2="21" y2="12" />
+      <line x1="8" y1="18" x2="21" y2="18" />
+      <line x1="3" y1="6" x2="3.01" y2="6" />
+      <line x1="3" y1="12" x2="3.01" y2="12" />
+      <line x1="3" y1="18" x2="3.01" y2="18" />
+    </>
+  ),
+  users: (
+    <>
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </>
+  ),
+  settings: (
+    <>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </>
+  ),
+  'clipboard-check': (
+    <>
+      <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
+      <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+      <path d="m9 14 2 2 4-4" />
+    </>
+  ),
+  'shield-check': (
+    <>
+      <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+      <path d="m9 12 2 2 4-4" />
+    </>
+  ),
+}
+
 export function NavIcon({ name, className = 'h-5 w-5' }: NavIconProps) {
-  switch (name) {
-    case 'home':
-      return (
-        <svg
-          className={className}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-          <polyline points="9 22 9 12 15 12 15 22" />
-        </svg>
-      )
-    case 'file-question':
-      return (
-        <svg
-          className={className}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-          <polyline points="14 2 14 8 20 8" />
-          <path d="M10 13a2 2 0 1 1 4 0c0 1-1 1.5-2 2" />
-          <line x1="12" y1="18" x2="12.01" y2="18" />
-        </svg>
-      )
-    case 'bar-chart':
-      return (
-        <svg
-          className={className}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <line x1="18" y1="20" x2="18" y2="10" />
-          <line x1="12" y1="20" x2="12" y2="4" />
-          <line x1="6" y1="20" x2="6" y2="14" />
-        </svg>
-      )
-    case 'book-open':
-      return (
-        <svg
-          className={className}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
-          <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
-        </svg>
-      )
-    case 'list':
-      return (
-        <svg
-          className={className}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <line x1="8" y1="6" x2="21" y2="6" />
-          <line x1="8" y1="12" x2="21" y2="12" />
-          <line x1="8" y1="18" x2="21" y2="18" />
-          <line x1="3" y1="6" x2="3.01" y2="6" />
-          <line x1="3" y1="12" x2="3.01" y2="12" />
-          <line x1="3" y1="18" x2="3.01" y2="18" />
-        </svg>
-      )
-    case 'users':
-      return (
-        <svg
-          className={className}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-          <circle cx="9" cy="7" r="4" />
-          <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-          <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-        </svg>
-      )
-    case 'settings':
-      return (
-        <svg
-          className={className}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <circle cx="12" cy="12" r="3" />
-          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-        </svg>
-      )
-    case 'clipboard-check':
-      return (
-        <svg
-          className={className}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
-          <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
-          <path d="m9 14 2 2 4-4" />
-        </svg>
-      )
-    case 'shield-check':
-      return (
-        <svg
-          className={className}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
-          <path d="m9 12 2 2 4-4" />
-        </svg>
-      )
-    default:
-      return null
-  }
+  const paths = ICON_PATHS[name]
+  if (!paths) return null
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {paths}
+    </svg>
+  )
 }

--- a/apps/web/app/app/_components/nav-items.ts
+++ b/apps/web/app/app/_components/nav-items.ts
@@ -10,11 +10,13 @@ export type NavItem = {
     | 'users'
     | 'settings'
     | 'clipboard-check'
+    | 'shield-check'
 }
 
 export const NAV_ITEMS: NavItem[] = [
   { href: '/app/dashboard', label: 'Dashboard', icon: 'home' },
   { href: '/app/quiz', label: 'Quiz', icon: 'file-question' },
+  { href: '/app/internal-exam', label: 'Internal Exam', icon: 'shield-check' },
   { href: '/app/reports', label: 'Reports', icon: 'bar-chart' },
   { href: '/app/settings', label: 'Settings', icon: 'settings' },
 ]
@@ -25,4 +27,5 @@ export const ADMIN_NAV_ITEMS: NavItem[] = [
   { href: '/app/admin/questions', label: 'Questions', icon: 'list' },
   { href: '/app/admin/students', label: 'Students', icon: 'users' },
   { href: '/app/admin/exam-config', label: 'Exam Config', icon: 'clipboard-check' },
+  { href: '/app/admin/internal-exams', label: 'Internal Exams', icon: 'shield-check' },
 ]

--- a/apps/web/app/app/_components/sidebar-nav.test.tsx
+++ b/apps/web/app/app/_components/sidebar-nav.test.tsx
@@ -123,4 +123,18 @@ describe('SidebarNav', () => {
     render(<SidebarNav userRole="student" collapsed={false} onToggle={vi.fn()} />)
     expect(screen.queryByText('Students')).not.toBeInTheDocument()
   })
+
+  it('renders the Internal Exam student nav item with the correct route', () => {
+    render(<SidebarNav collapsed={false} onToggle={vi.fn()} />)
+    const link = screen.getByText('Internal Exam').closest('a')
+    expect(link).toHaveAttribute('href', '/app/internal-exam')
+  })
+
+  it('renders the Internal Exams admin nav item with the correct route', () => {
+    render(<SidebarNav userRole="admin" collapsed={false} onToggle={vi.fn()} />)
+    // There are two entries with "Internal Exam" text: one student, one admin.
+    // The admin entry says "Internal Exams" (plural).
+    const link = screen.getByText('Internal Exams').closest('a')
+    expect(link).toHaveAttribute('href', '/app/admin/internal-exams')
+  })
 })

--- a/apps/web/app/app/admin/internal-exams/_components/attempts-table.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/attempts-table.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { InternalExamAttemptRow } from '../types'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+import { AttemptsTable } from './attempts-table'
+
+const baseRow: InternalExamAttemptRow = {
+  sessionId: 'sess-1',
+  studentId: 'stu-1',
+  studentName: 'Alice',
+  studentEmail: 'alice@example.com',
+  subjectId: 'subj-1',
+  subjectName: 'Air Law',
+  startedAt: '2026-04-28T10:00:00.000Z',
+  endedAt: '2026-04-28T10:30:00.000Z',
+  totalQuestions: 16,
+  correctCount: 14,
+  scorePercentage: 87.5,
+  passed: true,
+  voidReason: null,
+}
+
+describe('AttemptsTable', () => {
+  it('renders empty state when no rows', () => {
+    render(<AttemptsTable rows={[]} />)
+    expect(screen.getByText('No attempts yet')).toBeInTheDocument()
+  })
+
+  it('renders student name as a link to the report page with sessionId', () => {
+    render(<AttemptsTable rows={[baseRow]} />)
+    const link = screen.getByRole('link', { name: 'Alice' })
+    expect(link.getAttribute('href')).toBe('/app/quiz/report?id=sess-1')
+  })
+
+  it('renders subject name', () => {
+    render(<AttemptsTable rows={[baseRow]} />)
+    expect(screen.getByText('Air Law')).toBeInTheDocument()
+  })
+
+  it('renders score rounded to whole percent', () => {
+    render(<AttemptsTable rows={[baseRow]} />)
+    expect(screen.getByText('88%')).toBeInTheDocument()
+  })
+
+  it('renders Pass badge when passed is true', () => {
+    render(<AttemptsTable rows={[baseRow]} />)
+    expect(screen.getByLabelText('Passed')).toBeInTheDocument()
+    expect(screen.getByText('Pass')).toBeInTheDocument()
+  })
+
+  it('renders Fail badge when passed is false', () => {
+    render(<AttemptsTable rows={[{ ...baseRow, passed: false }]} />)
+    expect(screen.getByLabelText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('Fail')).toBeInTheDocument()
+  })
+
+  it('renders dash for passed when null', () => {
+    render(<AttemptsTable rows={[{ ...baseRow, passed: null }]} />)
+    expect(screen.queryByLabelText('Passed')).toBeNull()
+    expect(screen.queryByLabelText('Failed')).toBeNull()
+  })
+
+  it('renders correct/total count', () => {
+    render(<AttemptsTable rows={[baseRow]} />)
+    expect(screen.getByText('14/16')).toBeInTheDocument()
+  })
+
+  it('falls back to email when student name is empty', () => {
+    render(<AttemptsTable rows={[{ ...baseRow, studentName: '' }]} />)
+    const link = screen.getByRole('link', { name: 'alice@example.com' })
+    expect(link.getAttribute('href')).toBe('/app/quiz/report?id=sess-1')
+  })
+
+  it('renders dash for null score', () => {
+    render(<AttemptsTable rows={[{ ...baseRow, scorePercentage: null }]} />)
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/_components/attempts-table.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/attempts-table.test.tsx
@@ -1,10 +1,25 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import type { InternalExamAttemptRow } from '../types'
 
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
 vi.mock('next/link', () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
+  default: ({
+    href,
+    children,
+    onClick,
+  }: {
+    href: string
+    children: React.ReactNode
+    onClick?: (e: React.MouseEvent) => void
+  }) => (
+    <a href={href} onClick={onClick}>
+      {children}
+    </a>
   ),
 }))
 
@@ -35,7 +50,7 @@ describe('AttemptsTable', () => {
   it('renders student name as a link to the report page with sessionId', () => {
     render(<AttemptsTable rows={[baseRow]} />)
     const link = screen.getByRole('link', { name: 'Alice' })
-    expect(link.getAttribute('href')).toBe('/app/quiz/report?id=sess-1')
+    expect(link.getAttribute('href')).toBe('/app/admin/internal-exams/report?session=sess-1')
   })
 
   it('renders subject name', () => {
@@ -74,11 +89,18 @@ describe('AttemptsTable', () => {
   it('falls back to email when student name is empty', () => {
     render(<AttemptsTable rows={[{ ...baseRow, studentName: '' }]} />)
     const link = screen.getByRole('link', { name: 'alice@example.com' })
-    expect(link.getAttribute('href')).toBe('/app/quiz/report?id=sess-1')
+    expect(link.getAttribute('href')).toBe('/app/admin/internal-exams/report?session=sess-1')
   })
 
   it('renders dash for null score', () => {
     render(<AttemptsTable rows={[{ ...baseRow, scorePercentage: null }]} />)
     expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  })
+
+  it('navigates to the admin report when the row is clicked', () => {
+    mockPush.mockClear()
+    render(<AttemptsTable rows={[baseRow]} />)
+    fireEvent.click(screen.getByRole('link', { name: 'Alice' }).closest('tr') as HTMLElement)
+    expect(mockPush).toHaveBeenCalledWith('/app/admin/internal-exams/report?session=sess-1')
   })
 })

--- a/apps/web/app/app/admin/internal-exams/_components/attempts-table.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/attempts-table.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
 import {
   Table,
@@ -47,52 +48,64 @@ export function AttemptsTable({ rows }: Readonly<Props>) {
               </TableCell>
             </TableRow>
           ) : (
-            rows.map((r) => {
-              const total = r.totalQuestions ?? 0
-              const correct = r.correctCount ?? 0
-              const passed = r.passed
-              return (
-                <TableRow key={r.sessionId}>
-                  <TableCell>
-                    <Link
-                      href={`/app/quiz/report?id=${r.sessionId}`}
-                      className="text-primary hover:underline"
-                    >
-                      {r.studentName || r.studentEmail || '—'}
-                    </Link>
-                  </TableCell>
-                  <TableCell>{r.subjectName || '—'}</TableCell>
-                  <TableCell className="text-xs text-muted-foreground">
-                    {formatAbsolute(r.startedAt)}
-                  </TableCell>
-                  <TableCell className="text-xs text-muted-foreground">
-                    {formatAbsolute(r.endedAt)}
-                  </TableCell>
-                  <TableCell className="font-mono text-sm">
-                    {formatScore(r.scorePercentage)}
-                  </TableCell>
-                  <TableCell>
-                    {passed === null ? (
-                      <span className="text-muted-foreground">—</span>
-                    ) : passed ? (
-                      <Badge variant="default" aria-label="Passed">
-                        Pass
-                      </Badge>
-                    ) : (
-                      <Badge variant="destructive" aria-label="Failed">
-                        Fail
-                      </Badge>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-xs tabular-nums">
-                    {correct}/{total}
-                  </TableCell>
-                </TableRow>
-              )
-            })
+            rows.map((r) => <AttemptRow key={r.sessionId} row={r} />)
           )}
         </TableBody>
       </Table>
     </div>
+  )
+}
+
+function AttemptRow({ row: r }: { row: InternalExamAttemptRow }) {
+  const router = useRouter()
+  const total = r.totalQuestions ?? 0
+  const correct = r.correctCount ?? 0
+  const passed = r.passed
+  const href = `/app/admin/internal-exams/report?session=${r.sessionId}`
+  const studentLabel = r.studentName || r.studentEmail || '—'
+  const navigate = () => router.push(href)
+
+  return (
+    <TableRow
+      tabIndex={0}
+      onClick={navigate}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          navigate()
+        }
+      }}
+      className="cursor-pointer hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+    >
+      <TableCell>
+        <Link
+          href={href}
+          onClick={(e) => e.stopPropagation()}
+          className="font-medium text-foreground no-underline focus-visible:underline"
+        >
+          {studentLabel}
+        </Link>
+      </TableCell>
+      <TableCell>{r.subjectName || '—'}</TableCell>
+      <TableCell className="text-xs text-muted-foreground">{formatAbsolute(r.startedAt)}</TableCell>
+      <TableCell className="text-xs text-muted-foreground">{formatAbsolute(r.endedAt)}</TableCell>
+      <TableCell className="font-mono text-sm">{formatScore(r.scorePercentage)}</TableCell>
+      <TableCell>
+        {passed === null ? (
+          <span className="text-muted-foreground">—</span>
+        ) : passed ? (
+          <Badge variant="default" aria-label="Passed">
+            Pass
+          </Badge>
+        ) : (
+          <Badge variant="destructive" aria-label="Failed">
+            Fail
+          </Badge>
+        )}
+      </TableCell>
+      <TableCell className="text-xs tabular-nums">
+        {correct}/{total}
+      </TableCell>
+    </TableRow>
   )
 }

--- a/apps/web/app/app/admin/internal-exams/_components/attempts-table.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/attempts-table.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type { InternalExamAttemptRow } from '../types'
+
+type Props = { rows: InternalExamAttemptRow[] }
+
+function formatAbsolute(iso: string | null): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('en-GB', { dateStyle: 'short', timeStyle: 'short' })
+}
+
+function formatScore(score: number | null): string {
+  if (score === null || Number.isNaN(score)) return '—'
+  return `${Math.round(score)}%`
+}
+
+export function AttemptsTable({ rows }: Readonly<Props>) {
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="min-w-[160px]">Student</TableHead>
+            <TableHead className="min-w-[140px]">Subject</TableHead>
+            <TableHead className="w-40">Started</TableHead>
+            <TableHead className="w-40">Ended</TableHead>
+            <TableHead className="w-20">Score</TableHead>
+            <TableHead className="w-24">Result</TableHead>
+            <TableHead className="w-24">Answered</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={7} className="text-center text-sm text-muted-foreground">
+                No attempts yet
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((r) => {
+              const total = r.totalQuestions ?? 0
+              const correct = r.correctCount ?? 0
+              const passed = r.passed
+              return (
+                <TableRow key={r.sessionId}>
+                  <TableCell>
+                    <Link
+                      href={`/app/quiz/report?id=${r.sessionId}`}
+                      className="text-primary hover:underline"
+                    >
+                      {r.studentName || r.studentEmail || '—'}
+                    </Link>
+                  </TableCell>
+                  <TableCell>{r.subjectName || '—'}</TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {formatAbsolute(r.startedAt)}
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {formatAbsolute(r.endedAt)}
+                  </TableCell>
+                  <TableCell className="font-mono text-sm">
+                    {formatScore(r.scorePercentage)}
+                  </TableCell>
+                  <TableCell>
+                    {passed === null ? (
+                      <span className="text-muted-foreground">—</span>
+                    ) : passed ? (
+                      <Badge variant="default" aria-label="Passed">
+                        Pass
+                      </Badge>
+                    ) : (
+                      <Badge variant="destructive" aria-label="Failed">
+                        Fail
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-xs tabular-nums">
+                    {correct}/{total}
+                  </TableCell>
+                </TableRow>
+              )
+            })
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/_components/codes-tab.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/codes-tab.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useState } from 'react'
+import type { ExamSubjectOption, InternalExamCodeRow, OrgStudentOption } from '../types'
+import { CodesTable } from './codes-table'
+import { IssueCodeForm } from './issue-code-form'
+import { IssuedCodePanel } from './issued-code-panel'
+
+type Props = {
+  students: OrgStudentOption[]
+  subjects: ExamSubjectOption[]
+  codes: InternalExamCodeRow[]
+}
+
+export type IssuedCode = { code: string; expiresAt: string }
+
+export function CodesTab({ students, subjects, codes }: Readonly<Props>) {
+  const [issued, setIssued] = useState<IssuedCode | null>(null)
+
+  return (
+    <div className="space-y-6">
+      <IssueCodeForm students={students} subjects={subjects} onIssued={(code) => setIssued(code)} />
+      {issued ? (
+        <IssuedCodePanel
+          code={issued.code}
+          expiresAt={issued.expiresAt}
+          onDismiss={() => setIssued(null)}
+        />
+      ) : null}
+      <CodesTable rows={codes} />
+    </div>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/_components/codes-tab.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/codes-tab.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 export type IssuedCode = { code: string; expiresAt: string }
 
-export function CodesTab({ students, subjects, codes }: Readonly<Props>) {
+export function CodesTab({ students, subjects, codes }: Props) {
   const [issued, setIssued] = useState<IssuedCode | null>(null)
 
   return (

--- a/apps/web/app/app/admin/internal-exams/_components/codes-table.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/codes-table.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { InternalExamCodeRow } from '../types'
+
+const { mockReplace, mockUseSearchParams } = vi.hoisted(() => ({
+  mockReplace: vi.fn(),
+  mockUseSearchParams: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: mockUseSearchParams,
+}))
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string
+    onValueChange: (v: string) => void
+    children: React.ReactNode
+    items?: { value: string; label: string }[]
+  }) => (
+    <select
+      data-testid="status-select"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ 'aria-label': ariaLabel }: { 'aria-label'?: string }) => (
+    <button type="button" aria-label={ariaLabel} />
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder ?? ''}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}))
+
+// Mock VoidCodeDialog so clicking Void simply records the codeId.
+const { mockDialogProps } = vi.hoisted(() => ({ mockDialogProps: vi.fn() }))
+vi.mock('./void-code-dialog', () => ({
+  VoidCodeDialog: (props: { codeId: string | null; open: boolean }) => {
+    mockDialogProps(props)
+    return props.open ? <div data-testid="void-dialog">{props.codeId}</div> : null
+  },
+}))
+
+import { CodesTable } from './codes-table'
+
+const baseRow: InternalExamCodeRow = {
+  id: 'code-1',
+  code: 'ABCD-1234-X',
+  subjectId: 'subj-1',
+  subjectName: 'Air Law',
+  studentId: 'stu-1',
+  studentName: 'Alice',
+  studentEmail: 'alice@example.com',
+  issuedBy: 'admin-1',
+  issuedAt: '2026-04-28T10:00:00.000Z',
+  expiresAt: '2026-04-29T10:00:00.000Z',
+  consumedAt: null,
+  consumedSessionId: null,
+  voidedAt: null,
+  voidedBy: null,
+  voidReason: null,
+  status: 'active',
+  sessionEndedAt: null,
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockUseSearchParams.mockReturnValue(new URLSearchParams())
+})
+
+describe('CodesTable', () => {
+  it('renders empty state when no rows', () => {
+    render(<CodesTable rows={[]} />)
+    expect(screen.getByText('No codes found')).toBeInTheDocument()
+  })
+
+  it('renders code, student, subject', () => {
+    render(<CodesTable rows={[baseRow]} />)
+    expect(screen.getByText('ABCD-1234-X')).toBeInTheDocument()
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getByText('Air Law')).toBeInTheDocument()
+  })
+
+  it('shows active status badge for active codes', () => {
+    render(<CodesTable rows={[baseRow]} />)
+    expect(screen.getByText('active')).toBeInTheDocument()
+  })
+
+  it('shows finished status when consumed and session ended', () => {
+    const finished: InternalExamCodeRow = {
+      ...baseRow,
+      status: 'consumed',
+      consumedAt: '2026-04-28T11:00:00.000Z',
+      consumedSessionId: 'sess-1',
+      sessionEndedAt: '2026-04-28T11:30:00.000Z',
+    }
+    render(<CodesTable rows={[finished]} />)
+    expect(screen.getByText('finished')).toBeInTheDocument()
+  })
+
+  it('shows consumed status when consumed but session still in progress', () => {
+    const inProg: InternalExamCodeRow = {
+      ...baseRow,
+      status: 'consumed',
+      consumedAt: '2026-04-28T11:00:00.000Z',
+      consumedSessionId: 'sess-1',
+      sessionEndedAt: null,
+    }
+    render(<CodesTable rows={[inProg]} />)
+    expect(screen.getByText('consumed')).toBeInTheDocument()
+  })
+
+  it('disables Void button for finished (session ended) codes', () => {
+    const finished: InternalExamCodeRow = {
+      ...baseRow,
+      status: 'consumed',
+      sessionEndedAt: '2026-04-28T11:30:00.000Z',
+    }
+    render(<CodesTable rows={[finished]} />)
+    const btn = screen.getByRole('button', { name: 'Void' })
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('disables Void button for already-voided codes', () => {
+    const voided: InternalExamCodeRow = {
+      ...baseRow,
+      status: 'voided',
+      voidedAt: '2026-04-28T11:00:00.000Z',
+    }
+    render(<CodesTable rows={[voided]} />)
+    const btn = screen.getByRole('button', { name: 'Void' })
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('enables Void for active codes', () => {
+    render(<CodesTable rows={[baseRow]} />)
+    const btn = screen.getByRole('button', { name: 'Void' })
+    expect((btn as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('opens void dialog with the row id when Void is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<CodesTable rows={[baseRow]} />)
+    await user.click(screen.getByRole('button', { name: 'Void' }))
+    expect(screen.getByTestId('void-dialog').textContent).toBe('code-1')
+  })
+
+  it('navigates with status query param when status filter changes', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<CodesTable rows={[baseRow]} />)
+    await user.selectOptions(screen.getByTestId('status-select'), 'voided')
+    expect(mockReplace).toHaveBeenCalledWith('/app/admin/internal-exams?status=voided')
+  })
+
+  it('removes status query param when "all" is selected', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('status=active'))
+    render(<CodesTable rows={[baseRow]} status="active" />)
+    await user.selectOptions(screen.getByTestId('status-select'), '__all__')
+    expect(mockReplace).toHaveBeenCalledWith('/app/admin/internal-exams?')
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/_components/codes-table.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/codes-table.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type { InternalExamCodeRow, InternalExamCodeStatus } from '../types'
+import { VoidCodeDialog } from './void-code-dialog'
+
+type Props = { rows: InternalExamCodeRow[]; status?: InternalExamCodeStatus | 'finished' }
+
+const STATUS_ITEMS = [
+  { value: '__all__', label: 'All' },
+  { value: 'active', label: 'Active' },
+  { value: 'consumed', label: 'In progress' },
+  { value: 'finished', label: 'Finished' },
+  { value: 'voided', label: 'Voided' },
+  { value: 'expired', label: 'Expired' },
+]
+
+function displayStatus(row: InternalExamCodeRow): string {
+  if (row.status === 'consumed' && row.sessionEndedAt) return 'finished'
+  return row.status
+}
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  active: 'default',
+  consumed: 'secondary',
+  finished: 'default',
+  voided: 'destructive',
+  expired: 'outline',
+}
+
+function formatAbsolute(iso: string | null): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('en-GB', { dateStyle: 'short', timeStyle: 'short' })
+}
+
+function isVoidDisabled(r: InternalExamCodeRow): boolean {
+  if (r.status === 'voided') return true
+  return r.status === 'consumed' && r.sessionEndedAt !== null
+}
+
+function CodeRow({ r, onVoid }: { r: InternalExamCodeRow; onVoid: (id: string) => void }) {
+  const ds = displayStatus(r)
+  return (
+    <TableRow>
+      <TableCell>
+        <Badge variant={STATUS_VARIANT[ds] ?? 'outline'} className="text-xs capitalize">
+          {ds}
+        </Badge>
+      </TableCell>
+      <TableCell className="font-mono text-sm">{r.code}</TableCell>
+      <TableCell>{r.studentName || r.studentEmail || '—'}</TableCell>
+      <TableCell>{r.subjectName || '—'}</TableCell>
+      <TableCell className="text-xs text-muted-foreground">{formatAbsolute(r.issuedAt)}</TableCell>
+      <TableCell className="text-xs text-muted-foreground">{formatAbsolute(r.expiresAt)}</TableCell>
+      <TableCell>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isVoidDisabled(r)}
+          onClick={() => onVoid(r.id)}
+        >
+          Void
+        </Button>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+export function CodesTable({ rows, status }: Readonly<Props>) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [voidId, setVoidId] = useState<string | null>(null)
+
+  const onStatusChange = (value: string | null) => {
+    const params = new URLSearchParams(searchParams?.toString() ?? '')
+    if (value === null || value === '__all__') params.delete('status')
+    else params.set('status', value)
+    router.replace(`/app/admin/internal-exams?${params.toString()}`)
+  }
+
+  return (
+    <div className="space-y-3">
+      <Select value={status ?? '__all__'} onValueChange={onStatusChange} items={STATUS_ITEMS}>
+        <SelectTrigger className="w-40" aria-label="Status filter">
+          <SelectValue placeholder="All" />
+        </SelectTrigger>
+        <SelectContent>
+          {STATUS_ITEMS.map((item) => (
+            <SelectItem key={item.value} value={item.value} label={item.label}>
+              {item.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-24">Status</TableHead>
+              <TableHead className="min-w-[140px]">Code</TableHead>
+              <TableHead className="min-w-[160px]">Student</TableHead>
+              <TableHead className="min-w-[140px]">Subject</TableHead>
+              <TableHead className="w-40">Issued</TableHead>
+              <TableHead className="w-40">Expires</TableHead>
+              <TableHead className="w-24">Action</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center text-sm text-muted-foreground">
+                  No codes found
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((r) => <CodeRow key={r.id} r={r} onVoid={setVoidId} />)
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <VoidCodeDialog
+        codeId={voidId}
+        open={voidId !== null}
+        onOpenChange={(o) => !o && setVoidId(null)}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/_components/codes-table.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/codes-table.tsx
@@ -84,7 +84,7 @@ function CodeRow({ r, onVoid }: { r: InternalExamCodeRow; onVoid: (id: string) =
   )
 }
 
-export function CodesTable({ rows, status }: Readonly<Props>) {
+export function CodesTable({ rows, status }: Props) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [voidId, setVoidId] = useState<string | null>(null)

--- a/apps/web/app/app/admin/internal-exams/_components/internal-exams-content.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/internal-exams-content.tsx
@@ -1,0 +1,25 @@
+import {
+  listExamSubjects,
+  listInternalExamAttempts,
+  listInternalExamCodes,
+  listOrgStudents,
+} from '../queries'
+import { InternalExamsTabs } from './internal-exams-tabs'
+
+export async function InternalExamsContent() {
+  const [students, subjects, codesResult, attemptsResult] = await Promise.all([
+    listOrgStudents(),
+    listExamSubjects(),
+    listInternalExamCodes(),
+    listInternalExamAttempts(),
+  ])
+
+  return (
+    <InternalExamsTabs
+      students={students}
+      subjects={subjects}
+      codes={codesResult.rows}
+      attempts={attemptsResult.rows}
+    />
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/_components/internal-exams-fallback.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/internal-exams-fallback.tsx
@@ -1,0 +1,10 @@
+export function InternalExamsFallback() {
+  return (
+    <div className="grid gap-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+        <div key={i} className="h-20 animate-pulse rounded-lg bg-muted" />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/_components/internal-exams-tabs.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/internal-exams-tabs.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+import type {
+  ExamSubjectOption,
+  InternalExamAttemptRow,
+  InternalExamCodeRow,
+  OrgStudentOption,
+} from '../types'
+import { AttemptsTable } from './attempts-table'
+import { CodesTab } from './codes-tab'
+
+type Props = {
+  students: OrgStudentOption[]
+  subjects: ExamSubjectOption[]
+  codes: InternalExamCodeRow[]
+  attempts: InternalExamAttemptRow[]
+}
+
+type TabKey = 'codes' | 'attempts'
+
+export function InternalExamsTabs({ students, subjects, codes, attempts }: Readonly<Props>) {
+  const [tab, setTab] = useState<TabKey>('codes')
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="tablist"
+        aria-label="Internal exam sections"
+        className="flex border-b border-border"
+      >
+        <TabButton
+          id="codes"
+          active={tab === 'codes'}
+          label="Codes"
+          onClick={() => setTab('codes')}
+        />
+        <TabButton
+          id="attempts"
+          active={tab === 'attempts'}
+          label="Attempts"
+          onClick={() => setTab('attempts')}
+        />
+      </div>
+      <div
+        role="tabpanel"
+        id={`tabpanel-${tab}`}
+        aria-labelledby={`tab-${tab}`}
+        data-testid={`tabpanel-${tab}`}
+      >
+        {tab === 'codes' ? (
+          <CodesTab students={students} subjects={subjects} codes={codes} />
+        ) : (
+          <AttemptsTable rows={attempts} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TabButton({
+  id,
+  active,
+  label,
+  onClick,
+}: {
+  id: string
+  active: boolean
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      id={`tab-${id}`}
+      role="tab"
+      aria-selected={active}
+      aria-controls={`tabpanel-${id}`}
+      tabIndex={active ? 0 : -1}
+      onClick={onClick}
+      data-testid={`tab-${id}`}
+      className={`px-4 py-2.5 text-sm font-medium transition-colors border-b-2 ${
+        active
+          ? 'border-primary text-primary'
+          : 'border-transparent text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/_components/internal-exams-tabs.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/internal-exams-tabs.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useSearchParams } from 'next/navigation'
 import { type KeyboardEvent, useRef, useState } from 'react'
 import type {
   ExamSubjectOption,
@@ -22,7 +23,9 @@ type TabKey = 'codes' | 'attempts'
 const TAB_ORDER: TabKey[] = ['codes', 'attempts']
 
 export function InternalExamsTabs({ students, subjects, codes, attempts }: Props) {
-  const [tab, setTab] = useState<TabKey>('codes')
+  const searchParams = useSearchParams()
+  const initialTab: TabKey = searchParams.get('tab') === 'attempts' ? 'attempts' : 'codes'
+  const [tab, setTab] = useState<TabKey>(initialTab)
   const tablistRef = useRef<HTMLDivElement | null>(null)
 
   function focusTab(key: TabKey) {

--- a/apps/web/app/app/admin/internal-exams/_components/internal-exams-tabs.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/internal-exams-tabs.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useSearchParams } from 'next/navigation'
-import { type KeyboardEvent, useRef, useState } from 'react'
+import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
 import type {
   ExamSubjectOption,
   InternalExamAttemptRow,
@@ -22,10 +22,18 @@ type TabKey = 'codes' | 'attempts'
 
 const TAB_ORDER: TabKey[] = ['codes', 'attempts']
 
+function readTabParam(value: string | null): TabKey {
+  return value === 'attempts' ? 'attempts' : 'codes'
+}
+
 export function InternalExamsTabs({ students, subjects, codes, attempts }: Props) {
   const searchParams = useSearchParams()
-  const initialTab: TabKey = searchParams.get('tab') === 'attempts' ? 'attempts' : 'codes'
-  const [tab, setTab] = useState<TabKey>(initialTab)
+  const tabParam = searchParams.get('tab')
+  const [tab, setTab] = useState<TabKey>(readTabParam(tabParam))
+  // Re-sync when ?tab= changes via soft navigation (e.g., "Back" CTA from report page).
+  useEffect(() => {
+    setTab(readTabParam(tabParam))
+  }, [tabParam])
   const tablistRef = useRef<HTMLDivElement | null>(null)
 
   function focusTab(key: TabKey) {

--- a/apps/web/app/app/admin/internal-exams/_components/internal-exams-tabs.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/internal-exams-tabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { type KeyboardEvent, useRef, useState } from 'react'
 import type {
   ExamSubjectOption,
   InternalExamAttemptRow,
@@ -19,15 +19,44 @@ type Props = {
 
 type TabKey = 'codes' | 'attempts'
 
-export function InternalExamsTabs({ students, subjects, codes, attempts }: Readonly<Props>) {
+const TAB_ORDER: TabKey[] = ['codes', 'attempts']
+
+export function InternalExamsTabs({ students, subjects, codes, attempts }: Props) {
   const [tab, setTab] = useState<TabKey>('codes')
+  const tablistRef = useRef<HTMLDivElement | null>(null)
+
+  function focusTab(key: TabKey) {
+    setTab(key)
+    const el = tablistRef.current?.querySelector<HTMLButtonElement>(`[data-tabkey="${key}"]`)
+    el?.focus()
+  }
+
+  function onKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    const idx = TAB_ORDER.indexOf(tab)
+    if (idx < 0) return
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      focusTab(TAB_ORDER[(idx + 1) % TAB_ORDER.length] as TabKey)
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      focusTab(TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length] as TabKey)
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      focusTab(TAB_ORDER[0] as TabKey)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      focusTab(TAB_ORDER[TAB_ORDER.length - 1] as TabKey)
+    }
+  }
 
   return (
     <div className="space-y-4">
       <div
+        ref={tablistRef}
         role="tablist"
         aria-label="Internal exam sections"
         className="flex border-b border-border"
+        onKeyDown={onKeyDown}
       >
         <TabButton
           id="codes"
@@ -79,6 +108,7 @@ function TabButton({
       tabIndex={active ? 0 : -1}
       onClick={onClick}
       data-testid={`tab-${id}`}
+      data-tabkey={id}
       className={`px-4 py-2.5 text-sm font-medium transition-colors border-b-2 ${
         active
           ? 'border-primary text-primary'

--- a/apps/web/app/app/admin/internal-exams/_components/issue-code-form.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issue-code-form.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockIssue = vi.hoisted(() => vi.fn())
+const mockToastSuccess = vi.hoisted(() => vi.fn())
+const mockToastError = vi.hoisted(() => vi.fn())
+
+vi.mock('../actions/issue-code', () => ({
+  issueInternalExamCode: mockIssue,
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
+}))
+
+// Render Base UI Select as a native <select> so jsdom can drive it deterministically.
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    disabled,
+    children,
+  }: {
+    value: string
+    onValueChange?: (v: string) => void
+    disabled?: boolean
+    children: React.ReactNode
+    items?: { value: string; label: string }[]
+  }) => (
+    <select
+      data-testid="select"
+      data-value={value}
+      disabled={disabled}
+      value={value}
+      onChange={(e) => onValueChange?.(e.target.value)}
+    >
+      <option value="" />
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}))
+
+import { IssueCodeForm } from './issue-code-form'
+
+const STUDENTS = [
+  { id: 'stu-1', fullName: 'Alice', email: 'alice@example.com' },
+  { id: 'stu-2', fullName: 'Bob', email: 'bob@example.com' },
+]
+const SUBJECTS = [
+  { id: 'sub-1', code: '050', name: 'Meteorology' },
+  { id: 'sub-2', code: '040', name: 'Human Performance' },
+]
+
+function renderForm(props: Partial<React.ComponentProps<typeof IssueCodeForm>> = {}) {
+  const onIssued = vi.fn()
+  const utils = render(
+    <IssueCodeForm students={STUDENTS} subjects={SUBJECTS} onIssued={onIssued} {...props} />,
+  )
+  return { ...utils, onIssued }
+}
+
+describe('IssueCodeForm', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('disables the submit button until both student and subject are selected', () => {
+    renderForm()
+    const submit = screen.getByRole('button', { name: /issue code/i })
+    expect(submit).toBeDisabled()
+  })
+
+  it('does not call the action when submitted without selections', () => {
+    renderForm()
+    fireEvent.submit(screen.getByTestId('issue-code-form'))
+    expect(mockIssue).not.toHaveBeenCalled()
+  })
+
+  it('submits the action with the selected student and subject ids', async () => {
+    mockIssue.mockResolvedValue({
+      success: true,
+      codeId: 'code-1',
+      code: 'ABCD2345',
+      expiresAt: '2026-04-30T12:00:00.000Z',
+    })
+    const { onIssued } = renderForm()
+
+    const [studentSel, subjectSel] = screen.getAllByTestId('select') as HTMLSelectElement[]
+    fireEvent.change(studentSel!, { target: { value: 'stu-1' } })
+    fireEvent.change(subjectSel!, { target: { value: 'sub-1' } })
+
+    fireEvent.submit(screen.getByTestId('issue-code-form'))
+
+    // wait microtask
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockIssue).toHaveBeenCalledWith({ studentId: 'stu-1', subjectId: 'sub-1' })
+    expect(onIssued).toHaveBeenCalledWith({
+      code: 'ABCD2345',
+      expiresAt: '2026-04-30T12:00:00.000Z',
+    })
+    expect(mockToastSuccess).toHaveBeenCalledWith('Internal exam code issued')
+  })
+
+  it('shows an error toast and does not call onIssued when the action fails', async () => {
+    mockIssue.mockResolvedValue({ success: false, error: 'Configure exam for this subject first' })
+    const { onIssued } = renderForm()
+
+    const [studentSel, subjectSel] = screen.getAllByTestId('select') as HTMLSelectElement[]
+    fireEvent.change(studentSel!, { target: { value: 'stu-1' } })
+    fireEvent.change(subjectSel!, { target: { value: 'sub-1' } })
+    fireEvent.submit(screen.getByTestId('issue-code-form'))
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockToastError).toHaveBeenCalledWith('Configure exam for this subject first')
+    expect(onIssued).not.toHaveBeenCalled()
+  })
+
+  it('disables the selects when there are no students or subjects available', () => {
+    renderForm({ students: [], subjects: [] })
+    const selects = screen.getAllByTestId('select') as HTMLSelectElement[]
+    expect(selects[0]).toBeDisabled()
+    expect(selects[1]).toBeDisabled()
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/_components/issue-code-form.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issue-code-form.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { issueInternalExamCode } from '../actions/issue-code'
+import type { ExamSubjectOption, OrgStudentOption } from '../types'
+
+type Props = {
+  students: OrgStudentOption[]
+  subjects: ExamSubjectOption[]
+  onIssued: (issued: { code: string; expiresAt: string }) => void
+}
+
+export function IssueCodeForm({ students, subjects, onIssued }: Readonly<Props>) {
+  const [studentId, setStudentId] = useState<string>('')
+  const [subjectId, setSubjectId] = useState<string>('')
+  const [isPending, startTransition] = useTransition()
+
+  const studentItems = students.map((s) => ({
+    value: s.id,
+    label: s.fullName ? `${s.fullName} (${s.email})` : s.email,
+  }))
+  const subjectItems = subjects.map((s) => ({
+    value: s.id,
+    label: `${s.code} — ${s.name}`,
+  }))
+
+  const canSubmit = studentId !== '' && subjectId !== '' && !isPending
+
+  function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (!canSubmit) return
+    startTransition(async () => {
+      try {
+        const result = await issueInternalExamCode({ studentId, subjectId })
+        if (result.success) {
+          toast.success('Internal exam code issued')
+          onIssued({ code: result.code, expiresAt: result.expiresAt })
+          setStudentId('')
+          setSubjectId('')
+        } else {
+          toast.error(result.error)
+        }
+      } catch {
+        toast.error('Failed to issue internal exam code')
+      }
+    })
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="grid gap-4 rounded-lg border border-border bg-card p-4 md:grid-cols-[1fr_1fr_auto] md:items-end"
+      data-testid="issue-code-form"
+    >
+      <div className="grid gap-2">
+        <Label htmlFor="student">Student</Label>
+        <Select
+          value={studentId}
+          onValueChange={(v) => v && setStudentId(v)}
+          disabled={isPending || students.length === 0}
+          items={studentItems}
+        >
+          <SelectTrigger id="student" aria-label="Student" className="w-full">
+            <SelectValue placeholder="Select student" />
+          </SelectTrigger>
+          <SelectContent>
+            {studentItems.map((item) => (
+              <SelectItem key={item.value} value={item.value} label={item.label}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="subject">Subject</Label>
+        <Select
+          value={subjectId}
+          onValueChange={(v) => v && setSubjectId(v)}
+          disabled={isPending || subjects.length === 0}
+          items={subjectItems}
+        >
+          <SelectTrigger id="subject" aria-label="Subject" className="w-full">
+            <SelectValue placeholder="Select subject" />
+          </SelectTrigger>
+          <SelectContent>
+            {subjectItems.map((item) => (
+              <SelectItem key={item.value} value={item.value} label={item.label}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Button type="submit" disabled={!canSubmit}>
+        {isPending ? 'Issuing…' : 'Issue code'}
+      </Button>
+    </form>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/_components/issue-code-form.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issue-code-form.tsx
@@ -73,7 +73,7 @@ export function IssueCodeForm({ students, subjects, onIssued }: Readonly<Props>)
           <SelectTrigger id="student" aria-label="Student" className="w-full">
             <SelectValue placeholder="Select student" />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent alignItemWithTrigger={false}>
             {studentItems.map((item) => (
               <SelectItem key={item.value} value={item.value} label={item.label}>
                 {item.label}
@@ -94,7 +94,7 @@ export function IssueCodeForm({ students, subjects, onIssued }: Readonly<Props>)
           <SelectTrigger id="subject" aria-label="Subject" className="w-full">
             <SelectValue placeholder="Select subject" />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent alignItemWithTrigger={false}>
             {subjectItems.map((item) => (
               <SelectItem key={item.value} value={item.value} label={item.label}>
                 {item.label}

--- a/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockToastSuccess = vi.hoisted(() => vi.fn())
 const mockToastError = vi.hoisted(() => vi.fn())
@@ -17,8 +17,22 @@ const PROPS = {
 }
 
 describe('IssuedCodePanel', () => {
+  // Capture and restore the original clipboard descriptor across tests so we
+  // never leak a fake `writeText` to sibling specs.
+  const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+
   beforeEach(() => {
     vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor)
+    } else {
+      // Some jsdom builds don't define clipboard at all — strip the test fake.
+      // biome-ignore lint/performance/noDelete: required to fully restore navigator
+      delete (navigator as unknown as { clipboard?: unknown }).clipboard
+    }
   })
 
   it('displays the issued code in large monospace text', () => {

--- a/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockToastSuccess = vi.hoisted(() => vi.fn())
+const mockToastError = vi.hoisted(() => vi.fn())
+
+vi.mock('sonner', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
+}))
+
+import { IssuedCodePanel } from './issued-code-panel'
+
+const PROPS = {
+  code: 'ABCD2345',
+  expiresAt: '2026-04-30T12:00:00.000Z',
+  onDismiss: vi.fn(),
+}
+
+describe('IssuedCodePanel', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('displays the issued code in large monospace text', () => {
+    render(<IssuedCodePanel {...PROPS} />)
+    expect(screen.getByTestId('issued-code-value')).toHaveTextContent('ABCD2345')
+  })
+
+  it('warns the admin that the code will not be shown again', () => {
+    render(<IssuedCodePanel {...PROPS} />)
+    expect(screen.getByText(/won.?t be shown again/i)).toBeInTheDocument()
+  })
+
+  it('shows the expiry timestamp in a human-readable format', () => {
+    render(<IssuedCodePanel {...PROPS} />)
+    // The exact format depends on locale, but the year and month should appear.
+    expect(screen.getByText(/Expires/)).toBeInTheDocument()
+  })
+
+  it('copies the code to the clipboard and shows a confirmation toast on copy', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    render(<IssuedCodePanel {...PROPS} />)
+    fireEvent.click(screen.getByRole('button', { name: /copy code/i }))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(writeText).toHaveBeenCalledWith('ABCD2345')
+    expect(mockToastSuccess).toHaveBeenCalledWith('Code copied to clipboard')
+  })
+
+  it('shows an error toast when clipboard write fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    render(<IssuedCodePanel {...PROPS} />)
+    fireEvent.click(screen.getByRole('button', { name: /copy code/i }))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockToastError).toHaveBeenCalledWith('Could not copy code')
+  })
+
+  it('calls onDismiss when the dismiss button is clicked', () => {
+    const onDismiss = vi.fn()
+    render(<IssuedCodePanel {...PROPS} onDismiss={onDismiss} />)
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.test.tsx
@@ -88,4 +88,20 @@ describe('IssuedCodePanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
     expect(onDismiss).toHaveBeenCalledTimes(1)
   })
+
+  it('resets the Copied indicator when the panel is rerendered with a different code', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    const { rerender } = render(<IssuedCodePanel {...PROPS} />)
+    fireEvent.click(screen.getByRole('button', { name: /copy code/i }))
+    // findByRole awaits the post-clipboard rerender that flips the label.
+    expect(await screen.findByRole('button', { name: /^copied$/i })).toBeInTheDocument()
+
+    rerender(<IssuedCodePanel {...PROPS} code="ZZZZ7777" />)
+    expect(screen.getByRole('button', { name: /copy code/i })).toBeInTheDocument()
+  })
 })

--- a/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+
+type Props = {
+  code: string
+  expiresAt: string
+  onDismiss: () => void
+}
+
+function formatExpiry(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+export function IssuedCodePanel({ code, expiresAt, onDismiss }: Readonly<Props>) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      toast.success('Code copied to clipboard')
+    } catch {
+      toast.error('Could not copy code')
+    }
+  }
+
+  return (
+    <section
+      aria-label="Newly issued exam code"
+      data-testid="issued-code-panel"
+      className="rounded-lg border-2 border-primary bg-primary/5 p-6"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            New code issued
+          </p>
+          <p
+            className="font-mono text-3xl font-bold tracking-widest"
+            data-testid="issued-code-value"
+          >
+            {code}
+          </p>
+          <p className="text-sm text-muted-foreground">Expires {formatExpiry(expiresAt)}</p>
+          <p className="text-sm font-medium text-destructive">Won't be shown again — copy now.</p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Button type="button" onClick={handleCopy} variant="default">
+            {copied ? 'Copied' : 'Copy code'}
+          </Button>
+          <Button type="button" onClick={onDismiss} variant="outline">
+            Dismiss
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.tsx
@@ -16,7 +16,7 @@ function formatExpiry(iso: string): string {
   return d.toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' })
 }
 
-export function IssuedCodePanel({ code, expiresAt, onDismiss }: Readonly<Props>) {
+export function IssuedCodePanel({ code, expiresAt, onDismiss }: Props) {
   const [copied, setCopied] = useState(false)
 
   async function handleCopy() {

--- a/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 
@@ -18,6 +18,15 @@ function formatExpiry(iso: string): string {
 
 export function IssuedCodePanel({ code, expiresAt, onDismiss }: Props) {
   const [copied, setCopied] = useState(false)
+
+  // Reset the "Copied" indicator when the panel is reused for a different code
+  // (e.g. admin issues a second code without unmounting the panel). The effect
+  // body doesn't read `code`, but the dep is the change-trigger — exactly the
+  // case useExhaustiveDependencies misclassifies.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: code is the change trigger, not a read
+  useEffect(() => {
+    setCopied(false)
+  }, [code])
 
   async function handleCopy() {
     try {

--- a/apps/web/app/app/admin/internal-exams/_components/void-code-dialog.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/void-code-dialog.test.tsx
@@ -99,15 +99,16 @@ describe('VoidCodeDialog', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
-  it('shows session-ended toast when sessionEnded is true', async () => {
+  it('shows session-ended toast and closes dialog when sessionEnded is true', async () => {
     vi.mocked(voidInternalExamCode).mockResolvedValue({
       success: true,
       codeId: CODE_ID,
       sessionId: 'sess-1',
       sessionEnded: true,
     })
+    const onOpenChange = vi.fn()
     const user = userEvent.setup({ delay: null })
-    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={vi.fn()} />)
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={onOpenChange} />)
 
     await user.type(screen.getByLabelText('Reason'), 'reason')
     await user.click(screen.getByRole('button', { name: 'Void code' }))
@@ -115,6 +116,7 @@ describe('VoidCodeDialog', () => {
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith('Code voided and active session ended')
     })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it('shows inline error message and keeps dialog open on failure', async () => {

--- a/apps/web/app/app/admin/internal-exams/_components/void-code-dialog.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/void-code-dialog.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../actions/void-code', () => ({
+  voidInternalExamCode: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { toast } from 'sonner'
+import { voidInternalExamCode } from '../actions/void-code'
+import { VoidCodeDialog } from './void-code-dialog'
+
+const CODE_ID = '00000000-0000-4000-a000-000000000001'
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('VoidCodeDialog', () => {
+  it('does not render dialog content when closed', () => {
+    render(<VoidCodeDialog codeId={CODE_ID} open={false} onOpenChange={vi.fn()} />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders title, reason textarea, and submit button when open', () => {
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={vi.fn()} />)
+    expect(screen.getByText('Void internal exam code')).toBeInTheDocument()
+    expect(screen.getByLabelText('Reason')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Void code' })).toBeInTheDocument()
+  })
+
+  it('disables submit when reason is empty', () => {
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={vi.fn()} />)
+    const btn = screen.getByRole('button', { name: 'Void code' })
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('disables submit when codeId is null', async () => {
+    render(<VoidCodeDialog codeId={null} open={true} onOpenChange={vi.fn()} />)
+    const user = userEvent.setup({ delay: null })
+    await user.type(screen.getByLabelText('Reason'), 'because')
+    const btn = screen.getByRole('button', { name: 'Void code' })
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('enables submit when reason is provided and codeId is set', async () => {
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={vi.fn()} />)
+    const user = userEvent.setup({ delay: null })
+    await user.type(screen.getByLabelText('Reason'), 'rescheduled')
+    const btn = screen.getByRole('button', { name: 'Void code' })
+    expect((btn as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('calls voidInternalExamCode with codeId and trimmed reason on submit', async () => {
+    vi.mocked(voidInternalExamCode).mockResolvedValue({
+      success: true,
+      codeId: CODE_ID,
+      sessionId: null,
+      sessionEnded: false,
+    })
+    const user = userEvent.setup({ delay: null })
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Reason'), '  Student requested  ')
+    await user.click(screen.getByRole('button', { name: 'Void code' }))
+
+    await waitFor(() => {
+      expect(voidInternalExamCode).toHaveBeenCalledWith({
+        codeId: CODE_ID,
+        reason: 'Student requested',
+      })
+    })
+  })
+
+  it('closes dialog and shows success toast on success (no active session)', async () => {
+    vi.mocked(voidInternalExamCode).mockResolvedValue({
+      success: true,
+      codeId: CODE_ID,
+      sessionId: null,
+      sessionEnded: false,
+    })
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup({ delay: null })
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={onOpenChange} />)
+
+    await user.type(screen.getByLabelText('Reason'), 'reason')
+    await user.click(screen.getByRole('button', { name: 'Void code' }))
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Code voided')
+    })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('shows session-ended toast when sessionEnded is true', async () => {
+    vi.mocked(voidInternalExamCode).mockResolvedValue({
+      success: true,
+      codeId: CODE_ID,
+      sessionId: 'sess-1',
+      sessionEnded: true,
+    })
+    const user = userEvent.setup({ delay: null })
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Reason'), 'reason')
+    await user.click(screen.getByRole('button', { name: 'Void code' }))
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Code voided and active session ended')
+    })
+  })
+
+  it('shows inline error message and keeps dialog open on failure', async () => {
+    vi.mocked(voidInternalExamCode).mockResolvedValue({
+      success: false,
+      error: 'Cannot void a finished attempt — record is final',
+    })
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup({ delay: null })
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={onOpenChange} />)
+
+    await user.type(screen.getByLabelText('Reason'), 'reason')
+    await user.click(screen.getByRole('button', { name: 'Void code' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toBe(
+        'Cannot void a finished attempt — record is final',
+      )
+    })
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('shows generic error and keeps dialog open when action throws', async () => {
+    vi.mocked(voidInternalExamCode).mockRejectedValue(new Error('Network'))
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup({ delay: null })
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={onOpenChange} />)
+
+    await user.type(screen.getByLabelText('Reason'), 'reason')
+    await user.click(screen.getByRole('button', { name: 'Void code' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toBe('Failed to void internal exam code')
+    })
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it('calls onOpenChange(false) when Cancel is clicked', async () => {
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup({ delay: null })
+    render(<VoidCodeDialog codeId={CODE_ID} open={true} onOpenChange={onOpenChange} />)
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/_components/void-code-dialog.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/void-code-dialog.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useEffect, useState, useTransition } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { voidInternalExamCode } from '../actions/void-code'
+
+type Props = {
+  codeId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function VoidCodeDialog({ codeId, open, onOpenChange }: Readonly<Props>) {
+  const [reason, setReason] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    if (open) {
+      setReason('')
+      setError(null)
+    }
+  }, [open])
+
+  const trimmed = reason.trim()
+  const isValid = trimmed.length >= 1 && trimmed.length <= 500
+
+  function handleSubmit() {
+    if (!codeId || !isValid) return
+    setError(null)
+    startTransition(async () => {
+      try {
+        const result = await voidInternalExamCode({ codeId, reason: trimmed })
+        if (result.success) {
+          toast.success(
+            result.sessionEnded ? 'Code voided and active session ended' : 'Code voided',
+          )
+          onOpenChange(false)
+        } else {
+          setError(result.error)
+        }
+      } catch {
+        setError('Failed to void internal exam code')
+      }
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Void internal exam code</DialogTitle>
+          <DialogDescription>
+            Provide a reason for voiding this code. If the student has an active session it will be
+            terminated. Finished attempts cannot be voided.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="void-reason">Reason</Label>
+          <Textarea
+            id="void-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="e.g. Student requested rescheduling"
+            maxLength={500}
+            rows={4}
+          />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>{trimmed.length}/500</span>
+            {error ? (
+              <span role="alert" className="text-destructive">
+                {error}
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleSubmit}
+            disabled={isPending || !isValid || !codeId}
+          >
+            {isPending ? 'Voiding…' : 'Void code'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/actions/issue-code.test.ts
+++ b/apps/web/app/app/admin/internal-exams/actions/issue-code.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const mockRevalidatePath = vi.hoisted(() => vi.fn())
+const mockRequireAdmin = vi.hoisted(() => vi.fn())
+const mockRpc = vi.hoisted(() => vi.fn())
+
+vi.mock('next/cache', () => ({ revalidatePath: mockRevalidatePath }))
+vi.mock('@/lib/auth/require-admin', () => ({ requireAdmin: mockRequireAdmin }))
+vi.mock('@/lib/supabase-rpc', () => ({ rpc: mockRpc }))
+
+// ---- Subject under test ---------------------------------------------------
+
+import { issueInternalExamCode } from './issue-code'
+
+// ---- Helpers ---------------------------------------------------------------
+
+const STUDENT_ID = '00000000-0000-4000-a000-000000000001'
+const SUBJECT_ID = '00000000-0000-4000-a000-000000000002'
+const CODE_ID = '00000000-0000-4000-a000-000000000099'
+const SUPABASE = { __marker: 'supabase' }
+
+function mockAdmin() {
+  mockRequireAdmin.mockResolvedValue({
+    supabase: SUPABASE,
+    organizationId: 'org-001',
+    userId: 'admin-001',
+  })
+}
+
+const VALID_INPUT = { studentId: STUDENT_ID, subjectId: SUBJECT_ID }
+const RPC_OK_ROW = {
+  code_id: CODE_ID,
+  code: 'ABCD2345',
+  expires_at: '2026-04-29T00:00:00.000Z',
+}
+
+// ---- Tests ----------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('issueInternalExamCode', () => {
+  describe('input validation', () => {
+    it('rejects missing fields', async () => {
+      const result = await issueInternalExamCode({})
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Invalid input')
+    })
+
+    it('rejects non-uuid studentId', async () => {
+      const result = await issueInternalExamCode({ studentId: 'not-a-uuid', subjectId: SUBJECT_ID })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects non-uuid subjectId', async () => {
+      const result = await issueInternalExamCode({ studentId: STUDENT_ID, subjectId: 'bad' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('RPC call', () => {
+    it('calls issue_internal_exam_code with correct parameters', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: [RPC_OK_ROW], error: null })
+
+      await issueInternalExamCode(VALID_INPUT)
+
+      expect(mockRpc).toHaveBeenCalledWith(SUPABASE, 'issue_internal_exam_code', {
+        p_subject_id: SUBJECT_ID,
+        p_student_id: STUDENT_ID,
+      })
+    })
+
+    it('returns code data on success and revalidates path', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: [RPC_OK_ROW], error: null })
+
+      const result = await issueInternalExamCode(VALID_INPUT)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.codeId).toBe(CODE_ID)
+        expect(result.code).toBe('ABCD2345')
+        expect(result.expiresAt).toBe('2026-04-29T00:00:00.000Z')
+      }
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/app/admin/internal-exams')
+    })
+
+    it('handles RPC returning a single object (not an array)', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: RPC_OK_ROW, error: null })
+
+      const result = await issueInternalExamCode(VALID_INPUT)
+
+      expect(result.success).toBe(true)
+    })
+
+    it('returns "Failed to issue internal exam code" when RPC returns null data', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: null })
+
+      const result = await issueInternalExamCode(VALID_INPUT)
+
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Failed to issue internal exam code')
+    })
+
+    it('returns "Failed to issue internal exam code" when RPC returns malformed shape', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: [{ wrong: 'shape' }], error: null })
+
+      const result = await issueInternalExamCode(VALID_INPUT)
+
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('error code mapping', () => {
+    it('maps not_authenticated', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({
+        data: null,
+        error: { message: 'P0001: not_authenticated' },
+      })
+      const result = await issueInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Not authenticated')
+    })
+
+    it('maps not_admin', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'not_admin' } })
+      const result = await issueInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Admin permission required')
+    })
+
+    it('maps student_not_found', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'student_not_found' } })
+      const result = await issueInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Student not found in your organization')
+    })
+
+    it('maps subject_not_found', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'subject_not_found' } })
+      const result = await issueInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Subject not found')
+    })
+
+    it('maps exam_config_required', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'exam_config_required' } })
+      const result = await issueInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Configure exam for this subject first')
+    })
+
+    it('maps code_generation_failed', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'code_generation_failed' } })
+      const result = await issueInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Failed to generate code, please try again')
+    })
+
+    it('returns generic message for unrecognized RPC error', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'connection refused' } })
+      const result = await issueInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Failed to issue internal exam code')
+    })
+
+    it('does not revalidate on RPC error', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'student_not_found' } })
+      await issueInternalExamCode(VALID_INPUT)
+      expect(mockRevalidatePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('auth guard', () => {
+    it('propagates auth errors from requireAdmin', async () => {
+      mockRequireAdmin.mockRejectedValue(new Error('Not admin'))
+
+      await expect(issueInternalExamCode(VALID_INPUT)).rejects.toThrow('Not admin')
+    })
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/actions/issue-code.ts
+++ b/apps/web/app/app/admin/internal-exams/actions/issue-code.ts
@@ -1,0 +1,71 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { rpc } from '@/lib/supabase-rpc'
+
+const IssueCodeSchema = z.object({
+  studentId: z.uuid(),
+  subjectId: z.uuid(),
+})
+
+export type IssueCodeInput = z.infer<typeof IssueCodeSchema>
+
+export type IssueCodeResult =
+  | { success: true; codeId: string; code: string; expiresAt: string }
+  | { success: false; error: string }
+
+const ERROR_MESSAGES: Record<string, string> = {
+  not_authenticated: 'Not authenticated',
+  not_admin: 'Admin permission required',
+  admin_not_found: 'Admin permission required',
+  student_not_found: 'Student not found in your organization',
+  subject_not_found: 'Subject not found',
+  exam_config_required: 'Configure exam for this subject first',
+  code_generation_failed: 'Failed to generate code, please try again',
+}
+
+function mapRpcError(message: string): string {
+  for (const [code, msg] of Object.entries(ERROR_MESSAGES)) {
+    if (message.includes(code)) return msg
+  }
+  return 'Failed to issue internal exam code'
+}
+
+type RpcRow = { code_id: string; code: string; expires_at: string }
+
+function isRpcRow(value: unknown): value is RpcRow {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.code_id === 'string' && typeof v.code === 'string' && typeof v.expires_at === 'string'
+  )
+}
+
+export async function issueInternalExamCode(input: unknown): Promise<IssueCodeResult> {
+  const parsed = IssueCodeSchema.safeParse(input)
+  if (!parsed.success) return { success: false, error: 'Invalid input' }
+
+  const { supabase } = await requireAdmin()
+  const { studentId, subjectId } = parsed.data
+
+  const { data, error } = await rpc<unknown>(supabase, 'issue_internal_exam_code', {
+    p_subject_id: subjectId,
+    p_student_id: studentId,
+  })
+
+  if (error) {
+    console.error('[issueInternalExamCode] RPC error:', error.message)
+    return { success: false, error: mapRpcError(error.message) }
+  }
+
+  const row = Array.isArray(data) ? data[0] : data
+  if (!isRpcRow(row)) {
+    console.error('[issueInternalExamCode] RPC returned unexpected shape')
+    return { success: false, error: 'Failed to issue internal exam code' }
+  }
+
+  revalidatePath('/app/admin/internal-exams')
+  return { success: true, codeId: row.code_id, code: row.code, expiresAt: row.expires_at }
+}

--- a/apps/web/app/app/admin/internal-exams/actions/void-code.test.ts
+++ b/apps/web/app/app/admin/internal-exams/actions/void-code.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const mockRevalidatePath = vi.hoisted(() => vi.fn())
+const mockRequireAdmin = vi.hoisted(() => vi.fn())
+const mockRpc = vi.hoisted(() => vi.fn())
+
+vi.mock('next/cache', () => ({ revalidatePath: mockRevalidatePath }))
+vi.mock('@/lib/auth/require-admin', () => ({ requireAdmin: mockRequireAdmin }))
+vi.mock('@/lib/supabase-rpc', () => ({ rpc: mockRpc }))
+
+// ---- Subject under test ---------------------------------------------------
+
+import { voidInternalExamCode } from './void-code'
+
+// ---- Helpers ---------------------------------------------------------------
+
+const CODE_ID = '00000000-0000-4000-a000-000000000001'
+const SESSION_ID = '00000000-0000-4000-a000-000000000002'
+const SUPABASE = { __marker: 'supabase' }
+
+function mockAdmin() {
+  mockRequireAdmin.mockResolvedValue({
+    supabase: SUPABASE,
+    organizationId: 'org-001',
+    userId: 'admin-001',
+  })
+}
+
+const VALID_INPUT = { codeId: CODE_ID, reason: 'Student requested rescheduling' }
+
+const RPC_OK_NO_SESSION = { code_id: CODE_ID, session_id: null, session_ended: false }
+const RPC_OK_WITH_SESSION = {
+  code_id: CODE_ID,
+  session_id: SESSION_ID,
+  session_ended: true,
+}
+
+// ---- Tests ----------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('voidInternalExamCode', () => {
+  describe('input validation', () => {
+    it('rejects missing fields', async () => {
+      const result = await voidInternalExamCode({})
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Invalid input')
+    })
+
+    it('rejects non-uuid codeId', async () => {
+      const result = await voidInternalExamCode({ codeId: 'bad', reason: 'r' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects empty reason', async () => {
+      const result = await voidInternalExamCode({ codeId: CODE_ID, reason: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects reason longer than 500 chars', async () => {
+      const result = await voidInternalExamCode({
+        codeId: CODE_ID,
+        reason: 'x'.repeat(501),
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('RPC call', () => {
+    it('calls void_internal_exam_code with correct parameters', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: [RPC_OK_NO_SESSION], error: null })
+
+      await voidInternalExamCode(VALID_INPUT)
+
+      expect(mockRpc).toHaveBeenCalledWith(SUPABASE, 'void_internal_exam_code', {
+        p_code_id: CODE_ID,
+        p_reason: 'Student requested rescheduling',
+      })
+    })
+
+    it('returns success with null sessionId when code was unconsumed', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: [RPC_OK_NO_SESSION], error: null })
+
+      const result = await voidInternalExamCode(VALID_INPUT)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.codeId).toBe(CODE_ID)
+        expect(result.sessionId).toBeNull()
+        expect(result.sessionEnded).toBe(false)
+      }
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/app/admin/internal-exams')
+    })
+
+    it('returns success with sessionId and sessionEnded when active session was terminated', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: [RPC_OK_WITH_SESSION], error: null })
+
+      const result = await voidInternalExamCode(VALID_INPUT)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.sessionId).toBe(SESSION_ID)
+        expect(result.sessionEnded).toBe(true)
+      }
+    })
+
+    it('handles RPC returning a single object (not an array)', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: RPC_OK_NO_SESSION, error: null })
+
+      const result = await voidInternalExamCode(VALID_INPUT)
+
+      expect(result.success).toBe(true)
+    })
+
+    it('returns "Failed to void internal exam code" when RPC returns null data', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: null })
+
+      const result = await voidInternalExamCode(VALID_INPUT)
+
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Failed to void internal exam code')
+    })
+
+    it('returns "Failed to void internal exam code" when RPC returns malformed shape', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: [{ wrong: 'shape' }], error: null })
+
+      const result = await voidInternalExamCode(VALID_INPUT)
+
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('error code mapping', () => {
+    it('maps cannot_void_finished_attempt', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({
+        data: null,
+        error: { message: 'cannot_void_finished_attempt' },
+      })
+      const result = await voidInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBe('Cannot void a finished attempt — record is final')
+      }
+    })
+
+    it('maps code_not_found', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'code_not_found' } })
+      const result = await voidInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Code not found')
+    })
+
+    it('maps not_admin', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'not_admin' } })
+      const result = await voidInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Admin permission required')
+    })
+
+    it('returns generic message for unrecognized RPC error', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'connection lost' } })
+      const result = await voidInternalExamCode(VALID_INPUT)
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Failed to void internal exam code')
+    })
+
+    it('does not revalidate on RPC error', async () => {
+      mockAdmin()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'code_not_found' } })
+      await voidInternalExamCode(VALID_INPUT)
+      expect(mockRevalidatePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('auth guard', () => {
+    it('propagates auth errors from requireAdmin', async () => {
+      mockRequireAdmin.mockRejectedValue(new Error('Not admin'))
+
+      await expect(voidInternalExamCode(VALID_INPUT)).rejects.toThrow('Not admin')
+    })
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/actions/void-code.test.ts
+++ b/apps/web/app/app/admin/internal-exams/actions/void-code.test.ts
@@ -109,6 +109,7 @@ describe('voidInternalExamCode', () => {
         expect(result.sessionId).toBe(SESSION_ID)
         expect(result.sessionEnded).toBe(true)
       }
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/app/admin/internal-exams')
     })
 
     it('handles RPC returning a single object (not an array)', async () => {

--- a/apps/web/app/app/admin/internal-exams/actions/void-code.ts
+++ b/apps/web/app/app/admin/internal-exams/actions/void-code.ts
@@ -1,0 +1,77 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { rpc } from '@/lib/supabase-rpc'
+
+const VoidCodeSchema = z.object({
+  codeId: z.uuid(),
+  reason: z.string().min(1).max(500),
+})
+
+export type VoidCodeInput = z.infer<typeof VoidCodeSchema>
+
+export type VoidCodeResult =
+  | { success: true; codeId: string; sessionId: string | null; sessionEnded: boolean }
+  | { success: false; error: string }
+
+const ERROR_MESSAGES: Record<string, string> = {
+  not_authenticated: 'Not authenticated',
+  not_admin: 'Admin permission required',
+  admin_not_found: 'Admin permission required',
+  cannot_void_finished_attempt: 'Cannot void a finished attempt — record is final',
+  code_not_found: 'Code not found',
+  code_voided: 'Code is already voided',
+}
+
+function mapRpcError(message: string): string {
+  for (const [code, msg] of Object.entries(ERROR_MESSAGES)) {
+    if (message.includes(code)) return msg
+  }
+  return 'Failed to void internal exam code'
+}
+
+type RpcRow = { code_id: string; session_id: string | null; session_ended: boolean }
+
+function isRpcRow(value: unknown): value is RpcRow {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.code_id === 'string' &&
+    (v.session_id === null || typeof v.session_id === 'string') &&
+    typeof v.session_ended === 'boolean'
+  )
+}
+
+export async function voidInternalExamCode(input: unknown): Promise<VoidCodeResult> {
+  const parsed = VoidCodeSchema.safeParse(input)
+  if (!parsed.success) return { success: false, error: 'Invalid input' }
+
+  const { supabase } = await requireAdmin()
+  const { codeId, reason } = parsed.data
+
+  const { data, error } = await rpc<unknown>(supabase, 'void_internal_exam_code', {
+    p_code_id: codeId,
+    p_reason: reason,
+  })
+
+  if (error) {
+    console.error('[voidInternalExamCode] RPC error:', error.message)
+    return { success: false, error: mapRpcError(error.message) }
+  }
+
+  const row = Array.isArray(data) ? data[0] : data
+  if (!isRpcRow(row)) {
+    console.error('[voidInternalExamCode] RPC returned unexpected shape')
+    return { success: false, error: 'Failed to void internal exam code' }
+  }
+
+  revalidatePath('/app/admin/internal-exams')
+  return {
+    success: true,
+    codeId: row.code_id,
+    sessionId: row.session_id,
+    sessionEnded: row.session_ended,
+  }
+}

--- a/apps/web/app/app/admin/internal-exams/page.tsx
+++ b/apps/web/app/app/admin/internal-exams/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import { requireAdmin } from '@/lib/auth/require-admin'
 import { InternalExamsContent } from './_components/internal-exams-content'
+import { InternalExamsFallback } from './_components/internal-exams-fallback'
 
 export default async function InternalExamsPage() {
   await requireAdmin()
@@ -15,17 +16,6 @@ export default async function InternalExamsPage() {
       <Suspense fallback={<InternalExamsFallback />}>
         <InternalExamsContent />
       </Suspense>
-    </div>
-  )
-}
-
-function InternalExamsFallback() {
-  return (
-    <div className="grid gap-4">
-      {Array.from({ length: 4 }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
-        <div key={i} className="h-20 animate-pulse rounded-lg bg-muted" />
-      ))}
     </div>
   )
 }

--- a/apps/web/app/app/admin/internal-exams/page.tsx
+++ b/apps/web/app/app/admin/internal-exams/page.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from 'react'
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { InternalExamsContent } from './_components/internal-exams-content'
+
+export default async function InternalExamsPage() {
+  await requireAdmin()
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Internal Exams</h1>
+        <p className="text-sm text-muted-foreground">
+          Issue one-time exam codes to students and review past attempts.
+        </p>
+      </div>
+      <Suspense fallback={<InternalExamsFallback />}>
+        <InternalExamsContent />
+      </Suspense>
+    </div>
+  )
+}
+
+function InternalExamsFallback() {
+  return (
+    <div className="grid gap-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+        <div key={i} className="h-20 animate-pulse rounded-lg bg-muted" />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/queries.test.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.test.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // ---- Mocks ----------------------------------------------------------------
 
 const mockRequireAdmin = vi.hoisted(() => vi.fn())
-const mockFrom = vi.hoisted(() => vi.fn())
+const mockAdminFrom = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/auth/require-admin', () => ({ requireAdmin: mockRequireAdmin }))
+vi.mock('@repo/db/admin', () => ({ adminClient: { from: mockAdminFrom } }))
 
 // ---- Subject under test ---------------------------------------------------
 
@@ -20,7 +21,7 @@ const PAST = new Date('2026-04-27T12:00:00.000Z').toISOString()
 
 function mockAdmin() {
   mockRequireAdmin.mockResolvedValue({
-    supabase: { from: mockFrom },
+    supabase: { from: mockAdminFrom },
     organizationId: ORG_ID,
     userId: 'admin-001',
   })
@@ -70,7 +71,7 @@ describe('listInternalExamCodes', () => {
         users: { full_name: 'Alice', email: 'alice@example.com' },
         quiz_sessions: null,
       }
-      mockFrom.mockReturnValue(buildChain([row]))
+      mockAdminFrom.mockReturnValue(buildChain([row]))
 
       const result = await listInternalExamCodes()
 
@@ -106,7 +107,7 @@ describe('listInternalExamCodes', () => {
         users: null,
         quiz_sessions: null,
       }
-      mockFrom.mockReturnValue(buildChain([row]))
+      mockAdminFrom.mockReturnValue(buildChain([row]))
 
       const result = await listInternalExamCodes()
 
@@ -132,7 +133,7 @@ describe('listInternalExamCodes', () => {
         users: null,
         quiz_sessions: { ended_at: PAST },
       }
-      mockFrom.mockReturnValue(buildChain([row]))
+      mockAdminFrom.mockReturnValue(buildChain([row]))
 
       const result = await listInternalExamCodes()
 
@@ -159,7 +160,7 @@ describe('listInternalExamCodes', () => {
         users: null,
         quiz_sessions: null,
       }
-      mockFrom.mockReturnValue(buildChain([row]))
+      mockAdminFrom.mockReturnValue(buildChain([row]))
 
       const result = await listInternalExamCodes()
 
@@ -185,7 +186,7 @@ describe('listInternalExamCodes', () => {
         users: null,
         quiz_sessions: null,
       }
-      mockFrom.mockReturnValue(buildChain([row]))
+      mockAdminFrom.mockReturnValue(buildChain([row]))
 
       const result = await listInternalExamCodes()
 
@@ -237,7 +238,7 @@ describe('listInternalExamCodes', () => {
 
     it('filters by status', async () => {
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain(makeRows()))
+      mockAdminFrom.mockReturnValue(buildChain(makeRows()))
 
       const result = await listInternalExamCodes({ status: 'voided' })
 
@@ -286,7 +287,7 @@ describe('listInternalExamCodes', () => {
         },
       ]
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain(rows))
+      mockAdminFrom.mockReturnValue(buildChain(rows))
 
       const result = await listInternalExamCodes({ status: 'finished' })
 
@@ -333,7 +334,7 @@ describe('listInternalExamCodes', () => {
         },
       ]
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain(rows))
+      mockAdminFrom.mockReturnValue(buildChain(rows))
 
       const result = await listInternalExamCodes({ status: 'consumed' })
 
@@ -343,7 +344,7 @@ describe('listInternalExamCodes', () => {
 
     it('filters by studentId', async () => {
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain(makeRows()))
+      mockAdminFrom.mockReturnValue(buildChain(makeRows()))
 
       const result = await listInternalExamCodes({ studentId: 'stu-1' })
 
@@ -353,7 +354,7 @@ describe('listInternalExamCodes', () => {
 
     it('filters by subjectId', async () => {
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain(makeRows()))
+      mockAdminFrom.mockReturnValue(buildChain(makeRows()))
 
       const result = await listInternalExamCodes({ subjectId: 'sub-2' })
 
@@ -383,7 +384,7 @@ describe('listInternalExamCodes', () => {
         users: null,
         quiz_sessions: null,
       }))
-      mockFrom.mockReturnValue(buildChain(rows))
+      mockAdminFrom.mockReturnValue(buildChain(rows))
 
       const result = await listInternalExamCodes({ limit: 2 })
 
@@ -393,7 +394,7 @@ describe('listInternalExamCodes', () => {
 
     it('returns null nextCursor when no more rows remain', async () => {
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain([]))
+      mockAdminFrom.mockReturnValue(buildChain([]))
 
       const result = await listInternalExamCodes()
 
@@ -405,7 +406,7 @@ describe('listInternalExamCodes', () => {
   describe('error propagation', () => {
     it('throws when the codes query returns an error', async () => {
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain(null, { message: 'codes DB error' }))
+      mockAdminFrom.mockReturnValue(buildChain(null, { message: 'codes DB error' }))
 
       await expect(listInternalExamCodes()).rejects.toThrow('codes DB error')
     })
@@ -438,7 +439,7 @@ describe('listInternalExamAttempts', () => {
         users: { full_name: 'Alice', email: 'alice@example.com' },
         internal_exam_codes: null,
       }
-      mockFrom.mockReturnValue(buildChain([row]))
+      mockAdminFrom.mockReturnValue(buildChain([row]))
 
       const result = await listInternalExamAttempts()
 
@@ -474,7 +475,7 @@ describe('listInternalExamAttempts', () => {
         users: null,
         internal_exam_codes: [{ void_reason: 'cheating detected' }],
       }
-      mockFrom.mockReturnValue(buildChain([row]))
+      mockAdminFrom.mockReturnValue(buildChain([row]))
 
       const result = await listInternalExamAttempts()
 
@@ -497,7 +498,7 @@ describe('listInternalExamAttempts', () => {
         users: null,
         internal_exam_codes: null,
       }
-      mockFrom.mockReturnValue(buildChain([row]))
+      mockAdminFrom.mockReturnValue(buildChain([row]))
 
       const result = await listInternalExamAttempts()
 
@@ -541,7 +542,7 @@ describe('listInternalExamAttempts', () => {
 
     it('filters by studentId', async () => {
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain(makeRows()))
+      mockAdminFrom.mockReturnValue(buildChain(makeRows()))
 
       const result = await listInternalExamAttempts({ studentId: 'stu-2' })
 
@@ -551,7 +552,7 @@ describe('listInternalExamAttempts', () => {
 
     it('filters by subjectId', async () => {
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain(makeRows()))
+      mockAdminFrom.mockReturnValue(buildChain(makeRows()))
 
       const result = await listInternalExamAttempts({ subjectId: 'sub-1' })
 
@@ -563,7 +564,7 @@ describe('listInternalExamAttempts', () => {
   describe('error propagation', () => {
     it('throws when the attempts query returns an error', async () => {
       mockAdmin()
-      mockFrom.mockReturnValue(buildChain(null, { message: 'attempts DB error' }))
+      mockAdminFrom.mockReturnValue(buildChain(null, { message: 'attempts DB error' }))
 
       await expect(listInternalExamAttempts()).rejects.toThrow('attempts DB error')
     })

--- a/apps/web/app/app/admin/internal-exams/queries.test.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.test.ts
@@ -245,6 +245,102 @@ describe('listInternalExamCodes', () => {
       expect(result.rows[0]!.id).toBe('code-voided')
     })
 
+    it('returns only consumed-with-ended-session rows for status=finished', async () => {
+      // 'finished' = code is consumed AND the linked quiz_sessions row has
+      // ended_at set. 'consumed' = consumed but session still in flight.
+      // The split happens in the TS post-step (queries.ts ~L156-159).
+      const rows = [
+        {
+          id: 'code-in-flight',
+          code: 'IF',
+          subject_id: 'sub-1',
+          student_id: 'stu-1',
+          issued_by: 'a',
+          issued_at: PAST,
+          expires_at: FUTURE,
+          consumed_at: PAST,
+          consumed_session_id: 'sess-in-flight',
+          voided_at: null,
+          voided_by: null,
+          void_reason: null,
+          easa_subjects: null,
+          users: null,
+          quiz_sessions: { ended_at: null },
+        },
+        {
+          id: 'code-finished',
+          code: 'FN',
+          subject_id: 'sub-1',
+          student_id: 'stu-1',
+          issued_by: 'a',
+          issued_at: PAST,
+          expires_at: FUTURE,
+          consumed_at: PAST,
+          consumed_session_id: 'sess-done',
+          voided_at: null,
+          voided_by: null,
+          void_reason: null,
+          easa_subjects: null,
+          users: null,
+          quiz_sessions: { ended_at: PAST },
+        },
+      ]
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain(rows))
+
+      const result = await listInternalExamCodes({ status: 'finished' })
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!.id).toBe('code-finished')
+      expect(result.rows[0]!.sessionEndedAt).toBe(PAST)
+    })
+
+    it('returns only consumed-without-ended-session rows for status=consumed', async () => {
+      const rows = [
+        {
+          id: 'code-in-flight',
+          code: 'IF',
+          subject_id: 'sub-1',
+          student_id: 'stu-1',
+          issued_by: 'a',
+          issued_at: PAST,
+          expires_at: FUTURE,
+          consumed_at: PAST,
+          consumed_session_id: 'sess-in-flight',
+          voided_at: null,
+          voided_by: null,
+          void_reason: null,
+          easa_subjects: null,
+          users: null,
+          quiz_sessions: { ended_at: null },
+        },
+        {
+          id: 'code-finished',
+          code: 'FN',
+          subject_id: 'sub-1',
+          student_id: 'stu-1',
+          issued_by: 'a',
+          issued_at: PAST,
+          expires_at: FUTURE,
+          consumed_at: PAST,
+          consumed_session_id: 'sess-done',
+          voided_at: null,
+          voided_by: null,
+          void_reason: null,
+          easa_subjects: null,
+          users: null,
+          quiz_sessions: { ended_at: PAST },
+        },
+      ]
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain(rows))
+
+      const result = await listInternalExamCodes({ status: 'consumed' })
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!.id).toBe('code-in-flight')
+    })
+
     it('filters by studentId', async () => {
       mockAdmin()
       mockFrom.mockReturnValue(buildChain(makeRows()))

--- a/apps/web/app/app/admin/internal-exams/queries.test.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.test.ts
@@ -1,0 +1,483 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const mockRequireAdmin = vi.hoisted(() => vi.fn())
+const mockFrom = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/auth/require-admin', () => ({ requireAdmin: mockRequireAdmin }))
+
+// ---- Subject under test ---------------------------------------------------
+
+import { listInternalExamAttempts, listInternalExamCodes } from './queries'
+
+// ---- Helpers ---------------------------------------------------------------
+
+const ORG_ID = 'org-001'
+const NOW = new Date('2026-04-28T12:00:00.000Z')
+const FUTURE = new Date('2026-04-29T12:00:00.000Z').toISOString()
+const PAST = new Date('2026-04-27T12:00:00.000Z').toISOString()
+
+function mockAdmin() {
+  mockRequireAdmin.mockResolvedValue({
+    supabase: { from: mockFrom },
+    organizationId: ORG_ID,
+    userId: 'admin-001',
+  })
+}
+
+/**
+ * Builds a chainable Supabase mock. Every chain method returns the same builder.
+ * The builder is thenable — awaiting it resolves to { data, error }.
+ */
+function buildChain(data: unknown, error: { message: string } | null = null) {
+  const resolved = { data, error }
+  const builder: Record<string, unknown> = {}
+  for (const fn of ['select', 'eq', 'is', 'not', 'order', 'limit']) {
+    builder[fn] = vi.fn().mockReturnValue(builder)
+  }
+  // biome-ignore lint/suspicious/noThenProperty: supabase chain must be thenable to mock awaiting the query builder
+  builder.then = (cb: (v: typeof resolved) => unknown) => Promise.resolve(resolved).then(cb)
+  return builder
+}
+
+// ---- Tests ----------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+
+describe('listInternalExamCodes', () => {
+  describe('happy path', () => {
+    it('returns mapped rows with derived status="active" for unconsumed un-voided unexpired codes', async () => {
+      mockAdmin()
+      const row = {
+        id: 'code-1',
+        code: 'ABC23456',
+        subject_id: 'sub-1',
+        student_id: 'stu-1',
+        issued_by: 'admin-1',
+        issued_at: PAST,
+        expires_at: FUTURE,
+        consumed_at: null,
+        consumed_session_id: null,
+        voided_at: null,
+        voided_by: null,
+        void_reason: null,
+        easa_subjects: { name: 'Meteorology' },
+        users: { full_name: 'Alice', email: 'alice@example.com' },
+        quiz_sessions: null,
+      }
+      mockFrom.mockReturnValue(buildChain([row]))
+
+      const result = await listInternalExamCodes()
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!).toMatchObject({
+        id: 'code-1',
+        code: 'ABC23456',
+        subjectId: 'sub-1',
+        subjectName: 'Meteorology',
+        studentId: 'stu-1',
+        studentName: 'Alice',
+        studentEmail: 'alice@example.com',
+        status: 'active',
+      })
+    })
+
+    it('derives status="voided" when voided_at is set', async () => {
+      mockAdmin()
+      const row = {
+        id: 'code-1',
+        code: 'CODE0001',
+        subject_id: 'sub-1',
+        student_id: 'stu-1',
+        issued_by: 'a',
+        issued_at: PAST,
+        expires_at: FUTURE,
+        consumed_at: null,
+        consumed_session_id: null,
+        voided_at: PAST,
+        voided_by: 'admin-1',
+        void_reason: 'mistake',
+        easa_subjects: null,
+        users: null,
+        quiz_sessions: null,
+      }
+      mockFrom.mockReturnValue(buildChain([row]))
+
+      const result = await listInternalExamCodes()
+
+      expect(result.rows[0]!.status).toBe('voided')
+    })
+
+    it('derives status="consumed" when consumed_at is set', async () => {
+      mockAdmin()
+      const row = {
+        id: 'code-1',
+        code: 'CODE0002',
+        subject_id: 'sub-1',
+        student_id: 'stu-1',
+        issued_by: 'a',
+        issued_at: PAST,
+        expires_at: FUTURE,
+        consumed_at: PAST,
+        consumed_session_id: 'sess-1',
+        voided_at: null,
+        voided_by: null,
+        void_reason: null,
+        easa_subjects: null,
+        users: null,
+        quiz_sessions: { ended_at: PAST },
+      }
+      mockFrom.mockReturnValue(buildChain([row]))
+
+      const result = await listInternalExamCodes()
+
+      expect(result.rows[0]!.status).toBe('consumed')
+      expect(result.rows[0]!.sessionEndedAt).toBe(PAST)
+    })
+
+    it('derives status="expired" when expires_at is in the past and not consumed', async () => {
+      mockAdmin()
+      const row = {
+        id: 'code-1',
+        code: 'CODE0003',
+        subject_id: 'sub-1',
+        student_id: 'stu-1',
+        issued_by: 'a',
+        issued_at: PAST,
+        expires_at: PAST,
+        consumed_at: null,
+        consumed_session_id: null,
+        voided_at: null,
+        voided_by: null,
+        void_reason: null,
+        easa_subjects: null,
+        users: null,
+        quiz_sessions: null,
+      }
+      mockFrom.mockReturnValue(buildChain([row]))
+
+      const result = await listInternalExamCodes()
+
+      expect(result.rows[0]!.status).toBe('expired')
+    })
+
+    it('falls back to empty strings when join data is missing', async () => {
+      mockAdmin()
+      const row = {
+        id: 'code-1',
+        code: 'CODE0004',
+        subject_id: 'sub-1',
+        student_id: 'stu-1',
+        issued_by: 'a',
+        issued_at: PAST,
+        expires_at: FUTURE,
+        consumed_at: null,
+        consumed_session_id: null,
+        voided_at: null,
+        voided_by: null,
+        void_reason: null,
+        easa_subjects: null,
+        users: null,
+        quiz_sessions: null,
+      }
+      mockFrom.mockReturnValue(buildChain([row]))
+
+      const result = await listInternalExamCodes()
+
+      expect(result.rows[0]!.subjectName).toBe('')
+      expect(result.rows[0]!.studentName).toBe('')
+      expect(result.rows[0]!.studentEmail).toBe('')
+    })
+  })
+
+  describe('filters', () => {
+    function makeRows() {
+      return [
+        {
+          id: 'code-active',
+          code: 'A',
+          subject_id: 'sub-1',
+          student_id: 'stu-1',
+          issued_by: 'a',
+          issued_at: PAST,
+          expires_at: FUTURE,
+          consumed_at: null,
+          consumed_session_id: null,
+          voided_at: null,
+          voided_by: null,
+          void_reason: null,
+          easa_subjects: null,
+          users: null,
+          quiz_sessions: null,
+        },
+        {
+          id: 'code-voided',
+          code: 'B',
+          subject_id: 'sub-2',
+          student_id: 'stu-2',
+          issued_by: 'a',
+          issued_at: PAST,
+          expires_at: FUTURE,
+          consumed_at: null,
+          consumed_session_id: null,
+          voided_at: PAST,
+          voided_by: 'a',
+          void_reason: 'r',
+          easa_subjects: null,
+          users: null,
+          quiz_sessions: null,
+        },
+      ]
+    }
+
+    it('filters by status', async () => {
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain(makeRows()))
+
+      const result = await listInternalExamCodes({ status: 'voided' })
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!.id).toBe('code-voided')
+    })
+
+    it('filters by studentId', async () => {
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain(makeRows()))
+
+      const result = await listInternalExamCodes({ studentId: 'stu-1' })
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!.studentId).toBe('stu-1')
+    })
+
+    it('filters by subjectId', async () => {
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain(makeRows()))
+
+      const result = await listInternalExamCodes({ subjectId: 'sub-2' })
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!.subjectId).toBe('sub-2')
+    })
+  })
+
+  describe('pagination', () => {
+    it('returns nextCursor when there are more rows than the limit', async () => {
+      mockAdmin()
+      // 3 rows when limit is 2 → fetched limit+1 (3), so hasMore=true, return 2 rows
+      const rows = [1, 2, 3].map((n) => ({
+        id: `code-${n}`,
+        code: `C${n}`,
+        subject_id: 'sub-1',
+        student_id: 'stu-1',
+        issued_by: 'a',
+        issued_at: `2026-04-2${n}T00:00:00.000Z`,
+        expires_at: FUTURE,
+        consumed_at: null,
+        consumed_session_id: null,
+        voided_at: null,
+        voided_by: null,
+        void_reason: null,
+        easa_subjects: null,
+        users: null,
+        quiz_sessions: null,
+      }))
+      mockFrom.mockReturnValue(buildChain(rows))
+
+      const result = await listInternalExamCodes({ limit: 2 })
+
+      expect(result.rows).toHaveLength(2)
+      expect(result.nextCursor).toBe('2026-04-22T00:00:00.000Z')
+    })
+
+    it('returns null nextCursor when no more rows remain', async () => {
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain([]))
+
+      const result = await listInternalExamCodes()
+
+      expect(result.rows).toHaveLength(0)
+      expect(result.nextCursor).toBeNull()
+    })
+  })
+
+  describe('error propagation', () => {
+    it('throws when the codes query returns an error', async () => {
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain(null, { message: 'codes DB error' }))
+
+      await expect(listInternalExamCodes()).rejects.toThrow('codes DB error')
+    })
+  })
+
+  describe('auth guard', () => {
+    it('propagates errors from requireAdmin', async () => {
+      mockRequireAdmin.mockRejectedValue(new Error('Forbidden'))
+
+      await expect(listInternalExamCodes()).rejects.toThrow('Forbidden')
+    })
+  })
+})
+
+describe('listInternalExamAttempts', () => {
+  describe('happy path', () => {
+    it('returns mapped rows for completed internal_exam sessions', async () => {
+      mockAdmin()
+      const row = {
+        id: 'sess-1',
+        student_id: 'stu-1',
+        subject_id: 'sub-1',
+        started_at: PAST,
+        ended_at: PAST,
+        total_questions: 20,
+        correct_count: 15,
+        score_percentage: 75,
+        passed: true,
+        easa_subjects: { name: 'Meteorology' },
+        users: { full_name: 'Alice', email: 'alice@example.com' },
+        internal_exam_codes: null,
+      }
+      mockFrom.mockReturnValue(buildChain([row]))
+
+      const result = await listInternalExamAttempts()
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!).toMatchObject({
+        sessionId: 'sess-1',
+        studentId: 'stu-1',
+        studentName: 'Alice',
+        studentEmail: 'alice@example.com',
+        subjectId: 'sub-1',
+        subjectName: 'Meteorology',
+        totalQuestions: 20,
+        correctCount: 15,
+        scorePercentage: 75,
+        passed: true,
+        voidReason: null,
+      })
+    })
+
+    it('surfaces voidReason from the linked internal_exam_code', async () => {
+      mockAdmin()
+      const row = {
+        id: 'sess-1',
+        student_id: 'stu-1',
+        subject_id: 'sub-1',
+        started_at: PAST,
+        ended_at: PAST,
+        total_questions: 20,
+        correct_count: 0,
+        score_percentage: 0,
+        passed: false,
+        easa_subjects: null,
+        users: null,
+        internal_exam_codes: [{ void_reason: 'cheating detected' }],
+      }
+      mockFrom.mockReturnValue(buildChain([row]))
+
+      const result = await listInternalExamAttempts()
+
+      expect(result.rows[0]!.voidReason).toBe('cheating detected')
+    })
+
+    it('falls back to empty string when subject_id is null', async () => {
+      mockAdmin()
+      const row = {
+        id: 'sess-1',
+        student_id: 'stu-1',
+        subject_id: null,
+        started_at: PAST,
+        ended_at: PAST,
+        total_questions: 20,
+        correct_count: 0,
+        score_percentage: 0,
+        passed: false,
+        easa_subjects: null,
+        users: null,
+        internal_exam_codes: null,
+      }
+      mockFrom.mockReturnValue(buildChain([row]))
+
+      const result = await listInternalExamAttempts()
+
+      expect(result.rows[0]!.subjectId).toBe('')
+    })
+  })
+
+  describe('filters', () => {
+    function makeRows() {
+      return [
+        {
+          id: 'sess-1',
+          student_id: 'stu-1',
+          subject_id: 'sub-1',
+          started_at: PAST,
+          ended_at: PAST,
+          total_questions: 20,
+          correct_count: 15,
+          score_percentage: 75,
+          passed: true,
+          easa_subjects: null,
+          users: null,
+          internal_exam_codes: null,
+        },
+        {
+          id: 'sess-2',
+          student_id: 'stu-2',
+          subject_id: 'sub-2',
+          started_at: PAST,
+          ended_at: PAST,
+          total_questions: 20,
+          correct_count: 5,
+          score_percentage: 25,
+          passed: false,
+          easa_subjects: null,
+          users: null,
+          internal_exam_codes: null,
+        },
+      ]
+    }
+
+    it('filters by studentId', async () => {
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain(makeRows()))
+
+      const result = await listInternalExamAttempts({ studentId: 'stu-2' })
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!.studentId).toBe('stu-2')
+    })
+
+    it('filters by subjectId', async () => {
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain(makeRows()))
+
+      const result = await listInternalExamAttempts({ subjectId: 'sub-1' })
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]!.subjectId).toBe('sub-1')
+    })
+  })
+
+  describe('error propagation', () => {
+    it('throws when the attempts query returns an error', async () => {
+      mockAdmin()
+      mockFrom.mockReturnValue(buildChain(null, { message: 'attempts DB error' }))
+
+      await expect(listInternalExamAttempts()).rejects.toThrow('attempts DB error')
+    })
+  })
+
+  describe('auth guard', () => {
+    it('propagates errors from requireAdmin', async () => {
+      mockRequireAdmin.mockRejectedValue(new Error('Forbidden'))
+
+      await expect(listInternalExamAttempts()).rejects.toThrow('Forbidden')
+    })
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/queries.test.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.test.ts
@@ -33,7 +33,7 @@ function mockAdmin() {
 function buildChain(data: unknown, error: { message: string } | null = null) {
   const resolved = { data, error }
   const builder: Record<string, unknown> = {}
-  for (const fn of ['select', 'eq', 'is', 'not', 'order', 'limit']) {
+  for (const fn of ['select', 'eq', 'is', 'not', 'order', 'limit', 'lte', 'gt']) {
     builder[fn] = vi.fn().mockReturnValue(builder)
   }
   // biome-ignore lint/suspicious/noThenProperty: supabase chain must be thenable to mock awaiting the query builder

--- a/apps/web/app/app/admin/internal-exams/queries.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.ts
@@ -1,0 +1,192 @@
+import { requireAdmin } from '@/lib/auth/require-admin'
+import type {
+  InternalExamAttemptRow,
+  InternalExamCodeRow,
+  InternalExamCodeStatus,
+  ListAttemptsFilters,
+  ListCodesFilters,
+} from './types'
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+
+function clampLimit(limit?: number): number {
+  if (typeof limit !== 'number' || limit <= 0) return DEFAULT_LIMIT
+  return Math.min(limit, MAX_LIMIT)
+}
+
+function deriveStatus(row: {
+  consumed_at: string | null
+  voided_at: string | null
+  expires_at: string
+}): InternalExamCodeStatus {
+  if (row.voided_at) return 'voided'
+  if (row.consumed_at) return 'consumed'
+  if (new Date(row.expires_at).getTime() <= Date.now()) return 'expired'
+  return 'active'
+}
+
+type CodeRowRaw = {
+  id: string
+  code: string
+  subject_id: string
+  student_id: string
+  issued_by: string
+  issued_at: string
+  expires_at: string
+  consumed_at: string | null
+  consumed_session_id: string | null
+  voided_at: string | null
+  voided_by: string | null
+  void_reason: string | null
+  easa_subjects: { name: string | null } | null
+  users: { full_name: string | null; email: string | null } | null
+  quiz_sessions: { ended_at: string | null } | null
+}
+
+type AttemptRowRaw = {
+  id: string
+  student_id: string
+  subject_id: string | null
+  started_at: string
+  ended_at: string | null
+  total_questions: number | null
+  correct_count: number | null
+  score_percentage: number | null
+  passed: boolean | null
+  easa_subjects: { name: string | null } | null
+  users: { full_name: string | null; email: string | null } | null
+  internal_exam_codes: { void_reason: string | null }[] | null
+}
+
+type ChainBuilder = {
+  select: (cols: string) => ChainBuilder
+  eq: (col: string, val: unknown) => ChainBuilder
+  is: (col: string, val: null) => ChainBuilder
+  not: (col: string, op: string, val: unknown) => ChainBuilder
+  order: (col: string, opts: { ascending: boolean }) => ChainBuilder
+  limit: (n: number) => ChainBuilder
+}
+
+type AnyClient = {
+  from: (t: string) => ChainBuilder
+}
+
+export async function listInternalExamCodes(
+  filters: ListCodesFilters = {},
+): Promise<{ rows: InternalExamCodeRow[]; nextCursor: string | null }> {
+  const { supabase, organizationId } = await requireAdmin()
+  const limit = clampLimit(filters.limit)
+  const client = supabase as unknown as AnyClient
+
+  const builder = client
+    .from('internal_exam_codes')
+    .select(
+      `id, code, subject_id, student_id, issued_by, issued_at, expires_at,
+       consumed_at, consumed_session_id, voided_at, voided_by, void_reason,
+       easa_subjects(name),
+       users:student_id(full_name, email),
+       quiz_sessions:consumed_session_id(ended_at)`,
+    )
+    .eq('organization_id', organizationId)
+    .is('deleted_at', null)
+    .order('issued_at', { ascending: false })
+    .limit(limit + 1)
+
+  const { data, error } = (await (builder as unknown as PromiseLike<{
+    data: unknown
+    error: { message: string } | null
+  }>)) ?? { data: null, error: null }
+  if (error) throw new Error(`[listInternalExamCodes] ${error.message}`)
+  const raw = Array.isArray(data) ? (data as CodeRowRaw[]) : []
+
+  let mapped: InternalExamCodeRow[] = raw.map((r) => ({
+    id: r.id,
+    code: r.code,
+    subjectId: r.subject_id,
+    subjectName: r.easa_subjects?.name ?? '',
+    studentId: r.student_id,
+    studentName: r.users?.full_name ?? '',
+    studentEmail: r.users?.email ?? '',
+    issuedBy: r.issued_by,
+    issuedAt: r.issued_at,
+    expiresAt: r.expires_at,
+    consumedAt: r.consumed_at,
+    consumedSessionId: r.consumed_session_id,
+    voidedAt: r.voided_at,
+    voidedBy: r.voided_by,
+    voidReason: r.void_reason,
+    status: deriveStatus({
+      consumed_at: r.consumed_at,
+      voided_at: r.voided_at,
+      expires_at: r.expires_at,
+    }),
+    sessionEndedAt: r.quiz_sessions?.ended_at ?? null,
+  }))
+
+  if (filters.status) mapped = mapped.filter((r) => r.status === filters.status)
+  if (filters.studentId) mapped = mapped.filter((r) => r.studentId === filters.studentId)
+  if (filters.subjectId) mapped = mapped.filter((r) => r.subjectId === filters.subjectId)
+
+  const hasMore = mapped.length > limit
+  const rows = hasMore ? mapped.slice(0, limit) : mapped
+  const nextCursor = hasMore ? (rows[rows.length - 1]?.issuedAt ?? null) : null
+
+  return { rows, nextCursor }
+}
+
+export async function listInternalExamAttempts(
+  filters: ListAttemptsFilters = {},
+): Promise<{ rows: InternalExamAttemptRow[]; nextCursor: string | null }> {
+  const { supabase, organizationId } = await requireAdmin()
+  const limit = clampLimit(filters.limit)
+  const client = supabase as unknown as AnyClient
+
+  const builder = client
+    .from('quiz_sessions')
+    .select(
+      `id, student_id, subject_id, started_at, ended_at, total_questions,
+       correct_count, score_percentage, passed,
+       easa_subjects(name),
+       users:student_id(full_name, email),
+       internal_exam_codes:consumed_session_id(void_reason)`,
+    )
+    .eq('organization_id', organizationId)
+    .eq('mode', 'internal_exam')
+    .not('ended_at', 'is', null)
+    .is('deleted_at', null)
+    .order('started_at', { ascending: false })
+    .limit(limit + 1)
+
+  const { data, error } = (await (builder as unknown as PromiseLike<{
+    data: unknown
+    error: { message: string } | null
+  }>)) ?? { data: null, error: null }
+  if (error) throw new Error(`[listInternalExamAttempts] ${error.message}`)
+  const raw = Array.isArray(data) ? (data as AttemptRowRaw[]) : []
+
+  let mapped: InternalExamAttemptRow[] = raw.map((r) => ({
+    sessionId: r.id,
+    studentId: r.student_id,
+    studentName: r.users?.full_name ?? '',
+    studentEmail: r.users?.email ?? '',
+    subjectId: r.subject_id ?? '',
+    subjectName: r.easa_subjects?.name ?? '',
+    startedAt: r.started_at,
+    endedAt: r.ended_at,
+    totalQuestions: r.total_questions,
+    correctCount: r.correct_count,
+    scorePercentage: r.score_percentage,
+    passed: r.passed,
+    voidReason: r.internal_exam_codes?.[0]?.void_reason ?? null,
+  }))
+
+  if (filters.studentId) mapped = mapped.filter((r) => r.studentId === filters.studentId)
+  if (filters.subjectId) mapped = mapped.filter((r) => r.subjectId === filters.subjectId)
+
+  const hasMore = mapped.length > limit
+  const rows = hasMore ? mapped.slice(0, limit) : mapped
+  const nextCursor = hasMore ? (rows[rows.length - 1]?.startedAt ?? null) : null
+
+  return { rows, nextCursor }
+}

--- a/apps/web/app/app/admin/internal-exams/queries.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.ts
@@ -66,6 +66,8 @@ type ChainBuilder = {
   eq: (col: string, val: unknown) => ChainBuilder
   is: (col: string, val: null) => ChainBuilder
   not: (col: string, op: string, val: unknown) => ChainBuilder
+  lte: (col: string, val: unknown) => ChainBuilder
+  gt: (col: string, val: unknown) => ChainBuilder
   order: (col: string, opts: { ascending: boolean }) => ChainBuilder
   limit: (n: number) => ChainBuilder
 }
@@ -81,7 +83,7 @@ export async function listInternalExamCodes(
   const limit = clampLimit(filters.limit)
   const client = supabase as unknown as AnyClient
 
-  const builder = client
+  let builder = client
     .from('internal_exam_codes')
     .select(
       `id, code, subject_id, student_id, issued_by, issued_at, expires_at,
@@ -92,8 +94,30 @@ export async function listInternalExamCodes(
     )
     .eq('organization_id', organizationId)
     .is('deleted_at', null)
-    .order('issued_at', { ascending: false })
-    .limit(limit + 1)
+
+  if (filters.studentId) builder = builder.eq('student_id', filters.studentId)
+  if (filters.subjectId) builder = builder.eq('subject_id', filters.subjectId)
+
+  const nowIso = new Date().toISOString()
+  switch (filters.status) {
+    case 'voided':
+      builder = builder.not('voided_at', 'is', null)
+      break
+    case 'expired':
+      builder = builder.is('voided_at', null).is('consumed_at', null).lte('expires_at', nowIso)
+      break
+    case 'consumed':
+    case 'finished':
+      builder = builder.not('consumed_at', 'is', null).is('voided_at', null)
+      break
+    case 'active':
+      builder = builder.is('consumed_at', null).is('voided_at', null).gt('expires_at', nowIso)
+      break
+    default:
+      break
+  }
+
+  builder = builder.order('issued_at', { ascending: false }).limit(limit + 1)
 
   const { data, error } = (await (builder as unknown as PromiseLike<{
     data: unknown
@@ -126,7 +150,16 @@ export async function listInternalExamCodes(
     sessionEndedAt: r.quiz_sessions?.ended_at ?? null,
   }))
 
-  if (filters.status) mapped = mapped.filter((r) => r.status === filters.status)
+  // SQL above is the primary filter. TS guards below preserve correctness when
+  // a caller passes status-derived filters and act as a safety net for the
+  // 'consumed' vs 'finished' split (depends on linked quiz_sessions.ended_at).
+  if (filters.status === 'finished') {
+    mapped = mapped.filter((r) => r.sessionEndedAt !== null)
+  } else if (filters.status === 'consumed') {
+    mapped = mapped.filter((r) => r.sessionEndedAt === null && r.status === 'consumed')
+  } else if (filters.status) {
+    mapped = mapped.filter((r) => r.status === filters.status)
+  }
   if (filters.studentId) mapped = mapped.filter((r) => r.studentId === filters.studentId)
   if (filters.subjectId) mapped = mapped.filter((r) => r.subjectId === filters.subjectId)
 
@@ -144,7 +177,7 @@ export async function listInternalExamAttempts(
   const limit = clampLimit(filters.limit)
   const client = supabase as unknown as AnyClient
 
-  const builder = client
+  let builder = client
     .from('quiz_sessions')
     .select(
       `id, student_id, subject_id, started_at, ended_at, total_questions,
@@ -157,8 +190,11 @@ export async function listInternalExamAttempts(
     .eq('mode', 'internal_exam')
     .not('ended_at', 'is', null)
     .is('deleted_at', null)
-    .order('started_at', { ascending: false })
-    .limit(limit + 1)
+
+  if (filters.studentId) builder = builder.eq('student_id', filters.studentId)
+  if (filters.subjectId) builder = builder.eq('subject_id', filters.subjectId)
+
+  builder = builder.order('started_at', { ascending: false }).limit(limit + 1)
 
   const { data, error } = (await (builder as unknown as PromiseLike<{
     data: unknown
@@ -183,6 +219,7 @@ export async function listInternalExamAttempts(
     voidReason: r.internal_exam_codes?.[0]?.void_reason ?? null,
   }))
 
+  // SQL filters above are primary; TS guards preserve safety on already-paginated rows.
   if (filters.studentId) mapped = mapped.filter((r) => r.studentId === filters.studentId)
   if (filters.subjectId) mapped = mapped.filter((r) => r.subjectId === filters.subjectId)
 

--- a/apps/web/app/app/admin/internal-exams/queries.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.ts
@@ -1,3 +1,4 @@
+import { adminClient } from '@repo/db/admin'
 import { requireAdmin } from '@/lib/auth/require-admin'
 import type {
   ExamSubjectOption,
@@ -79,9 +80,11 @@ type AnyClient = {
 export async function listInternalExamCodes(
   filters: ListCodesFilters = {},
 ): Promise<{ rows: InternalExamCodeRow[]; nextCursor: string | null }> {
-  const { supabase, organizationId } = await requireAdmin()
+  const { organizationId } = await requireAdmin()
   const limit = clampLimit(filters.limit)
-  const client = supabase as unknown as AnyClient
+  // adminClient: cross-row reads on `users` are unreliable under tenant_isolation RLS
+  // (self-referential subquery), and PostgREST applies RLS to embedded resources too.
+  const client = adminClient as unknown as AnyClient
 
   let builder = client
     .from('internal_exam_codes')
@@ -89,8 +92,8 @@ export async function listInternalExamCodes(
       `id, code, subject_id, student_id, issued_by, issued_at, expires_at,
        consumed_at, consumed_session_id, voided_at, voided_by, void_reason,
        easa_subjects(name),
-       users:student_id(full_name, email),
-       quiz_sessions:consumed_session_id(ended_at)`,
+       users!student_id(full_name, email),
+       quiz_sessions!consumed_session_id(ended_at)`,
     )
     .eq('organization_id', organizationId)
     .is('deleted_at', null)
@@ -173,9 +176,11 @@ export async function listInternalExamCodes(
 export async function listInternalExamAttempts(
   filters: ListAttemptsFilters = {},
 ): Promise<{ rows: InternalExamAttemptRow[]; nextCursor: string | null }> {
-  const { supabase, organizationId } = await requireAdmin()
+  const { organizationId } = await requireAdmin()
   const limit = clampLimit(filters.limit)
-  const client = supabase as unknown as AnyClient
+  // adminClient: same RLS-recursion reason as listInternalExamCodes — embed of `users`
+  // returns null under the user-scoped client.
+  const client = adminClient as unknown as AnyClient
 
   let builder = client
     .from('quiz_sessions')
@@ -183,8 +188,8 @@ export async function listInternalExamAttempts(
       `id, student_id, subject_id, started_at, ended_at, total_questions,
        correct_count, score_percentage, passed,
        easa_subjects(name),
-       users:student_id(full_name, email),
-       internal_exam_codes:consumed_session_id(void_reason)`,
+       users!student_id(full_name, email),
+       internal_exam_codes!consumed_session_id(void_reason)`,
     )
     .eq('organization_id', organizationId)
     .eq('mode', 'internal_exam')
@@ -233,9 +238,11 @@ export async function listInternalExamAttempts(
 type StudentRowRaw = { id: string; full_name: string | null; email: string | null }
 
 export async function listOrgStudents(): Promise<OrgStudentOption[]> {
-  const { supabase, organizationId } = await requireAdmin()
+  const { organizationId } = await requireAdmin()
 
-  const { data, error } = await supabase
+  // Cross-row reads on `users` are unreliable under tenant_isolation RLS
+  // (self-referential subquery). Mirrors apps/web/app/app/admin/students/queries.ts.
+  const { data, error } = await adminClient
     .from('users')
     .select('id, full_name, email')
     .eq('organization_id', organizationId)

--- a/apps/web/app/app/admin/internal-exams/queries.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.ts
@@ -1,10 +1,12 @@
 import { requireAdmin } from '@/lib/auth/require-admin'
 import type {
+  ExamSubjectOption,
   InternalExamAttemptRow,
   InternalExamCodeRow,
   InternalExamCodeStatus,
   ListAttemptsFilters,
   ListCodesFilters,
+  OrgStudentOption,
 } from './types'
 
 const DEFAULT_LIMIT = 50
@@ -189,4 +191,56 @@ export async function listInternalExamAttempts(
   const nextCursor = hasMore ? (rows[rows.length - 1]?.startedAt ?? null) : null
 
   return { rows, nextCursor }
+}
+
+type StudentRowRaw = { id: string; full_name: string | null; email: string | null }
+
+export async function listOrgStudents(): Promise<OrgStudentOption[]> {
+  const { supabase, organizationId } = await requireAdmin()
+
+  const { data, error } = await supabase
+    .from('users')
+    .select('id, full_name, email')
+    .eq('organization_id', organizationId)
+    .eq('role', 'student')
+    .is('deleted_at', null)
+    .order('full_name', { ascending: true })
+
+  if (error) {
+    console.error('[listOrgStudents] DB error:', error.message)
+    throw new Error('Failed to load students')
+  }
+
+  const rows = (data ?? []) as StudentRowRaw[]
+  return rows.map((r) => ({
+    id: r.id,
+    fullName: r.full_name ?? '',
+    email: r.email ?? '',
+  }))
+}
+
+type SubjectRowRaw = { id: string; code: string; name: string }
+
+export async function listExamSubjects(): Promise<ExamSubjectOption[]> {
+  const { supabase, organizationId } = await requireAdmin()
+
+  const { data, error } = await supabase
+    .from('exam_configs')
+    .select('subject_id, easa_subjects:subject_id(id, code, name)')
+    .eq('organization_id', organizationId)
+    .eq('enabled', true)
+    .is('deleted_at', null)
+
+  if (error) {
+    console.error('[listExamSubjects] DB error:', error.message)
+    throw new Error('Failed to load subjects')
+  }
+
+  type Joined = { easa_subjects: SubjectRowRaw | null }
+  const rows = (data ?? []) as Joined[]
+  return rows
+    .map((r) => r.easa_subjects)
+    .filter((s): s is SubjectRowRaw => s !== null)
+    .sort((a, b) => a.code.localeCompare(b.code))
+    .map((s) => ({ id: s.id, code: s.code, name: s.name }))
 }

--- a/apps/web/app/app/admin/internal-exams/report/_components/admin-internal-exam-report-footer.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/report/_components/admin-internal-exam-report-footer.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string
+    children: React.ReactNode
+    className?: string
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+import { AdminInternalExamReportFooter } from './admin-internal-exam-report-footer'
+
+describe('AdminInternalExamReportFooter', () => {
+  it('renders a link back to internal exams', () => {
+    render(<AdminInternalExamReportFooter />)
+    const link = screen.getByRole('link', { name: /back to internal exams/i })
+    expect(link).toBeInTheDocument()
+  })
+
+  it('points to the internal exams attempts tab URL', () => {
+    render(<AdminInternalExamReportFooter />)
+    const link = screen.getByRole('link', { name: /back to internal exams/i })
+    expect(link).toHaveAttribute('href', '/app/admin/internal-exams?tab=attempts')
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/report/_components/admin-internal-exam-report-footer.tsx
+++ b/apps/web/app/app/admin/internal-exams/report/_components/admin-internal-exam-report-footer.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export function AdminInternalExamReportFooter() {
+  return (
+    <div className="flex justify-center">
+      <Link
+        href="/app/admin/internal-exams?tab=attempts"
+        className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        Back to Internal Exams
+      </Link>
+    </div>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/report/_components/admin-internal-exam-report-header.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/report/_components/admin-internal-exam-report-header.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string
+    children: React.ReactNode
+    className?: string
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+import { AdminInternalExamReportHeader } from './admin-internal-exam-report-header'
+
+describe('AdminInternalExamReportHeader', () => {
+  it('renders the student name as the current breadcrumb segment', () => {
+    render(<AdminInternalExamReportHeader studentName="Alice Aviator" />)
+    expect(screen.getByText('Alice Aviator')).toBeInTheDocument()
+  })
+
+  it('falls back to "Student" when studentName is null', () => {
+    render(<AdminInternalExamReportHeader studentName={null} />)
+    expect(screen.getByText('Student')).toBeInTheDocument()
+  })
+
+  it('renders an Internal Exams breadcrumb link pointing to the attempts tab', () => {
+    render(<AdminInternalExamReportHeader studentName="Alice Aviator" />)
+    const link = screen.getByRole('link', { name: 'Internal Exams' })
+    expect(link).toHaveAttribute('href', '/app/admin/internal-exams?tab=attempts')
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/report/_components/admin-internal-exam-report-header.tsx
+++ b/apps/web/app/app/admin/internal-exams/report/_components/admin-internal-exam-report-header.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+type Props = Readonly<{ studentName: string | null }>
+
+export function AdminInternalExamReportHeader({ studentName }: Props) {
+  return (
+    <nav className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <Link
+        href="/app/admin/internal-exams?tab=attempts"
+        className="transition-colors hover:text-foreground"
+      >
+        Internal Exams
+      </Link>
+      <span>/</span>
+      <span className="text-foreground">{studentName ?? 'Student'}</span>
+    </nav>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/report/page.tsx
+++ b/apps/web/app/app/admin/internal-exams/report/page.tsx
@@ -1,0 +1,50 @@
+import { redirect } from 'next/navigation'
+import { QuestionBreakdown } from '@/app/app/quiz/report/_components/question-breakdown'
+import { ResultSummary } from '@/app/app/quiz/report/_components/result-summary'
+import {
+  getAdminQuizReportQuestions,
+  getAdminQuizReportSummary,
+} from '@/lib/queries/admin-quiz-report'
+import { PAGE_SIZE } from '@/lib/queries/quiz-report'
+import { parsePageParam } from '@/lib/utils/parse-page-param'
+import { AdminInternalExamReportFooter } from './_components/admin-internal-exam-report-footer'
+import { AdminInternalExamReportHeader } from './_components/admin-internal-exam-report-header'
+
+export default async function AdminInternalExamReportPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ session?: string; page?: string }>
+}) {
+  const { session: sessionId, page: pageParam } = await searchParams
+  if (!sessionId) redirect('/app/admin/internal-exams?tab=attempts')
+
+  const summary = await getAdminQuizReportSummary(sessionId)
+  if (!summary) redirect('/app/admin/internal-exams?tab=attempts')
+  // Defense-in-depth: this URL is only for internal_exam sessions.
+  if (summary.mode !== 'internal_exam') {
+    redirect(`/app/admin/dashboard/sessions/${sessionId}`)
+  }
+
+  const page = parsePageParam(pageParam)
+  const questionsResult = await getAdminQuizReportQuestions({ sessionId, page })
+  if (!questionsResult.ok) redirect('/app/admin/internal-exams?tab=attempts')
+
+  const totalPages = Math.max(1, Math.ceil(questionsResult.totalCount / PAGE_SIZE))
+  if (page > totalPages) {
+    redirect(`/app/admin/internal-exams/report?session=${sessionId}&page=${totalPages}`)
+  }
+
+  return (
+    <main className="space-y-6">
+      <AdminInternalExamReportHeader studentName={summary.studentName} />
+      <ResultSummary summary={summary} />
+      <QuestionBreakdown
+        questions={questionsResult.questions}
+        page={page}
+        totalCount={questionsResult.totalCount}
+        pageSize={PAGE_SIZE}
+      />
+      <AdminInternalExamReportFooter />
+    </main>
+  )
+}

--- a/apps/web/app/app/admin/internal-exams/report/page.tsx
+++ b/apps/web/app/app/admin/internal-exams/report/page.tsx
@@ -10,13 +10,17 @@ import { parsePageParam } from '@/lib/utils/parse-page-param'
 import { AdminInternalExamReportFooter } from './_components/admin-internal-exam-report-footer'
 import { AdminInternalExamReportHeader } from './_components/admin-internal-exam-report-header'
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export default async function AdminInternalExamReportPage({
   searchParams,
 }: {
   searchParams: Promise<{ session?: string; page?: string }>
 }) {
   const { session: sessionId, page: pageParam } = await searchParams
-  if (!sessionId) redirect('/app/admin/internal-exams?tab=attempts')
+  if (!sessionId || !UUID_RE.test(sessionId)) {
+    redirect('/app/admin/internal-exams?tab=attempts')
+  }
 
   const summary = await getAdminQuizReportSummary(sessionId)
   if (!summary) redirect('/app/admin/internal-exams?tab=attempts')

--- a/apps/web/app/app/admin/internal-exams/types.ts
+++ b/apps/web/app/app/admin/internal-exams/types.ts
@@ -1,0 +1,52 @@
+export type InternalExamCodeStatus = 'active' | 'consumed' | 'expired' | 'voided'
+
+export type InternalExamCodeRow = {
+  id: string
+  code: string
+  subjectId: string
+  subjectName: string
+  studentId: string
+  studentName: string
+  studentEmail: string
+  issuedBy: string
+  issuedAt: string
+  expiresAt: string
+  consumedAt: string | null
+  consumedSessionId: string | null
+  voidedAt: string | null
+  voidedBy: string | null
+  voidReason: string | null
+  status: InternalExamCodeStatus
+  sessionEndedAt: string | null
+}
+
+export type ListCodesFilters = {
+  status?: InternalExamCodeStatus
+  studentId?: string
+  subjectId?: string
+  limit?: number
+  cursor?: string
+}
+
+export type InternalExamAttemptRow = {
+  sessionId: string
+  studentId: string
+  studentName: string
+  studentEmail: string
+  subjectId: string
+  subjectName: string
+  startedAt: string
+  endedAt: string | null
+  totalQuestions: number | null
+  correctCount: number | null
+  scorePercentage: number | null
+  passed: boolean | null
+  voidReason: string | null
+}
+
+export type ListAttemptsFilters = {
+  studentId?: string
+  subjectId?: string
+  limit?: number
+  cursor?: string
+}

--- a/apps/web/app/app/admin/internal-exams/types.ts
+++ b/apps/web/app/app/admin/internal-exams/types.ts
@@ -50,3 +50,15 @@ export type ListAttemptsFilters = {
   limit?: number
   cursor?: string
 }
+
+export type OrgStudentOption = {
+  id: string
+  fullName: string
+  email: string
+}
+
+export type ExamSubjectOption = {
+  id: string
+  code: string
+  name: string
+}

--- a/apps/web/app/app/admin/internal-exams/types.ts
+++ b/apps/web/app/app/admin/internal-exams/types.ts
@@ -21,7 +21,7 @@ export type InternalExamCodeRow = {
 }
 
 export type ListCodesFilters = {
-  status?: InternalExamCodeStatus
+  status?: InternalExamCodeStatus | 'finished'
   studentId?: string
   subjectId?: string
   limit?: number

--- a/apps/web/app/app/internal-exam/_components/available-tab.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/available-tab.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./code-entry-modal', () => ({
+  CodeEntryModal: ({
+    open,
+    onOpenChange,
+  }: {
+    open: boolean
+    onOpenChange: (o: boolean) => void
+  }) => (
+    <button
+      type="button"
+      data-testid="code-entry-modal"
+      data-open={open ? 'true' : 'false'}
+      onClick={() => onOpenChange(false)}
+    />
+  ),
+}))
+
+import type { AvailableInternalExam } from '../queries'
+import { AvailableTab } from './available-tab'
+
+const ROW: AvailableInternalExam = {
+  id: 'code-1',
+  subjectId: 'subj-1',
+  subjectName: 'Air Law',
+  subjectShort: '010',
+  expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+  issuedAt: new Date().toISOString(),
+}
+
+describe('AvailableTab', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders the empty state when there are no rows', () => {
+    render(<AvailableTab rows={[]} userId="user-1" />)
+    expect(screen.getByTestId('available-empty')).toHaveTextContent(/no internal exams available/i)
+  })
+
+  it('renders the subject short and name in each row', () => {
+    render(<AvailableTab rows={[ROW]} userId="user-1" />)
+    expect(screen.getByText(/010 — Air Law/)).toBeInTheDocument()
+  })
+
+  it('does not display the code value anywhere in the list', () => {
+    const sneaky: AvailableInternalExam & { code?: string } = { ...ROW, code: 'SECRETXX' }
+    render(<AvailableTab rows={[sneaky as AvailableInternalExam]} userId="user-1" />)
+    expect(screen.queryByText('SECRETXX')).toBeNull()
+  })
+
+  it('shows the absolute and relative expiry times', () => {
+    render(<AvailableTab rows={[ROW]} userId="user-1" />)
+    // relative: "in N min" or "in N h"
+    expect(screen.getByText(/in \d+/)).toBeInTheDocument()
+    // absolute: includes "Expires"
+    expect(screen.getByText(/Expires/)).toBeInTheDocument()
+  })
+
+  it('opens the code-entry modal when Start is clicked', async () => {
+    render(<AvailableTab rows={[ROW]} userId="user-1" />)
+    const modal = screen.getByTestId('code-entry-modal')
+    expect(modal.getAttribute('data-open')).toBe('false')
+    await userEvent.click(screen.getByTestId('start-button'))
+    expect(modal.getAttribute('data-open')).toBe('true')
+  })
+})

--- a/apps/web/app/app/internal-exam/_components/available-tab.tsx
+++ b/apps/web/app/app/internal-exam/_components/available-tab.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import type { AvailableInternalExam } from '../queries'
+import { CodeEntryModal } from './code-entry-modal'
+
+type Props = { rows: AvailableInternalExam[]; userId: string }
+
+function formatAbsolute(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+function formatRelative(iso: string, now: Date = new Date()): string {
+  const target = new Date(iso)
+  if (Number.isNaN(target.getTime())) return ''
+  const diffMs = target.getTime() - now.getTime()
+  if (diffMs <= 0) return 'expired'
+  const minutes = Math.round(diffMs / 60_000)
+  if (minutes < 60) return `in ${minutes} min`
+  const hours = Math.round(minutes / 60)
+  if (hours < 48) return `in ${hours} h`
+  const days = Math.round(hours / 24)
+  return `in ${days} d`
+}
+
+export function AvailableTab({ rows, userId }: Readonly<Props>) {
+  const [selected, setSelected] = useState<AvailableInternalExam | null>(null)
+
+  if (rows.length === 0) {
+    return (
+      <div
+        className="rounded-lg border border-dashed border-border bg-muted/30 p-6 text-center text-sm text-muted-foreground"
+        data-testid="available-empty"
+      >
+        No internal exams available — your administrator will issue you a code when one is ready.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <ul className="space-y-3" data-testid="available-list">
+        {rows.map((row) => (
+          <li
+            key={row.id}
+            data-testid={`available-row-${row.id}`}
+            className="flex items-center justify-between gap-4 rounded-lg border border-border bg-card p-4"
+          >
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-foreground">
+                {row.subjectShort ? `${row.subjectShort} — ` : ''}
+                {row.subjectName}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Expires {formatAbsolute(row.expiresAt)}{' '}
+                <span className="text-muted-foreground/80">({formatRelative(row.expiresAt)})</span>
+              </p>
+            </div>
+            <Button type="button" onClick={() => setSelected(row)} data-testid="start-button">
+              Start
+            </Button>
+          </li>
+        ))}
+      </ul>
+      <CodeEntryModal
+        open={selected !== null}
+        onOpenChange={(next) => {
+          if (!next) setSelected(null)
+        }}
+        userId={userId}
+        subjectName={selected?.subjectName ?? ''}
+        subjectShort={selected?.subjectShort ?? ''}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/app/internal-exam/_components/available-tab.tsx
+++ b/apps/web/app/app/internal-exam/_components/available-tab.tsx
@@ -55,8 +55,15 @@ export function AvailableTab({ rows, userId }: Readonly<Props>) {
                 {row.subjectName}
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
-                Expires {formatAbsolute(row.expiresAt)}{' '}
-                <span className="text-muted-foreground/80">({formatRelative(row.expiresAt)})</span>
+                Expires {formatAbsolute(row.expiresAt)}
+                {formatRelative(row.expiresAt) && (
+                  <>
+                    {' '}
+                    <span className="text-muted-foreground/80">
+                      ({formatRelative(row.expiresAt)})
+                    </span>
+                  </>
+                )}
               </p>
             </div>
             <Button type="button" onClick={() => setSelected(row)} data-testid="start-button">

--- a/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockRouterPush, mockStartInternalExam } = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+  mockStartInternalExam: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+vi.mock('../actions/start-internal-exam', () => ({
+  startInternalExam: (...args: unknown[]) => mockStartInternalExam(...args),
+}))
+
+// Render Base UI Dialog as a plain div so jsdom can drive it deterministically.
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+import { CodeEntryModal } from './code-entry-modal'
+
+function renderModal(open = true) {
+  const onOpenChange = vi.fn()
+  const utils = render(
+    <CodeEntryModal
+      open={open}
+      onOpenChange={onOpenChange}
+      userId="user-1"
+      subjectName="Air Law"
+      subjectShort="ALW"
+    />,
+  )
+  return { ...utils, onOpenChange }
+}
+
+describe('CodeEntryModal', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('disables the submit button when the input is empty', () => {
+    renderModal()
+    expect(screen.getByRole('button', { name: /start exam/i })).toBeDisabled()
+  })
+
+  it('uppercases input and rejects characters outside the Crockford alphabet', async () => {
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    // I, O, 0, 1 are NOT in the alphabet; lowercase should uppercase
+    await userEvent.type(input, 'aiob01x9')
+    // After sanitize: A (a→A), I rejected, O rejected, B (uppercased), 0 rejected, 1 rejected, X, 9
+    expect(input.value).toBe('ABX9')
+  })
+
+  it('does NOT call the action when the code is shorter than 8 chars', async () => {
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    await userEvent.type(input, 'ABCD23')
+    // submit button is disabled below 8 valid chars
+    expect(screen.getByRole('button', { name: /start exam/i })).toBeDisabled()
+    // also if user submits the form somehow, action shouldn't fire
+    await userEvent.click(screen.getByRole('button', { name: /start exam/i }))
+    expect(mockStartInternalExam).not.toHaveBeenCalled()
+  })
+
+  it('calls startInternalExam with a valid 8-char code', async () => {
+    mockStartInternalExam.mockResolvedValue({ success: true, sessionId: 'sess-123' })
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    await userEvent.type(input, 'ABCD2345')
+    await userEvent.click(screen.getByRole('button', { name: /start exam/i }))
+
+    await waitFor(() => expect(mockStartInternalExam).toHaveBeenCalledWith({ code: 'ABCD2345' }))
+  })
+
+  it('writes the session handoff payload and navigates to /app/quiz/session on success', async () => {
+    mockStartInternalExam.mockResolvedValue({
+      success: true,
+      sessionId: 'sess-abc',
+      questionIds: ['q-1', 'q-2'],
+      timeLimitSeconds: 1800,
+      passMark: 75,
+      startedAt: '2026-04-29T10:00:00.000Z',
+    })
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    await userEvent.type(input, 'ABCD2345')
+    await userEvent.click(screen.getByRole('button', { name: /start exam/i }))
+
+    await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/app/quiz/session'))
+    const stored = sessionStorage.getItem('quiz-session:user-1')
+    expect(stored).not.toBeNull()
+    const payload = JSON.parse(stored as string)
+    expect(payload).toMatchObject({
+      userId: 'user-1',
+      sessionId: 'sess-abc',
+      mode: 'exam',
+      examMode: 'internal_exam',
+      questionIds: ['q-1', 'q-2'],
+      timeLimitSeconds: 1800,
+      passMark: 75,
+      subjectName: 'Air Law',
+      subjectCode: 'ALW',
+    })
+  })
+
+  it('renders the action error with role="alert" and does not navigate on failure', async () => {
+    mockStartInternalExam.mockResolvedValue({ success: false, error: 'This code has expired.' })
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    await userEvent.type(input, 'ABCD2345')
+    await userEvent.click(screen.getByRole('button', { name: /start exam/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/this code has expired/i),
+    )
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('shows a generic error and does not navigate when the action throws', async () => {
+    mockStartInternalExam.mockRejectedValue(new Error('boom'))
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    await userEvent.type(input, 'ABCD2345')
+    await userEvent.click(screen.getByRole('button', { name: /start exam/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/something went wrong/i),
+    )
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
@@ -61,6 +61,16 @@ describe('CodeEntryModal', () => {
     expect(input.value).toBe('ABX9')
   })
 
+  it('truncates input to 8 valid characters when more are pasted', async () => {
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    // 12 valid alphabet chars — sanitize() must clip to first 8.
+    await userEvent.click(input)
+    await userEvent.paste('ABCD2345EFGH')
+    expect(input.value).toBe('ABCD2345')
+    expect(input.value.length).toBe(8)
+  })
+
   it('does NOT call the action when the code is shorter than 8 chars', async () => {
     renderModal()
     const input = screen.getByTestId('code-input') as HTMLInputElement

--- a/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
@@ -45,6 +45,10 @@ function renderModal(open = true) {
 describe('CodeEntryModal', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    // The successful-start path writes 'quiz-session:<userId>' into sessionStorage.
+    // Clear so cases that run after it don't inherit the seed and assert against
+    // stale state.
+    sessionStorage.clear()
   })
 
   it('disables the submit button when the input is empty', () => {

--- a/apps/web/app/app/internal-exam/_components/code-entry-modal.tsx
+++ b/apps/web/app/app/internal-exam/_components/code-entry-modal.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { sessionHandoffKey } from '../../quiz/session/_utils/quiz-session-storage'
+import { startInternalExam } from '../actions/start-internal-exam'
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId: string
+  subjectName: string
+  subjectShort: string
+}
+
+const CODE_LENGTH = 8
+// Crockford-style alphabet shared with the issue-code RPC (no I/O/0/1).
+const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+const ALLOWED_RE = new RegExp(`^[${CODE_ALPHABET}]{${CODE_LENGTH}}$`)
+
+function sanitize(input: string): string {
+  const upper = input.toUpperCase()
+  let out = ''
+  for (const ch of upper) {
+    if (CODE_ALPHABET.includes(ch)) out += ch
+    if (out.length >= CODE_LENGTH) break
+  }
+  return out
+}
+
+export function CodeEntryModal({
+  open,
+  onOpenChange,
+  userId,
+  subjectName,
+  subjectShort,
+}: Readonly<Props>) {
+  const router = useRouter()
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleClose(next: boolean) {
+    if (!next) {
+      setCode('')
+      setError(null)
+    }
+    onOpenChange(next)
+  }
+
+  function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    if (!ALLOWED_RE.test(code)) {
+      setError(`Code must be ${CODE_LENGTH} characters (letters and digits, no I/O/0/1).`)
+      return
+    }
+    startTransition(async () => {
+      try {
+        const result = await startInternalExam({ code })
+        if (result.success) {
+          try {
+            sessionStorage.setItem(
+              sessionHandoffKey(userId),
+              JSON.stringify({
+                userId,
+                sessionId: result.sessionId,
+                questionIds: result.questionIds,
+                subjectName,
+                subjectCode: subjectShort,
+                mode: 'exam',
+                examMode: 'internal_exam',
+                timeLimitSeconds: result.timeLimitSeconds,
+                passMark: result.passMark,
+                startedAt: result.startedAt,
+              }),
+            )
+          } catch (storageErr) {
+            console.error('[code-entry-modal] sessionStorage handoff failed:', storageErr)
+            // Internal exam cannot be discarded by design — surface the error
+            // and let the recovery banner handle resume on next visit.
+            setError(
+              'Unable to start internal exam right now. Please try again or refresh the page.',
+            )
+            return
+          }
+          router.push('/app/quiz/session')
+          return
+        }
+        setError(result.error)
+      } catch {
+        setError('Something went wrong. Please try again.')
+      }
+    })
+  }
+
+  const isValid = ALLOWED_RE.test(code)
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Enter internal exam code</DialogTitle>
+          <DialogDescription>
+            {subjectShort ? `${subjectShort} — ` : ''}
+            {subjectName}. Paste or type the {CODE_LENGTH}-character code provided by your
+            administrator.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-3"
+          data-testid="code-entry-form"
+          noValidate
+        >
+          <div className="space-y-2">
+            <Label htmlFor="internal-exam-code">Code</Label>
+            <Input
+              id="internal-exam-code"
+              data-testid="code-input"
+              value={code}
+              onChange={(e) => setCode(sanitize(e.target.value))}
+              autoComplete="off"
+              autoCapitalize="characters"
+              spellCheck={false}
+              inputMode="text"
+              maxLength={CODE_LENGTH}
+              placeholder="ABC23XYZ"
+              className="font-mono tracking-widest uppercase"
+              aria-invalid={error !== null}
+            />
+            {error ? (
+              <p role="alert" className="text-xs text-destructive">
+                {error}
+              </p>
+            ) : null}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleClose(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending || !isValid}>
+              {isPending ? 'Starting…' : 'Start exam'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/app/internal-exam/_components/internal-exam-content.tsx
+++ b/apps/web/app/app/internal-exam/_components/internal-exam-content.tsx
@@ -1,0 +1,27 @@
+import { getActiveInternalExamSession } from '../actions/get-active-internal-exam-session'
+import { listAvailableInternalExams, listMyInternalExamHistory } from '../queries'
+import { InternalExamTabs } from './internal-exam-tabs'
+import { RecoveryBanner } from './recovery-banner'
+
+type Props = {
+  userId: string
+}
+
+export async function InternalExamContent({ userId }: Readonly<Props>) {
+  const [available, history, activeResult] = await Promise.all([
+    listAvailableInternalExams(),
+    listMyInternalExamHistory(),
+    getActiveInternalExamSession(),
+  ])
+
+  const activeSessions = activeResult.success ? activeResult.sessions : []
+
+  return (
+    <div className="space-y-4">
+      {activeSessions.map((session) => (
+        <RecoveryBanner key={session.sessionId} userId={userId} session={session} />
+      ))}
+      <InternalExamTabs available={available} history={history} userId={userId} />
+    </div>
+  )
+}

--- a/apps/web/app/app/internal-exam/_components/internal-exam-tabs.tsx
+++ b/apps/web/app/app/internal-exam/_components/internal-exam-tabs.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useSearchParams } from 'next/navigation'
 import { type KeyboardEvent, useRef, useState } from 'react'
 import type { AvailableInternalExam, InternalExamHistoryEntry } from '../queries'
 import { AvailableTab } from './available-tab'
@@ -16,7 +17,9 @@ type TabKey = 'available' | 'reports'
 const TAB_ORDER: TabKey[] = ['available', 'reports']
 
 export function InternalExamTabs({ available, history, userId }: Props) {
-  const [tab, setTab] = useState<TabKey>('available')
+  const searchParams = useSearchParams()
+  const initialTab: TabKey = searchParams.get('tab') === 'reports' ? 'reports' : 'available'
+  const [tab, setTab] = useState<TabKey>(initialTab)
   const tablistRef = useRef<HTMLDivElement | null>(null)
 
   function focusTab(key: TabKey) {

--- a/apps/web/app/app/internal-exam/_components/internal-exam-tabs.tsx
+++ b/apps/web/app/app/internal-exam/_components/internal-exam-tabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { type KeyboardEvent, useRef, useState } from 'react'
 import type { AvailableInternalExam, InternalExamHistoryEntry } from '../queries'
 import { AvailableTab } from './available-tab'
 import { MyReportsTab } from './my-reports-tab'
@@ -13,15 +13,44 @@ type Props = {
 
 type TabKey = 'available' | 'reports'
 
-export function InternalExamTabs({ available, history, userId }: Readonly<Props>) {
+const TAB_ORDER: TabKey[] = ['available', 'reports']
+
+export function InternalExamTabs({ available, history, userId }: Props) {
   const [tab, setTab] = useState<TabKey>('available')
+  const tablistRef = useRef<HTMLDivElement | null>(null)
+
+  function focusTab(key: TabKey) {
+    setTab(key)
+    const el = tablistRef.current?.querySelector<HTMLButtonElement>(`[data-tabkey="${key}"]`)
+    el?.focus()
+  }
+
+  function onKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    const idx = TAB_ORDER.indexOf(tab)
+    if (idx < 0) return
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      focusTab(TAB_ORDER[(idx + 1) % TAB_ORDER.length] as TabKey)
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      focusTab(TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length] as TabKey)
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      focusTab(TAB_ORDER[0] as TabKey)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      focusTab(TAB_ORDER[TAB_ORDER.length - 1] as TabKey)
+    }
+  }
 
   return (
     <div className="space-y-4">
       <div
+        ref={tablistRef}
         role="tablist"
         aria-label="Internal exam sections"
         className="flex border-b border-border"
+        onKeyDown={onKeyDown}
       >
         <TabButton
           id="available"
@@ -76,6 +105,7 @@ function TabButton({
       tabIndex={active ? 0 : -1}
       onClick={onClick}
       data-testid={`tab-${id}`}
+      data-tabkey={id}
       className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-colors border-b-2 ${
         active
           ? 'border-primary text-primary'

--- a/apps/web/app/app/internal-exam/_components/internal-exam-tabs.tsx
+++ b/apps/web/app/app/internal-exam/_components/internal-exam-tabs.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState } from 'react'
+import type { AvailableInternalExam, InternalExamHistoryEntry } from '../queries'
+import { AvailableTab } from './available-tab'
+import { MyReportsTab } from './my-reports-tab'
+
+type Props = {
+  available: AvailableInternalExam[]
+  history: InternalExamHistoryEntry[]
+  userId: string
+}
+
+type TabKey = 'available' | 'reports'
+
+export function InternalExamTabs({ available, history, userId }: Readonly<Props>) {
+  const [tab, setTab] = useState<TabKey>('available')
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="tablist"
+        aria-label="Internal exam sections"
+        className="flex border-b border-border"
+      >
+        <TabButton
+          id="available"
+          active={tab === 'available'}
+          label="Available"
+          badge={available.length || undefined}
+          onClick={() => setTab('available')}
+        />
+        <TabButton
+          id="reports"
+          active={tab === 'reports'}
+          label="My Reports"
+          onClick={() => setTab('reports')}
+        />
+      </div>
+      <div
+        role="tabpanel"
+        id={`tabpanel-${tab}`}
+        aria-labelledby={`tab-${tab}`}
+        data-testid={`tabpanel-${tab}`}
+      >
+        {tab === 'available' ? (
+          <AvailableTab rows={available} userId={userId} />
+        ) : (
+          <MyReportsTab rows={history} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TabButton({
+  id,
+  active,
+  label,
+  badge,
+  onClick,
+}: {
+  id: string
+  active: boolean
+  label: string
+  badge?: number
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      id={`tab-${id}`}
+      role="tab"
+      aria-selected={active}
+      aria-controls={`tabpanel-${id}`}
+      tabIndex={active ? 0 : -1}
+      onClick={onClick}
+      data-testid={`tab-${id}`}
+      className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-colors border-b-2 ${
+        active
+          ? 'border-primary text-primary'
+          : 'border-transparent text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {label}
+      {badge != null && badge > 0 && (
+        <span
+          data-testid={`tab-${id}-badge`}
+          className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-primary-foreground"
+        >
+          {badge}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/apps/web/app/app/internal-exam/_components/internal-exam-tabs.tsx
+++ b/apps/web/app/app/internal-exam/_components/internal-exam-tabs.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useSearchParams } from 'next/navigation'
-import { type KeyboardEvent, useRef, useState } from 'react'
+import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
 import type { AvailableInternalExam, InternalExamHistoryEntry } from '../queries'
 import { AvailableTab } from './available-tab'
 import { MyReportsTab } from './my-reports-tab'
@@ -16,10 +16,18 @@ type TabKey = 'available' | 'reports'
 
 const TAB_ORDER: TabKey[] = ['available', 'reports']
 
+function readTabParam(value: string | null): TabKey {
+  return value === 'reports' ? 'reports' : 'available'
+}
+
 export function InternalExamTabs({ available, history, userId }: Props) {
   const searchParams = useSearchParams()
-  const initialTab: TabKey = searchParams.get('tab') === 'reports' ? 'reports' : 'available'
-  const [tab, setTab] = useState<TabKey>(initialTab)
+  const tabParam = searchParams.get('tab')
+  const [tab, setTab] = useState<TabKey>(readTabParam(tabParam))
+  // Re-sync when ?tab= changes via soft navigation (e.g., "Back" CTA from report page).
+  useEffect(() => {
+    setTab(readTabParam(tabParam))
+  }, [tabParam])
   const tablistRef = useRef<HTMLDivElement | null>(null)
 
   function focusTab(key: TabKey) {

--- a/apps/web/app/app/internal-exam/_components/my-reports-tab.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/my-reports-tab.test.tsx
@@ -1,9 +1,24 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
 vi.mock('next/link', () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
+  default: ({
+    href,
+    children,
+    onClick,
+  }: {
+    href: string
+    children: React.ReactNode
+    onClick?: (e: React.MouseEvent) => void
+  }) => (
+    <a href={href} onClick={onClick}>
+      {children}
+    </a>
   ),
 }))
 
@@ -30,16 +45,32 @@ describe('MyReportsTab', () => {
     expect(screen.getByTestId('reports-empty')).toHaveTextContent(/no internal exam attempts yet/i)
   })
 
-  it('renders the subject short as a link to the report page with the session id', () => {
+  it('renders the full subject name as a link to the report page with the session id', () => {
     render(<MyReportsTab rows={[baseRow]} />)
-    const link = screen.getByRole('link', { name: '010' })
-    expect(link.getAttribute('href')).toBe('/app/quiz/report?id=sess-1')
+    const link = screen.getByRole('link', { name: 'Air Law' })
+    expect(link.getAttribute('href')).toBe('/app/internal-exam/report?session=sess-1')
   })
 
-  it('falls back to the subject name when there is no short code', () => {
-    render(<MyReportsTab rows={[{ ...baseRow, subjectShort: '' }]} />)
-    const link = screen.getByRole('link', { name: 'Air Law' })
-    expect(link.getAttribute('href')).toBe('/app/quiz/report?id=sess-1')
+  it('falls back to the subject short code when there is no full name', () => {
+    render(<MyReportsTab rows={[{ ...baseRow, subjectName: '' }]} />)
+    const link = screen.getByRole('link', { name: '010' })
+    expect(link.getAttribute('href')).toBe('/app/internal-exam/report?session=sess-1')
+  })
+
+  it('navigates to the report when the row is clicked', () => {
+    mockPush.mockClear()
+    render(<MyReportsTab rows={[baseRow]} />)
+    const row = screen.getByTestId('report-row-sess-1')
+    fireEvent.click(row)
+    expect(mockPush).toHaveBeenCalledWith('/app/internal-exam/report?session=sess-1')
+  })
+
+  it('navigates to the report when Enter is pressed on a focused row', () => {
+    mockPush.mockClear()
+    render(<MyReportsTab rows={[baseRow]} />)
+    const row = screen.getByTestId('report-row-sess-1')
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(mockPush).toHaveBeenCalledWith('/app/internal-exam/report?session=sess-1')
   })
 
   it('renders the attempt number prefixed with #', () => {

--- a/apps/web/app/app/internal-exam/_components/my-reports-tab.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/my-reports-tab.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+import type { InternalExamHistoryEntry } from '../queries'
+import { MyReportsTab } from './my-reports-tab'
+
+const baseRow: InternalExamHistoryEntry = {
+  id: 'sess-1',
+  subjectId: 'subj-1',
+  subjectName: 'Air Law',
+  subjectShort: '010',
+  startedAt: '2026-04-28T09:00:00.000Z',
+  endedAt: '2026-04-28T09:30:00.000Z',
+  scorePercentage: 87.5,
+  passed: true,
+  totalQuestions: 16,
+  answeredCount: 15,
+  attemptNumber: 2,
+}
+
+describe('MyReportsTab', () => {
+  it('renders the empty state when there are no rows', () => {
+    render(<MyReportsTab rows={[]} />)
+    expect(screen.getByTestId('reports-empty')).toHaveTextContent(/no internal exam attempts yet/i)
+  })
+
+  it('renders the subject short as a link to the report page with the session id', () => {
+    render(<MyReportsTab rows={[baseRow]} />)
+    const link = screen.getByRole('link', { name: '010' })
+    expect(link.getAttribute('href')).toBe('/app/quiz/report?id=sess-1')
+  })
+
+  it('falls back to the subject name when there is no short code', () => {
+    render(<MyReportsTab rows={[{ ...baseRow, subjectShort: '' }]} />)
+    const link = screen.getByRole('link', { name: 'Air Law' })
+    expect(link.getAttribute('href')).toBe('/app/quiz/report?id=sess-1')
+  })
+
+  it('renders the attempt number prefixed with #', () => {
+    render(<MyReportsTab rows={[baseRow]} />)
+    expect(screen.getByText('#2')).toBeInTheDocument()
+  })
+
+  it('renders the score rounded to a whole percent', () => {
+    render(<MyReportsTab rows={[baseRow]} />)
+    expect(screen.getByText('88%')).toBeInTheDocument()
+  })
+
+  it('renders the Pass badge when passed is true', () => {
+    render(<MyReportsTab rows={[baseRow]} />)
+    expect(screen.getByLabelText('Passed')).toBeInTheDocument()
+  })
+
+  it('renders the Fail badge when passed is false', () => {
+    render(<MyReportsTab rows={[{ ...baseRow, passed: false }]} />)
+    expect(screen.getByLabelText('Failed')).toBeInTheDocument()
+  })
+
+  it('renders neither pass nor fail badge when passed is null', () => {
+    render(<MyReportsTab rows={[{ ...baseRow, passed: null }]} />)
+    expect(screen.queryByLabelText('Passed')).toBeNull()
+    expect(screen.queryByLabelText('Failed')).toBeNull()
+  })
+
+  it('renders the answered/total count', () => {
+    render(<MyReportsTab rows={[baseRow]} />)
+    expect(screen.getByText('15/16')).toBeInTheDocument()
+  })
+
+  it('renders a dash when the score is null', () => {
+    render(<MyReportsTab rows={[{ ...baseRow, scorePercentage: null }]} />)
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/app/app/internal-exam/_components/my-reports-tab.tsx
+++ b/apps/web/app/app/internal-exam/_components/my-reports-tab.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type { InternalExamHistoryEntry } from '../queries'
+
+type Props = { rows: InternalExamHistoryEntry[] }
+
+function formatAbsolute(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString('en-GB', { dateStyle: 'short', timeStyle: 'short' })
+}
+
+function formatScore(score: number | null): string {
+  if (score === null || Number.isNaN(score)) return '—'
+  return `${Math.round(score)}%`
+}
+
+export function MyReportsTab({ rows }: Readonly<Props>) {
+  if (rows.length === 0) {
+    return (
+      <div
+        className="rounded-lg border border-dashed border-border bg-muted/30 p-6 text-center text-sm text-muted-foreground"
+        data-testid="reports-empty"
+      >
+        No internal exam attempts yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="min-w-[140px]">Subject</TableHead>
+            <TableHead className="w-16">Attempt</TableHead>
+            <TableHead className="w-40">Started</TableHead>
+            <TableHead className="w-40">Ended</TableHead>
+            <TableHead className="w-20">Score</TableHead>
+            <TableHead className="w-24">Result</TableHead>
+            <TableHead className="w-24">Answered</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((r) => {
+            const label = r.subjectShort || r.subjectName || '—'
+            return (
+              <TableRow key={r.id} data-testid={`report-row-${r.id}`}>
+                <TableCell>
+                  <Link
+                    href={`/app/quiz/report?id=${r.id}`}
+                    className="text-primary hover:underline"
+                  >
+                    {label}
+                  </Link>
+                </TableCell>
+                <TableCell className="tabular-nums">#{r.attemptNumber}</TableCell>
+                <TableCell className="text-xs text-muted-foreground">
+                  {formatAbsolute(r.startedAt)}
+                </TableCell>
+                <TableCell className="text-xs text-muted-foreground">
+                  {formatAbsolute(r.endedAt)}
+                </TableCell>
+                <TableCell className="font-mono text-sm">
+                  {formatScore(r.scorePercentage)}
+                </TableCell>
+                <TableCell>
+                  {r.passed === null ? (
+                    <span className="text-muted-foreground">—</span>
+                  ) : r.passed ? (
+                    <Badge variant="default" aria-label="Passed">
+                      Pass
+                    </Badge>
+                  ) : (
+                    <Badge variant="destructive" aria-label="Failed">
+                      Fail
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-xs tabular-nums">
+                  {r.answeredCount}/{r.totalQuestions}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/apps/web/app/app/internal-exam/_components/my-reports-tab.tsx
+++ b/apps/web/app/app/internal-exam/_components/my-reports-tab.tsx
@@ -26,7 +26,7 @@ function formatScore(score: number | null): string {
   return `${Math.round(score)}%`
 }
 
-export function MyReportsTab({ rows }: Readonly<Props>) {
+export function MyReportsTab({ rows }: Props) {
   if (rows.length === 0) {
     return (
       <div

--- a/apps/web/app/app/internal-exam/_components/my-reports-tab.tsx
+++ b/apps/web/app/app/internal-exam/_components/my-reports-tab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
 import {
   Table,
@@ -53,49 +54,63 @@ export function MyReportsTab({ rows }: Props) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {rows.map((r) => {
-            const label = r.subjectShort || r.subjectName || '—'
-            return (
-              <TableRow key={r.id} data-testid={`report-row-${r.id}`}>
-                <TableCell>
-                  <Link
-                    href={`/app/quiz/report?id=${r.id}`}
-                    className="text-primary hover:underline"
-                  >
-                    {label}
-                  </Link>
-                </TableCell>
-                <TableCell className="tabular-nums">#{r.attemptNumber}</TableCell>
-                <TableCell className="text-xs text-muted-foreground">
-                  {formatAbsolute(r.startedAt)}
-                </TableCell>
-                <TableCell className="text-xs text-muted-foreground">
-                  {formatAbsolute(r.endedAt)}
-                </TableCell>
-                <TableCell className="font-mono text-sm">
-                  {formatScore(r.scorePercentage)}
-                </TableCell>
-                <TableCell>
-                  {r.passed === null ? (
-                    <span className="text-muted-foreground">—</span>
-                  ) : r.passed ? (
-                    <Badge variant="default" aria-label="Passed">
-                      Pass
-                    </Badge>
-                  ) : (
-                    <Badge variant="destructive" aria-label="Failed">
-                      Fail
-                    </Badge>
-                  )}
-                </TableCell>
-                <TableCell className="text-xs tabular-nums">
-                  {r.answeredCount}/{r.totalQuestions}
-                </TableCell>
-              </TableRow>
-            )
-          })}
+          {rows.map((r) => (
+            <ReportRow key={r.id} row={r} />
+          ))}
         </TableBody>
       </Table>
     </div>
+  )
+}
+
+function ReportRow({ row: r }: { row: InternalExamHistoryEntry }) {
+  const router = useRouter()
+  const href = `/app/internal-exam/report?session=${r.id}`
+  const label = r.subjectName || r.subjectShort || '—'
+  const navigate = () => router.push(href)
+
+  return (
+    <TableRow
+      data-testid={`report-row-${r.id}`}
+      tabIndex={0}
+      onClick={navigate}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          navigate()
+        }
+      }}
+      className="cursor-pointer hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+    >
+      <TableCell>
+        <Link
+          href={href}
+          onClick={(e) => e.stopPropagation()}
+          className="font-medium text-foreground no-underline focus-visible:underline"
+        >
+          {label}
+        </Link>
+      </TableCell>
+      <TableCell className="tabular-nums">#{r.attemptNumber}</TableCell>
+      <TableCell className="text-xs text-muted-foreground">{formatAbsolute(r.startedAt)}</TableCell>
+      <TableCell className="text-xs text-muted-foreground">{formatAbsolute(r.endedAt)}</TableCell>
+      <TableCell className="font-mono text-sm">{formatScore(r.scorePercentage)}</TableCell>
+      <TableCell>
+        {r.passed === null ? (
+          <span className="text-muted-foreground">—</span>
+        ) : r.passed ? (
+          <Badge variant="default" aria-label="Passed">
+            Pass
+          </Badge>
+        ) : (
+          <Badge variant="destructive" aria-label="Failed">
+            Fail
+          </Badge>
+        )}
+      </TableCell>
+      <TableCell className="text-xs tabular-nums">
+        {r.answeredCount}/{r.totalQuestions}
+      </TableCell>
+    </TableRow>
   )
 }

--- a/apps/web/app/app/internal-exam/_components/recovery-banner.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/recovery-banner.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockRouterPush } = vi.hoisted(() => ({ mockRouterPush: vi.fn() }))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+import type { ActiveInternalExamSession } from '../actions/get-active-internal-exam-session'
+import { RecoveryBanner } from './recovery-banner'
+
+const SESSION: ActiveInternalExamSession = {
+  sessionId: 'sess-active-001',
+  subjectId: 'subj-aaa',
+  subjectName: 'Air Law',
+  subjectCode: '010',
+  startedAt: '2026-04-28T10:00:00.000Z',
+  timeLimitSeconds: 3600,
+  passMark: 75,
+  questionIds: ['q-1', 'q-2'],
+}
+
+describe('RecoveryBanner', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    sessionStorage.clear()
+  })
+
+  it('renders the active-internal-exam title and subject', () => {
+    render(<RecoveryBanner userId="user-1" session={SESSION} />)
+    expect(screen.getByText(/active internal exam in progress/i)).toBeInTheDocument()
+    expect(screen.getByText(/air law/i)).toBeInTheDocument()
+  })
+
+  it('writes session handoff and navigates to /app/quiz/session on resume click', async () => {
+    render(<RecoveryBanner userId="user-1" session={SESSION} />)
+    await userEvent.click(screen.getByRole('button', { name: /resume internal exam/i }))
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/app/quiz/session')
+    const stored = sessionStorage.getItem('quiz-session:user-1')
+    expect(stored).not.toBeNull()
+    const payload = JSON.parse(stored as string)
+    expect(payload).toMatchObject({
+      userId: 'user-1',
+      sessionId: 'sess-active-001',
+      mode: 'exam',
+      examMode: 'internal_exam',
+      questionIds: ['q-1', 'q-2'],
+      timeLimitSeconds: 3600,
+      passMark: 75,
+      subjectName: 'Air Law',
+      subjectCode: '010',
+    })
+  })
+
+  it('falls back to a generic subtitle when subjectName is empty', () => {
+    render(<RecoveryBanner userId="user-1" session={{ ...SESSION, subjectName: '' }} />)
+    expect(screen.getByText(/session in progress/i)).toBeInTheDocument()
+  })
+
+  it('renders with amber accent styling', () => {
+    render(<RecoveryBanner userId="user-1" session={SESSION} />)
+    const banner = screen.getByTestId('internal-exam-recovery-banner')
+    expect(banner.className).toContain('amber')
+  })
+})

--- a/apps/web/app/app/internal-exam/_components/recovery-banner.tsx
+++ b/apps/web/app/app/internal-exam/_components/recovery-banner.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { sessionHandoffKey } from '../../quiz/session/_utils/quiz-session-storage'
+import type { ActiveInternalExamSession } from '../actions/get-active-internal-exam-session'
+
+type Props = {
+  userId: string
+  session: ActiveInternalExamSession
+}
+
+export function RecoveryBanner({ userId, session }: Readonly<Props>) {
+  const router = useRouter()
+  const subtitle = session.subjectName
+    ? `${session.subjectName} — session in progress`
+    : 'Session in progress'
+
+  function handleResume() {
+    try {
+      sessionStorage.setItem(
+        sessionHandoffKey(userId),
+        JSON.stringify({
+          userId,
+          sessionId: session.sessionId,
+          questionIds: session.questionIds,
+          subjectName: session.subjectName,
+          subjectCode: session.subjectCode,
+          mode: 'exam',
+          examMode: 'internal_exam',
+          timeLimitSeconds: session.timeLimitSeconds,
+          passMark: session.passMark,
+          startedAt: session.startedAt,
+        }),
+      )
+    } catch (err) {
+      console.error('[recovery-banner] sessionStorage handoff failed:', err)
+      // Fall through — quiz-session-loader has its own error UX.
+    }
+    router.push('/app/quiz/session')
+  }
+
+  return (
+    <div
+      role="status"
+      data-testid="internal-exam-recovery-banner"
+      className="mx-auto max-w-md rounded-lg border border-amber-500/30 bg-amber-500/5 p-4"
+    >
+      <p className="text-sm font-medium text-foreground">
+        You have an active internal exam in progress
+      </p>
+      <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
+      <div className="mt-3">
+        <button
+          type="button"
+          onClick={handleResume}
+          className="inline-flex items-center rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-600"
+          data-testid="resume-internal-exam-link"
+        >
+          Resume internal exam
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/app/internal-exam/actions/_error-messages.ts
+++ b/apps/web/app/app/internal-exam/actions/_error-messages.ts
@@ -1,0 +1,28 @@
+// RPC error tokens from start_internal_exam_session (mig 060/065/070/071)
+// mapped to user-friendly strings. mapRpcError() runs `String.includes()` so
+// each entry must be a literal substring of a RAISE EXCEPTION string. Keep in
+// sync with the RPC body if new tokens are added.
+
+export const START_INTERNAL_EXAM_ERROR_MESSAGES: Array<[string, string]> = [
+  ['not_authenticated', 'Not authenticated'],
+  // UNIFIED — never reveal whether the code exists for a different student.
+  ['code_not_found', 'Invalid or expired code. Please contact your administrator.'],
+  ['code_not_yours', 'Invalid or expired code. Please contact your administrator.'],
+  ['code_expired', 'This code has expired. Please contact your administrator.'],
+  ['code_already_used', 'This code has already been used.'],
+  ['code_voided', 'This code has been cancelled. Please contact your administrator.'],
+  [
+    'active_session_exists',
+    'You already have an active internal exam session for this subject. Submit it before starting a new one.',
+  ],
+  ['insufficient_questions_for_exam', 'Cannot start exam: not enough questions configured.'],
+  [
+    'exam_config_required',
+    'No exam configuration available for this subject. Please contact your administrator.',
+  ],
+  // Literal RAISE EXCEPTION string from mig 070/071 (with spaces, not snake_case).
+  [
+    'user not found or inactive',
+    'Your account is no longer active. Please contact your administrator.',
+  ],
+]

--- a/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.test.ts
+++ b/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const { mockGetUser, mockFrom, mockRpc } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockRpc: vi.fn(),
+}))
+
+vi.mock('@repo/db/server', () => ({
+  createServerSupabaseClient: async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  }),
+}))
+
+vi.mock('@/lib/supabase-rpc', () => ({
+  rpc: mockRpc,
+}))
+
+// ---- Subject under test ---------------------------------------------------
+
+import { getActiveInternalExamSession } from './get-active-internal-exam-session'
+
+// ---- Helpers -------------------------------------------------------------
+
+function buildChain(returnValue: unknown) {
+  const awaitable = {
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable for Supabase chain mock
+    then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+      Promise.resolve(returnValue).then(resolve, reject),
+  }
+  return new Proxy(awaitable as Record<string, unknown>, {
+    get(target, prop) {
+      if (prop === 'then') return target.then
+      return (..._args: unknown[]) => buildChain(returnValue)
+    },
+  })
+}
+
+const SESSION_ROW = {
+  id: 'sess-001',
+  subject_id: 'subj-aaa',
+  started_at: '2026-04-29T10:00:00.000Z',
+  time_limit_seconds: 3600,
+  config: { question_ids: ['q-1', 'q-2', 'q-3'], pass_mark: 75 },
+  easa_subjects: { name: 'Air Law', short: 'ALW' },
+}
+
+// ---- Lifecycle ------------------------------------------------------------
+// Freeze "now" at 10:30 — SESSION_ROW started at 10:00 with a 3600s limit, so
+// the default fixture is well within deadline.
+const NOW_MS = Date.parse('2026-04-29T10:30:00.000Z')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW_MS)
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+  mockRpc.mockResolvedValue({ data: null, error: null })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ---- Tests ----------------------------------------------------------------
+
+describe('getActiveInternalExamSession — unauthenticated', () => {
+  it('returns error when auth error is present', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no session' } })
+    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({ success: false, error: 'Not authenticated' })
+  })
+
+  it('returns error when user is null without auth error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null })
+    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({ success: false, error: 'Not authenticated' })
+  })
+})
+
+describe('getActiveInternalExamSession — happy path', () => {
+  it('returns an array of active internal exam sessions with questionIds', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: [SESSION_ROW], error: null }))
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [
+        {
+          sessionId: 'sess-001',
+          subjectId: 'subj-aaa',
+          subjectName: 'Air Law',
+          subjectCode: 'ALW',
+          startedAt: '2026-04-29T10:00:00.000Z',
+          timeLimitSeconds: 3600,
+          passMark: 75,
+          questionIds: ['q-1', 'q-2', 'q-3'],
+        },
+      ],
+      orphanedSessionIds: [],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('returns an empty array when no active internal exam sessions exist', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: [],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('returns an empty array when data is null', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: null, error: null }))
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: [],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('falls back to Unknown subject when easa_subjects is null', async () => {
+    mockFrom.mockReturnValue(
+      buildChain({ data: [{ ...SESSION_ROW, easa_subjects: null }], error: null }),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.sessions[0]?.subjectName).toBe('Unknown subject')
+      expect(result.sessions[0]?.subjectCode).toBe('')
+    }
+  })
+
+  it('queries the quiz_sessions table', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+
+    await getActiveInternalExamSession()
+
+    expect(mockFrom).toHaveBeenCalledWith('quiz_sessions')
+  })
+})
+
+describe('getActiveInternalExamSession — malformed config (row skipped)', () => {
+  it('skips a row with empty question_ids and adds id to orphanedSessionIds', async () => {
+    mockFrom.mockReturnValue(
+      buildChain({
+        data: [{ ...SESSION_ROW, id: 'session-empty', config: { question_ids: [] } }],
+        error: null,
+      }),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['session-empty'],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('skips a row with missing pass_mark and adds id to orphanedSessionIds', async () => {
+    mockFrom.mockReturnValue(
+      buildChain({
+        data: [
+          {
+            ...SESSION_ROW,
+            id: 'session-no-pm',
+            config: { question_ids: ['q-1', 'q-2'] },
+          },
+        ],
+        error: null,
+      }),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['session-no-pm'],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('skips a row with null config and adds id to orphanedSessionIds', async () => {
+    mockFrom.mockReturnValue(
+      buildChain({ data: [{ ...SESSION_ROW, id: 'session-null', config: null }], error: null }),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['session-null'],
+      expiredSessionIds: [],
+    })
+  })
+})
+
+describe('getActiveInternalExamSession — DB error', () => {
+  it('returns error when query fails', async () => {
+    mockFrom.mockReturnValue(
+      buildChain({ data: null, error: { message: 'relation does not exist' } }),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to fetch active internal exam sessions.',
+    })
+  })
+})
+
+describe('getActiveInternalExamSession — expired sessions (Layer 1)', () => {
+  const overdueRow = (id: string) => ({
+    ...SESSION_ROW,
+    id,
+    started_at: '2026-04-29T10:00:00.000Z',
+    time_limit_seconds: 60, // deadline 10:01, NOW = 10:30 → overdue
+  })
+
+  it('moves an overdue row to expiredSessionIds and invokes complete_overdue_exam_session', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: [overdueRow('expired-1')], error: null }))
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.sessions).toEqual([])
+      expect(result.expiredSessionIds).toEqual(['expired-1'])
+      expect(result.orphanedSessionIds).toEqual([])
+    }
+    expect(mockRpc).toHaveBeenCalledWith(expect.anything(), 'complete_overdue_exam_session', {
+      p_session_id: 'expired-1',
+    })
+  })
+
+  it('routes overdue row to orphanedSessionIds when RPC errors', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: [overdueRow('expired-2')], error: null }))
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'session is not overdue' } })
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const result = await getActiveInternalExamSession()
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.expiredSessionIds).toEqual([])
+        expect(result.orphanedSessionIds).toEqual(['expired-2'])
+      }
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[getActiveInternalExamSession] Auto-complete failed:',
+        'expired-2',
+        'session is not overdue',
+      )
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+
+  it('keeps an active (deadline-in-future) row in sessions; does not call RPC', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: [SESSION_ROW], error: null }))
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.sessions).toHaveLength(1)
+      expect(result.sessions[0]?.sessionId).toBe('sess-001')
+      expect(result.expiredSessionIds).toEqual([])
+    }
+    expect(mockRpc).not.toHaveBeenCalled()
+  })
+
+  it('filters by mode=internal_exam (chain receives the correct equality argument)', async () => {
+    // Capture .eq calls so we can verify the mode filter is "internal_exam".
+    const eqCalls: Array<[string, unknown]> = []
+    const chain: Record<string, unknown> = {}
+    // biome-ignore lint/suspicious/noThenProperty: supabase chain must be thenable to mock awaiting the query builder
+    chain.then = (resolve: (v: unknown) => void) =>
+      Promise.resolve({ data: [], error: null }).then(resolve)
+    chain.select = () => chain
+    chain.eq = (col: string, val: unknown) => {
+      eqCalls.push([col, val])
+      return chain
+    }
+    chain.is = () => chain
+    chain.order = () => chain
+    mockFrom.mockReturnValue(chain)
+
+    await getActiveInternalExamSession()
+
+    const modeFilter = eqCalls.find(([col]) => col === 'mode')
+    expect(modeFilter?.[1]).toBe('internal_exam')
+  })
+})

--- a/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.test.ts
+++ b/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.test.ts
@@ -321,8 +321,9 @@ describe('getActiveInternalExamSession — expired sessions (Layer 1)', () => {
     expect(mockRpc).not.toHaveBeenCalled()
   })
 
-  it('filters by mode=internal_exam (chain receives the correct equality argument)', async () => {
-    // Capture .eq calls so we can verify the mode filter is "internal_exam".
+  it('filters by mode=internal_exam and the resolved organization_id', async () => {
+    // Capture .eq calls so we can verify both the mode and org-scope filters
+    // make it onto the quiz_sessions chain.
     const eqCalls: Array<[string, unknown]> = []
     const chain: Record<string, unknown> = {}
     // biome-ignore lint/suspicious/noThenProperty: supabase chain must be thenable to mock awaiting the query builder
@@ -343,5 +344,7 @@ describe('getActiveInternalExamSession — expired sessions (Layer 1)', () => {
 
     const modeFilter = eqCalls.find(([col]) => col === 'mode')
     expect(modeFilter?.[1]).toBe('internal_exam')
+    const orgFilter = eqCalls.find(([col]) => col === 'organization_id')
+    expect(orgFilter?.[1]).toBe(USER_ORG_ROW.organization_id)
   })
 })

--- a/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.test.ts
+++ b/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.test.ts
@@ -39,6 +39,19 @@ function buildChain(returnValue: unknown) {
   })
 }
 
+const USER_ORG_ROW = { organization_id: 'org-1' }
+
+/**
+ * Wraps a session-table chain factory so that requests against the `users`
+ * table return the standard org row, while everything else falls back to the
+ * provided session chain. Mirrors how the production code calls
+ * `from('users')` first to look up organization_id.
+ */
+function withUserChain(sessionChain: unknown) {
+  return (table: string) =>
+    table === 'users' ? buildChain({ data: USER_ORG_ROW, error: null }) : sessionChain
+}
+
 const SESSION_ROW = {
   id: 'sess-001',
   subject_id: 'subj-aaa',
@@ -70,7 +83,7 @@ afterEach(() => {
 describe('getActiveInternalExamSession — unauthenticated', () => {
   it('returns error when auth error is present', async () => {
     mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'no session' } })
-    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    mockFrom.mockImplementation(withUserChain(buildChain({ data: [], error: null })))
 
     const result = await getActiveInternalExamSession()
 
@@ -79,7 +92,7 @@ describe('getActiveInternalExamSession — unauthenticated', () => {
 
   it('returns error when user is null without auth error', async () => {
     mockGetUser.mockResolvedValue({ data: { user: null }, error: null })
-    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    mockFrom.mockImplementation(withUserChain(buildChain({ data: [], error: null })))
 
     const result = await getActiveInternalExamSession()
 
@@ -89,7 +102,7 @@ describe('getActiveInternalExamSession — unauthenticated', () => {
 
 describe('getActiveInternalExamSession — happy path', () => {
   it('returns an array of active internal exam sessions with questionIds', async () => {
-    mockFrom.mockReturnValue(buildChain({ data: [SESSION_ROW], error: null }))
+    mockFrom.mockImplementation(withUserChain(buildChain({ data: [SESSION_ROW], error: null })))
 
     const result = await getActiveInternalExamSession()
 
@@ -113,7 +126,7 @@ describe('getActiveInternalExamSession — happy path', () => {
   })
 
   it('returns an empty array when no active internal exam sessions exist', async () => {
-    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    mockFrom.mockImplementation(withUserChain(buildChain({ data: [], error: null })))
 
     const result = await getActiveInternalExamSession()
 
@@ -126,7 +139,7 @@ describe('getActiveInternalExamSession — happy path', () => {
   })
 
   it('returns an empty array when data is null', async () => {
-    mockFrom.mockReturnValue(buildChain({ data: null, error: null }))
+    mockFrom.mockImplementation(withUserChain(buildChain({ data: null, error: null })))
 
     const result = await getActiveInternalExamSession()
 
@@ -139,8 +152,8 @@ describe('getActiveInternalExamSession — happy path', () => {
   })
 
   it('falls back to Unknown subject when easa_subjects is null', async () => {
-    mockFrom.mockReturnValue(
-      buildChain({ data: [{ ...SESSION_ROW, easa_subjects: null }], error: null }),
+    mockFrom.mockImplementation(
+      withUserChain(buildChain({ data: [{ ...SESSION_ROW, easa_subjects: null }], error: null })),
     )
 
     const result = await getActiveInternalExamSession()
@@ -153,7 +166,7 @@ describe('getActiveInternalExamSession — happy path', () => {
   })
 
   it('queries the quiz_sessions table', async () => {
-    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    mockFrom.mockImplementation(withUserChain(buildChain({ data: [], error: null })))
 
     await getActiveInternalExamSession()
 
@@ -163,11 +176,13 @@ describe('getActiveInternalExamSession — happy path', () => {
 
 describe('getActiveInternalExamSession — malformed config (row skipped)', () => {
   it('skips a row with empty question_ids and adds id to orphanedSessionIds', async () => {
-    mockFrom.mockReturnValue(
-      buildChain({
-        data: [{ ...SESSION_ROW, id: 'session-empty', config: { question_ids: [] } }],
-        error: null,
-      }),
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'session-empty', config: { question_ids: [] } }],
+          error: null,
+        }),
+      ),
     )
 
     const result = await getActiveInternalExamSession()
@@ -181,17 +196,19 @@ describe('getActiveInternalExamSession — malformed config (row skipped)', () =
   })
 
   it('skips a row with missing pass_mark and adds id to orphanedSessionIds', async () => {
-    mockFrom.mockReturnValue(
-      buildChain({
-        data: [
-          {
-            ...SESSION_ROW,
-            id: 'session-no-pm',
-            config: { question_ids: ['q-1', 'q-2'] },
-          },
-        ],
-        error: null,
-      }),
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [
+            {
+              ...SESSION_ROW,
+              id: 'session-no-pm',
+              config: { question_ids: ['q-1', 'q-2'] },
+            },
+          ],
+          error: null,
+        }),
+      ),
     )
 
     const result = await getActiveInternalExamSession()
@@ -205,8 +222,13 @@ describe('getActiveInternalExamSession — malformed config (row skipped)', () =
   })
 
   it('skips a row with null config and adds id to orphanedSessionIds', async () => {
-    mockFrom.mockReturnValue(
-      buildChain({ data: [{ ...SESSION_ROW, id: 'session-null', config: null }], error: null }),
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'session-null', config: null }],
+          error: null,
+        }),
+      ),
     )
 
     const result = await getActiveInternalExamSession()
@@ -222,8 +244,8 @@ describe('getActiveInternalExamSession — malformed config (row skipped)', () =
 
 describe('getActiveInternalExamSession — DB error', () => {
   it('returns error when query fails', async () => {
-    mockFrom.mockReturnValue(
-      buildChain({ data: null, error: { message: 'relation does not exist' } }),
+    mockFrom.mockImplementation(
+      withUserChain(buildChain({ data: null, error: { message: 'relation does not exist' } })),
     )
 
     const result = await getActiveInternalExamSession()
@@ -244,7 +266,9 @@ describe('getActiveInternalExamSession — expired sessions (Layer 1)', () => {
   })
 
   it('moves an overdue row to expiredSessionIds and invokes complete_overdue_exam_session', async () => {
-    mockFrom.mockReturnValue(buildChain({ data: [overdueRow('expired-1')], error: null }))
+    mockFrom.mockImplementation(
+      withUserChain(buildChain({ data: [overdueRow('expired-1')], error: null })),
+    )
 
     const result = await getActiveInternalExamSession()
 
@@ -260,7 +284,9 @@ describe('getActiveInternalExamSession — expired sessions (Layer 1)', () => {
   })
 
   it('routes overdue row to orphanedSessionIds when RPC errors', async () => {
-    mockFrom.mockReturnValue(buildChain({ data: [overdueRow('expired-2')], error: null }))
+    mockFrom.mockImplementation(
+      withUserChain(buildChain({ data: [overdueRow('expired-2')], error: null })),
+    )
     mockRpc.mockResolvedValue({ data: null, error: { message: 'session is not overdue' } })
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {
@@ -282,7 +308,7 @@ describe('getActiveInternalExamSession — expired sessions (Layer 1)', () => {
   })
 
   it('keeps an active (deadline-in-future) row in sessions; does not call RPC', async () => {
-    mockFrom.mockReturnValue(buildChain({ data: [SESSION_ROW], error: null }))
+    mockFrom.mockImplementation(withUserChain(buildChain({ data: [SESSION_ROW], error: null })))
 
     const result = await getActiveInternalExamSession()
 
@@ -309,7 +335,9 @@ describe('getActiveInternalExamSession — expired sessions (Layer 1)', () => {
     }
     chain.is = () => chain
     chain.order = () => chain
-    mockFrom.mockReturnValue(chain)
+    mockFrom.mockImplementation((table: string) =>
+      table === 'users' ? buildChain({ data: USER_ORG_ROW, error: null }) : chain,
+    )
 
     await getActiveInternalExamSession()
 

--- a/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.test.ts
+++ b/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.test.ts
@@ -174,6 +174,191 @@ describe('getActiveInternalExamSession — happy path', () => {
   })
 })
 
+describe('getActiveInternalExamSession — malformed time_limit_seconds (row quarantined)', () => {
+  it('quarantines a row with time_limit_seconds=null into orphanedSessionIds', async () => {
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'sess-null-tl', time_limit_seconds: null }],
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['sess-null-tl'],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('quarantines a row with time_limit_seconds=0 into orphanedSessionIds', async () => {
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'sess-zero-tl', time_limit_seconds: 0 }],
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['sess-zero-tl'],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('quarantines a row with a non-integer (fractional) time_limit_seconds into orphanedSessionIds', async () => {
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'sess-frac-tl', time_limit_seconds: 3600.5 }],
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['sess-frac-tl'],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('quarantines a row with time_limit_seconds=NaN into orphanedSessionIds', async () => {
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'sess-nan-tl', time_limit_seconds: Number.NaN }],
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['sess-nan-tl'],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('quarantines a row with time_limit_seconds=Infinity into orphanedSessionIds', async () => {
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [
+            { ...SESSION_ROW, id: 'sess-inf-tl', time_limit_seconds: Number.POSITIVE_INFINITY },
+          ],
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['sess-inf-tl'],
+      expiredSessionIds: [],
+    })
+  })
+})
+
+describe('getActiveInternalExamSession — malformed started_at (row quarantined)', () => {
+  it('quarantines a row with a non-string started_at into orphanedSessionIds', async () => {
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'sess-num-sa', started_at: 1_700_000_000_000 }],
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['sess-num-sa'],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('quarantines a row with an unparseable started_at string into orphanedSessionIds', async () => {
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'sess-bad-sa', started_at: 'not-a-date' }],
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['sess-bad-sa'],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('quarantines a row with null started_at into orphanedSessionIds', async () => {
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'sess-null-sa', started_at: null }],
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result).toEqual({
+      success: true,
+      sessions: [],
+      orphanedSessionIds: ['sess-null-sa'],
+      expiredSessionIds: [],
+    })
+  })
+
+  it('accepts a valid ISO started_at string and places the row in sessions', async () => {
+    mockFrom.mockImplementation(
+      withUserChain(
+        buildChain({
+          data: [{ ...SESSION_ROW, id: 'sess-valid-sa', started_at: '2026-04-29T10:00:00.000Z' }],
+          error: null,
+        }),
+      ),
+    )
+
+    const result = await getActiveInternalExamSession()
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.sessions[0]?.sessionId).toBe('sess-valid-sa')
+      expect(result.orphanedSessionIds).toEqual([])
+    }
+  })
+})
+
 describe('getActiveInternalExamSession — malformed config (row skipped)', () => {
   it('skips a row with empty question_ids and adds id to orphanedSessionIds', async () => {
     mockFrom.mockImplementation(

--- a/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts
+++ b/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts
@@ -1,0 +1,100 @@
+'use server'
+
+import { createServerSupabaseClient } from '@repo/db/server'
+import {
+  extractPassMark,
+  extractQuestionIds,
+  isExamOverdue,
+} from '@/app/app/quiz/actions/_overdue-helpers'
+import { rpc } from '@/lib/supabase-rpc'
+
+export type ActiveInternalExamSession = {
+  sessionId: string
+  subjectId: string
+  subjectName: string
+  subjectCode: string
+  startedAt: string
+  timeLimitSeconds: number
+  passMark: number
+  questionIds: string[]
+}
+
+export type GetActiveInternalExamSessionResult =
+  | {
+      success: true
+      sessions: ActiveInternalExamSession[]
+      orphanedSessionIds: string[]
+      expiredSessionIds: string[]
+    }
+  | { success: false; error: string }
+
+export async function getActiveInternalExamSession(): Promise<GetActiveInternalExamSessionResult> {
+  try {
+    const supabase = await createServerSupabaseClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) return { success: false, error: 'Not authenticated' }
+
+    const { data, error } = await supabase
+      .from('quiz_sessions')
+      .select('id, subject_id, started_at, time_limit_seconds, config, easa_subjects(name, short)')
+      .eq('student_id', user.id)
+      .is('ended_at', null)
+      .is('deleted_at', null)
+      .eq('mode', 'internal_exam')
+      .order('started_at', { ascending: false })
+
+    if (error) {
+      console.error('[getActiveInternalExamSession] Query error:', error.message)
+      return { success: false, error: 'Failed to fetch active internal exam sessions.' }
+    }
+
+    const sessions: ActiveInternalExamSession[] = []
+    const orphanedSessionIds: string[] = []
+    const expiredSessionIds: string[] = []
+    for (const row of data ?? []) {
+      const questionIds = extractQuestionIds(row.config)
+      const passMark = extractPassMark(row.config)
+      if (!questionIds || passMark === null) {
+        const reason = !questionIds ? 'malformed questionIds' : 'malformed pass_mark'
+        console.error(`[getActiveInternalExamSession] Skipping row (${reason}):`, row.id)
+        orphanedSessionIds.push(row.id)
+        continue
+      }
+      const timeLimitSeconds = row.time_limit_seconds ?? 0
+      if (isExamOverdue(row.started_at, timeLimitSeconds)) {
+        const { error: rpcErr } = await rpc<unknown>(supabase, 'complete_overdue_exam_session', {
+          p_session_id: row.id,
+        })
+        if (rpcErr) {
+          // Auto-complete failed: route to orphanedSessionIds so the discard-only
+          // banner handles it (mirrors get-active-exam-session.ts).
+          const log = '[getActiveInternalExamSession] Auto-complete failed:'
+          console.error(log, row.id, rpcErr.message)
+          orphanedSessionIds.push(row.id)
+          continue
+        }
+        expiredSessionIds.push(row.id)
+        continue
+      }
+      const rel = row.easa_subjects as { name?: unknown; short?: unknown } | null
+      sessions.push({
+        sessionId: row.id,
+        subjectId: row.subject_id ?? '',
+        subjectName: typeof rel?.name === 'string' ? rel.name : 'Unknown subject',
+        subjectCode: typeof rel?.short === 'string' ? rel.short : '',
+        startedAt: row.started_at,
+        timeLimitSeconds,
+        passMark,
+        questionIds,
+      })
+    }
+
+    return { success: true, sessions, orphanedSessionIds, expiredSessionIds }
+  } catch (err) {
+    console.error('[getActiveInternalExamSession] Uncaught error:', err)
+    return { success: false, error: 'Something went wrong. Please try again.' }
+  }
+}

--- a/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts
+++ b/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts
@@ -75,7 +75,30 @@ export async function getActiveInternalExamSession(): Promise<GetActiveInternalE
         orphanedSessionIds.push(row.id)
         continue
       }
-      const timeLimitSeconds = row.time_limit_seconds ?? 0
+      // Defensive: a row with non-positive/non-integer time_limit_seconds or an
+      // unparseable started_at can't be evaluated by isExamOverdue. Internal
+      // exam mode has no discard path, so a stranded row would lock the
+      // student into a non-expiring official attempt. Quarantine instead.
+      const rawTimeLimit = row.time_limit_seconds
+      if (
+        typeof rawTimeLimit !== 'number' ||
+        !Number.isFinite(rawTimeLimit) ||
+        rawTimeLimit <= 0 ||
+        !Number.isInteger(rawTimeLimit)
+      ) {
+        console.error(
+          '[getActiveInternalExamSession] Skipping row (invalid time_limit_seconds):',
+          row.id,
+        )
+        orphanedSessionIds.push(row.id)
+        continue
+      }
+      if (typeof row.started_at !== 'string' || Number.isNaN(Date.parse(row.started_at))) {
+        console.error('[getActiveInternalExamSession] Skipping row (invalid started_at):', row.id)
+        orphanedSessionIds.push(row.id)
+        continue
+      }
+      const timeLimitSeconds = rawTimeLimit
       if (isExamOverdue(row.started_at, timeLimitSeconds)) {
         const { error: rpcErr } = await rpc<unknown>(supabase, 'complete_overdue_exam_session', {
           p_session_id: row.id,

--- a/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts
+++ b/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts
@@ -37,10 +37,22 @@ export async function getActiveInternalExamSession(): Promise<GetActiveInternalE
     } = await supabase.auth.getUser()
     if (authError || !user) return { success: false, error: 'Not authenticated' }
 
+    const { data: userRow, error: userErr } = await supabase
+      .from('users')
+      .select('organization_id')
+      .eq('id', user.id)
+      .is('deleted_at', null)
+      .maybeSingle()
+    if (userErr || !userRow?.organization_id) {
+      console.error('[getActiveInternalExamSession] User lookup error:', userErr?.message)
+      return { success: false, error: 'Failed to fetch active internal exam sessions.' }
+    }
+
     const { data, error } = await supabase
       .from('quiz_sessions')
       .select('id, subject_id, started_at, time_limit_seconds, config, easa_subjects(name, short)')
       .eq('student_id', user.id)
+      .eq('organization_id', userRow.organization_id)
       .is('ended_at', null)
       .is('deleted_at', null)
       .eq('mode', 'internal_exam')

--- a/apps/web/app/app/internal-exam/actions/start-internal-exam.test.ts
+++ b/apps/web/app/app/internal-exam/actions/start-internal-exam.test.ts
@@ -166,6 +166,29 @@ describe('startInternalExam — RPC error messages', () => {
     expect(result.error).toBe('Cannot start exam: not enough questions configured.')
   })
 
+  it('tells the student no exam config is set up when exam_config_required is returned', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'exam_config_required' } })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe(
+      'No exam configuration available for this subject. Please contact your administrator.',
+    )
+  })
+
+  it('tells the student their account is inactive when the RPC raises user not found or inactive', async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { message: 'user not found or inactive' },
+    })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe(
+      'Your account is no longer active. Please contact your administrator.',
+    )
+  })
+
   it('returns a generic failure for an unknown RPC error', async () => {
     mockRpc.mockResolvedValue({ data: null, error: { message: 'unexpected db failure' } })
     const result = await startInternalExam({ code: VALID_CODE })

--- a/apps/web/app/app/internal-exam/actions/start-internal-exam.test.ts
+++ b/apps/web/app/app/internal-exam/actions/start-internal-exam.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const { mockGetUser, mockRpc } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockRpc: vi.fn(),
+}))
+
+vi.mock('@repo/db/server', () => ({
+  createServerSupabaseClient: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@/lib/supabase-rpc', () => ({
+  rpc: mockRpc,
+}))
+
+// ---- Subject under test ---------------------------------------------------
+
+import { startInternalExam } from './start-internal-exam'
+
+// ---- Fixtures -------------------------------------------------------------
+
+const VALID_CODE = 'ABC12345'
+const VALID_SESSION_ID = '00000000-0000-4000-a000-000000000010'
+const VALID_QUESTION_IDS = [
+  '00000000-0000-4000-a000-000000000020',
+  '00000000-0000-4000-a000-000000000021',
+]
+
+const RPC_SUCCESS_ROW = {
+  session_id: VALID_SESSION_ID,
+  question_ids: VALID_QUESTION_IDS,
+  time_limit_seconds: 3600,
+  total_questions: 2,
+  pass_mark: 75,
+  started_at: '2026-04-29T12:00:00.000Z',
+}
+
+// ---- Lifecycle ------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+// ---- Auth -----------------------------------------------------------------
+
+describe('startInternalExam — authentication', () => {
+  it('returns failure when the user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Not authenticated')
+  })
+
+  it('returns failure when authentication returns an error', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'session expired' },
+    })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Not authenticated')
+  })
+})
+
+// ---- Input validation -----------------------------------------------------
+
+describe('startInternalExam — input validation', () => {
+  beforeEach(() => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+  })
+
+  it('returns failure when code is missing', async () => {
+    const result = await startInternalExam({})
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Invalid input')
+  })
+
+  it('returns failure when code is empty', async () => {
+    const result = await startInternalExam({ code: '' })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Invalid input')
+  })
+
+  it('returns failure when input is null', async () => {
+    const result = await startInternalExam(null)
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Invalid input')
+  })
+})
+
+// ---- RPC error handling ---------------------------------------------------
+
+describe('startInternalExam — RPC error messages', () => {
+  beforeEach(() => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+  })
+
+  it('maps code_not_found to a unified generic message', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'code_not_found' } })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Invalid or expired code. Please contact your administrator.')
+  })
+
+  it('maps code_not_yours to the same unified message as code_not_found', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'code_not_yours' } })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    // Must NOT reveal that the code exists for a different student.
+    expect(result.error).toBe('Invalid or expired code. Please contact your administrator.')
+  })
+
+  it('maps code_expired to a domain-specific message', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'code_expired' } })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('This code has expired. Please contact your administrator.')
+  })
+
+  it('maps code_already_used to a domain-specific message', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'code_already_used' } })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('This code has already been used.')
+  })
+
+  it('maps code_voided to a domain-specific message', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'code_voided' } })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('This code has been cancelled. Please contact your administrator.')
+  })
+
+  it('maps active_session_exists to a domain-specific message', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'active_session_exists' } })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe(
+      'You already have an active internal exam session for this subject. Submit it before starting a new one.',
+    )
+  })
+
+  it('maps insufficient_questions_for_exam to a domain-specific message', async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { message: 'insufficient_questions_for_exam' },
+    })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Cannot start exam: not enough questions configured.')
+  })
+
+  it('returns a generic failure for an unknown RPC error', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'unexpected db failure' } })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Failed to start internal exam.')
+  })
+
+  it('logs server-side and returns generic message; never returns raw DB error string', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      mockRpc.mockResolvedValue({
+        data: null,
+        error: { message: 'connection to db@1.2.3.4 refused' },
+      })
+      const result = await startInternalExam({ code: VALID_CODE })
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error).not.toContain('1.2.3.4')
+      expect(consoleSpy).toHaveBeenCalled()
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+})
+
+// ---- RPC payload validation ----------------------------------------------
+
+describe('startInternalExam — RPC payload validation', () => {
+  beforeEach(() => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+  })
+
+  it('returns failure when RPC returns null data without an error', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: null })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Failed to start internal exam.')
+  })
+
+  it('returns failure when RPC payload is missing session_id', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      mockRpc.mockResolvedValue({
+        data: [{ ...RPC_SUCCESS_ROW, session_id: undefined }],
+        error: null,
+      })
+      const result = await startInternalExam({ code: VALID_CODE })
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error).toBe('Failed to start internal exam.')
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[startInternalExam] Invalid RPC payload, fields:',
+        expect.arrayContaining(['session_id']),
+      )
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+
+  it('rejects pass_mark = 0', async () => {
+    mockRpc.mockResolvedValue({
+      data: [{ ...RPC_SUCCESS_ROW, pass_mark: 0 }],
+      error: null,
+    })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe('Failed to start internal exam.')
+  })
+})
+
+// ---- Happy path -----------------------------------------------------------
+
+describe('startInternalExam — happy path', () => {
+  beforeEach(() => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+  })
+
+  it('returns sessionId on success when RPC returns a TABLE (array)', async () => {
+    mockRpc.mockResolvedValue({ data: [RPC_SUCCESS_ROW], error: null })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.sessionId).toBe(VALID_SESSION_ID)
+  })
+
+  it('handles RPC returning a single object (not wrapped in array)', async () => {
+    mockRpc.mockResolvedValue({ data: RPC_SUCCESS_ROW, error: null })
+    const result = await startInternalExam({ code: VALID_CODE })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.sessionId).toBe(VALID_SESSION_ID)
+  })
+
+  it('passes p_code to start_internal_exam_session RPC', async () => {
+    mockRpc.mockResolvedValue({ data: [RPC_SUCCESS_ROW], error: null })
+    await startInternalExam({ code: VALID_CODE })
+    expect(mockRpc).toHaveBeenCalledWith(expect.anything(), 'start_internal_exam_session', {
+      p_code: VALID_CODE,
+    })
+  })
+})
+
+// ---- Uncaught errors ------------------------------------------------------
+
+describe('startInternalExam — uncaught errors', () => {
+  it('returns a generic error and logs when an unexpected exception is thrown', async () => {
+    mockGetUser.mockRejectedValue(new Error('network failure'))
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const result = await startInternalExam({ code: VALID_CODE })
+      expect(result.success).toBe(false)
+      if (!result.success) expect(result.error).toBe('Something went wrong. Please try again.')
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[startInternalExam] Uncaught error:',
+        expect.any(Error),
+      )
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+})

--- a/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
+++ b/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
@@ -12,7 +12,6 @@ const RpcRowSchema = z.object({
   session_id: z.uuid(),
   question_ids: z.array(z.uuid()),
   time_limit_seconds: z.number().int().positive(),
-  total_questions: z.number().int().positive(),
   pass_mark: z.number().int().min(1).max(100),
   started_at: z.string(),
 })

--- a/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
+++ b/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
@@ -20,7 +20,14 @@ const RpcRowSchema = z.object({
 type RpcRow = z.infer<typeof RpcRowSchema>
 
 export type StartInternalExamResult =
-  | { success: true; sessionId: string }
+  | {
+      success: true
+      sessionId: string
+      questionIds: string[]
+      timeLimitSeconds: number
+      passMark: number
+      startedAt: string
+    }
   | { success: false; error: string }
 
 const ERROR_MESSAGES: Array<[string, string]> = [
@@ -78,7 +85,14 @@ export async function startInternalExam(raw: unknown): Promise<StartInternalExam
     }
 
     const result: RpcRow = rowParsed.data
-    return { success: true, sessionId: result.session_id }
+    return {
+      success: true,
+      sessionId: result.session_id,
+      questionIds: result.question_ids,
+      timeLimitSeconds: result.time_limit_seconds,
+      passMark: result.pass_mark,
+      startedAt: result.started_at,
+    }
   } catch (err) {
     console.error('[startInternalExam] Uncaught error:', err)
     return { success: false, error: 'Something went wrong. Please try again.' }

--- a/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
+++ b/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
@@ -1,0 +1,86 @@
+'use server'
+
+import { createServerSupabaseClient } from '@repo/db/server'
+import { z } from 'zod'
+import { rpc } from '@/lib/supabase-rpc'
+
+const StartInternalExamInput = z.object({
+  code: z.string().min(1).max(64),
+})
+
+const RpcRowSchema = z.object({
+  session_id: z.uuid(),
+  question_ids: z.array(z.uuid()),
+  time_limit_seconds: z.number().int().positive(),
+  total_questions: z.number().int().positive(),
+  pass_mark: z.number().int().min(1).max(100),
+  started_at: z.string(),
+})
+
+type RpcRow = z.infer<typeof RpcRowSchema>
+
+export type StartInternalExamResult =
+  | { success: true; sessionId: string }
+  | { success: false; error: string }
+
+const ERROR_MESSAGES: Array<[string, string]> = [
+  ['not_authenticated', 'Not authenticated'],
+  // UNIFIED — never reveal whether the code exists for a different student.
+  ['code_not_found', 'Invalid or expired code. Please contact your administrator.'],
+  ['code_not_yours', 'Invalid or expired code. Please contact your administrator.'],
+  ['code_expired', 'This code has expired. Please contact your administrator.'],
+  ['code_already_used', 'This code has already been used.'],
+  ['code_voided', 'This code has been cancelled. Please contact your administrator.'],
+  [
+    'active_session_exists',
+    'You already have an active internal exam session for this subject. Submit it before starting a new one.',
+  ],
+  ['insufficient_questions_for_exam', 'Cannot start exam: not enough questions configured.'],
+]
+
+function mapRpcError(message: string): string {
+  for (const [token, friendly] of ERROR_MESSAGES) {
+    if (message.includes(token)) return friendly
+  }
+  return 'Failed to start internal exam.'
+}
+
+export async function startInternalExam(raw: unknown): Promise<StartInternalExamResult> {
+  try {
+    const supabase = await createServerSupabaseClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) return { success: false, error: 'Not authenticated' }
+
+    const parsed = StartInternalExamInput.safeParse(raw)
+    if (!parsed.success) {
+      console.error('[startInternalExam] Invalid input')
+      return { success: false, error: 'Invalid input' }
+    }
+
+    const { data, error } = await rpc<unknown>(supabase, 'start_internal_exam_session', {
+      p_code: parsed.data.code,
+    })
+
+    if (error) {
+      console.error('[startInternalExam] RPC error:', error.message)
+      return { success: false, error: mapRpcError(error.message) }
+    }
+
+    const row: unknown = Array.isArray(data) ? data[0] : data
+    const rowParsed = RpcRowSchema.safeParse(row)
+    if (!rowParsed.success) {
+      const failedFields = rowParsed.error.issues.map((i) => i.path.join('.'))
+      console.error('[startInternalExam] Invalid RPC payload, fields:', failedFields)
+      return { success: false, error: 'Failed to start internal exam.' }
+    }
+
+    const result: RpcRow = rowParsed.data
+    return { success: true, sessionId: result.session_id }
+  } catch (err) {
+    console.error('[startInternalExam] Uncaught error:', err)
+    return { success: false, error: 'Something went wrong. Please try again.' }
+  }
+}

--- a/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
+++ b/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
@@ -42,6 +42,15 @@ const ERROR_MESSAGES: Array<[string, string]> = [
     'You already have an active internal exam session for this subject. Submit it before starting a new one.',
   ],
   ['insufficient_questions_for_exam', 'Cannot start exam: not enough questions configured.'],
+  [
+    'exam_config_required',
+    'No exam configuration available for this subject. Please contact your administrator.',
+  ],
+  // Token text is the literal RAISE EXCEPTION string from mig 070/071, with spaces.
+  [
+    'user not found or inactive',
+    'Your account is no longer active. Please contact your administrator.',
+  ],
 ]
 
 function mapRpcError(message: string): string {

--- a/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
+++ b/apps/web/app/app/internal-exam/actions/start-internal-exam.ts
@@ -3,6 +3,7 @@
 import { createServerSupabaseClient } from '@repo/db/server'
 import { z } from 'zod'
 import { rpc } from '@/lib/supabase-rpc'
+import { START_INTERNAL_EXAM_ERROR_MESSAGES } from './_error-messages'
 
 const StartInternalExamInput = z.object({
   code: z.string().min(1).max(64),
@@ -29,32 +30,8 @@ export type StartInternalExamResult =
     }
   | { success: false; error: string }
 
-const ERROR_MESSAGES: Array<[string, string]> = [
-  ['not_authenticated', 'Not authenticated'],
-  // UNIFIED — never reveal whether the code exists for a different student.
-  ['code_not_found', 'Invalid or expired code. Please contact your administrator.'],
-  ['code_not_yours', 'Invalid or expired code. Please contact your administrator.'],
-  ['code_expired', 'This code has expired. Please contact your administrator.'],
-  ['code_already_used', 'This code has already been used.'],
-  ['code_voided', 'This code has been cancelled. Please contact your administrator.'],
-  [
-    'active_session_exists',
-    'You already have an active internal exam session for this subject. Submit it before starting a new one.',
-  ],
-  ['insufficient_questions_for_exam', 'Cannot start exam: not enough questions configured.'],
-  [
-    'exam_config_required',
-    'No exam configuration available for this subject. Please contact your administrator.',
-  ],
-  // Token text is the literal RAISE EXCEPTION string from mig 070/071, with spaces.
-  [
-    'user not found or inactive',
-    'Your account is no longer active. Please contact your administrator.',
-  ],
-]
-
 function mapRpcError(message: string): string {
-  for (const [token, friendly] of ERROR_MESSAGES) {
+  for (const [token, friendly] of START_INTERNAL_EXAM_ERROR_MESSAGES) {
     if (message.includes(token)) return friendly
   }
   return 'Failed to start internal exam.'

--- a/apps/web/app/app/internal-exam/page.tsx
+++ b/apps/web/app/app/internal-exam/page.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react'
+import { requireAuthUser } from '@/lib/auth/require-auth-user'
+import { InternalExamContent } from './_components/internal-exam-content'
+
+export const dynamic = 'force-dynamic'
+
+export default async function InternalExamPage() {
+  const user = await requireAuthUser()
+
+  return (
+    <main className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Internal Exam</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Enter the code from your administrator to begin a supervised internal exam.
+        </p>
+      </div>
+      <Suspense fallback={<InternalExamFallback />}>
+        <InternalExamContent userId={user.id} />
+      </Suspense>
+    </main>
+  )
+}
+
+function InternalExamFallback() {
+  return (
+    <div className="grid gap-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
+        <div key={i} className="h-20 animate-pulse rounded-lg bg-muted" />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/app/app/internal-exam/queries.test.ts
+++ b/apps/web/app/app/internal-exam/queries.test.ts
@@ -1,0 +1,363 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+}))
+
+vi.mock('@repo/db/server', () => ({
+  createServerSupabaseClient: async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  }),
+}))
+
+// ---- Subject under test ---------------------------------------------------
+
+import { listAvailableInternalExams, listMyInternalExamHistory } from './queries'
+
+// ---- Helpers --------------------------------------------------------------
+
+function buildChain(returnValue: unknown) {
+  const awaitable = {
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable for Supabase chain mock
+    then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+      Promise.resolve(returnValue).then(resolve, reject),
+  }
+  return new Proxy(awaitable as Record<string, unknown>, {
+    get(target, prop) {
+      if (prop === 'then') return target.then
+      return (..._args: unknown[]) => buildChain(returnValue)
+    },
+  })
+}
+
+function mockFromSequence(...returnValues: unknown[]) {
+  let i = 0
+  mockFrom.mockImplementation(() => {
+    const v = returnValues[Math.min(i, returnValues.length - 1)]
+    i++
+    return buildChain(v)
+  })
+}
+
+// ---- Lifecycle ------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+})
+
+// ---- listAvailableInternalExams ------------------------------------------
+
+describe('listAvailableInternalExams', () => {
+  it('returns an empty array when no user is authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null })
+    const result = await listAvailableInternalExams()
+    expect(result).toEqual([])
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('returns mapped rows omitting the code value', async () => {
+    mockFrom.mockReturnValue(
+      buildChain({
+        data: [
+          {
+            id: 'code-1',
+            subject_id: 'sub-1',
+            expires_at: '2026-05-01T12:00:00.000Z',
+            issued_at: '2026-04-29T12:00:00.000Z',
+            easa_subjects: { name: 'Air Law', short: 'ALW' },
+          },
+        ],
+        error: null,
+      }),
+    )
+
+    const result = await listAvailableInternalExams()
+
+    expect(result).toEqual([
+      {
+        id: 'code-1',
+        subjectId: 'sub-1',
+        subjectName: 'Air Law',
+        subjectShort: 'ALW',
+        expiresAt: '2026-05-01T12:00:00.000Z',
+        issuedAt: '2026-04-29T12:00:00.000Z',
+      },
+    ])
+    // Privileged: code value must never be on the returned objects
+    for (const entry of result) {
+      expect(Object.keys(entry)).not.toContain('code')
+    }
+  })
+
+  it('NEVER returns the code value even if the row contains one (defense-in-depth)', async () => {
+    mockFrom.mockReturnValue(
+      buildChain({
+        data: [
+          {
+            id: 'code-1',
+            // Even if a future schema change leaks `code` into the row, the
+            // mapper must not expose it.
+            code: 'SECRET-XYZ',
+            subject_id: 'sub-1',
+            expires_at: '2026-05-01T12:00:00.000Z',
+            issued_at: '2026-04-29T12:00:00.000Z',
+            easa_subjects: { name: 'Air Law', short: 'ALW' },
+          },
+        ],
+        error: null,
+      }),
+    )
+
+    const result = await listAvailableInternalExams()
+
+    expect(result).toHaveLength(1)
+    // The privileged code value must NOT appear anywhere in the serialized result.
+    expect(JSON.stringify(result)).not.toContain('SECRET-XYZ')
+    const entry = result[0]
+    expect(entry).toBeDefined()
+    if (!entry) return
+    // The returned shape is fixed and intentionally omits `code`.
+    expect(Object.keys(entry).sort()).toEqual(
+      ['id', 'subjectId', 'subjectName', 'subjectShort', 'expiresAt', 'issuedAt'].sort(),
+    )
+  })
+
+  it('queries the internal_exam_codes table', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    await listAvailableInternalExams()
+    expect(mockFrom).toHaveBeenCalledWith('internal_exam_codes')
+  })
+
+  it('falls back to "Unknown subject" when easa_subjects is null', async () => {
+    mockFrom.mockReturnValue(
+      buildChain({
+        data: [
+          {
+            id: 'code-2',
+            subject_id: 'sub-2',
+            expires_at: '2026-05-01T12:00:00.000Z',
+            issued_at: '2026-04-29T12:00:00.000Z',
+            easa_subjects: null,
+          },
+        ],
+        error: null,
+      }),
+    )
+
+    const result = await listAvailableInternalExams()
+    expect(result[0]?.subjectName).toBe('Unknown subject')
+    expect(result[0]?.subjectShort).toBe('')
+  })
+
+  it('returns an empty array on query error and logs', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    try {
+      mockFrom.mockReturnValue(buildChain({ data: null, error: { message: 'boom' } }))
+      const result = await listAvailableInternalExams()
+      expect(result).toEqual([])
+      expect(consoleSpy).toHaveBeenCalledWith('[listAvailableInternalExams] Query error:', 'boom')
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+
+  it('returns an empty array when data is null', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: null, error: null }))
+    const result = await listAvailableInternalExams()
+    expect(result).toEqual([])
+  })
+})
+
+// ---- listMyInternalExamHistory --------------------------------------------
+
+describe('listMyInternalExamHistory', () => {
+  it('returns an empty array when no user is authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null })
+    const result = await listMyInternalExamHistory()
+    expect(result).toEqual([])
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('returns sessions sorted newest-first, with attemptNumber computed per subject (1=oldest)', async () => {
+    mockFromSequence(
+      {
+        data: [
+          // Newest first (already DESC). Two attempts on subject A, one on subject B.
+          {
+            id: 'sess-3',
+            subject_id: 'sub-A',
+            started_at: '2026-04-29T15:00:00.000Z',
+            ended_at: '2026-04-29T16:00:00.000Z',
+            score_percentage: 80,
+            passed: true,
+            total_questions: 10,
+            easa_subjects: { name: 'Air Law', short: 'ALW' },
+          },
+          {
+            id: 'sess-2',
+            subject_id: 'sub-B',
+            started_at: '2026-04-28T15:00:00.000Z',
+            ended_at: '2026-04-28T16:00:00.000Z',
+            score_percentage: 60,
+            passed: false,
+            total_questions: 10,
+            easa_subjects: { name: 'Met', short: 'MET' },
+          },
+          {
+            id: 'sess-1',
+            subject_id: 'sub-A',
+            started_at: '2026-04-27T15:00:00.000Z',
+            ended_at: '2026-04-27T16:00:00.000Z',
+            score_percentage: 50,
+            passed: false,
+            total_questions: 10,
+            easa_subjects: { name: 'Air Law', short: 'ALW' },
+          },
+        ],
+        error: null,
+      },
+      {
+        data: [
+          { session_id: 'sess-1' },
+          { session_id: 'sess-1' },
+          { session_id: 'sess-1' },
+          { session_id: 'sess-2' },
+          { session_id: 'sess-3' },
+          { session_id: 'sess-3' },
+        ],
+        error: null,
+      },
+    )
+
+    const result = await listMyInternalExamHistory()
+
+    expect(result.map((r) => r.id)).toEqual(['sess-3', 'sess-2', 'sess-1'])
+    // Attempt numbers: sess-1 is the oldest sub-A attempt → 1; sess-3 is the
+    // newer sub-A attempt → 2; sess-2 is the only sub-B attempt → 1.
+    const byId = new Map(result.map((r) => [r.id, r]))
+    expect(byId.get('sess-1')?.attemptNumber).toBe(1)
+    expect(byId.get('sess-3')?.attemptNumber).toBe(2)
+    expect(byId.get('sess-2')?.attemptNumber).toBe(1)
+    expect(byId.get('sess-1')?.answeredCount).toBe(3)
+    expect(byId.get('sess-2')?.answeredCount).toBe(1)
+    expect(byId.get('sess-3')?.answeredCount).toBe(2)
+    expect(byId.get('sess-3')?.passed).toBe(true)
+    expect(byId.get('sess-3')?.scorePercentage).toBe(80)
+    expect(byId.get('sess-3')?.subjectName).toBe('Air Law')
+    expect(byId.get('sess-3')?.subjectShort).toBe('ALW')
+  })
+
+  it('returns answeredCount=0 when no answers are returned for a session', async () => {
+    mockFromSequence(
+      {
+        data: [
+          {
+            id: 'sess-x',
+            subject_id: 'sub-x',
+            started_at: '2026-04-29T15:00:00.000Z',
+            ended_at: null,
+            score_percentage: null,
+            passed: null,
+            total_questions: 10,
+            easa_subjects: { name: 'X', short: 'X' },
+          },
+        ],
+        error: null,
+      },
+      { data: [], error: null },
+    )
+
+    const result = await listMyInternalExamHistory()
+    expect(result).toHaveLength(1)
+    expect(result[0]?.answeredCount).toBe(0)
+    expect(result[0]?.passed).toBe(null)
+  })
+
+  it('returns an empty array when no internal exam sessions exist', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    const result = await listMyInternalExamHistory()
+    expect(result).toEqual([])
+  })
+
+  it('returns an empty array on session query error', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    try {
+      mockFrom.mockReturnValue(buildChain({ data: null, error: { message: 'boom' } }))
+      const result = await listMyInternalExamHistory()
+      expect(result).toEqual([])
+      expect(consoleSpy).toHaveBeenCalledWith('[listMyInternalExamHistory] Query error:', 'boom')
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+
+  it('queries the quiz_sessions table first', async () => {
+    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    await listMyInternalExamHistory()
+    expect(mockFrom).toHaveBeenCalledWith('quiz_sessions')
+  })
+
+  it('falls back to "Unknown subject" when easa_subjects is null', async () => {
+    mockFromSequence(
+      {
+        data: [
+          {
+            id: 'sess-y',
+            subject_id: 'sub-y',
+            started_at: '2026-04-29T15:00:00.000Z',
+            ended_at: '2026-04-29T16:00:00.000Z',
+            score_percentage: 75,
+            passed: true,
+            total_questions: 10,
+            easa_subjects: null,
+          },
+        ],
+        error: null,
+      },
+      { data: [], error: null },
+    )
+
+    const result = await listMyInternalExamHistory()
+    expect(result[0]?.subjectName).toBe('Unknown subject')
+    expect(result[0]?.subjectShort).toBe('')
+  })
+
+  it('still returns sessions even when answers query errors (degrades gracefully)', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    try {
+      mockFromSequence(
+        {
+          data: [
+            {
+              id: 'sess-z',
+              subject_id: 'sub-z',
+              started_at: '2026-04-29T15:00:00.000Z',
+              ended_at: '2026-04-29T16:00:00.000Z',
+              score_percentage: 80,
+              passed: true,
+              total_questions: 10,
+              easa_subjects: { name: 'Z', short: 'Z' },
+            },
+          ],
+          error: null,
+        },
+        { data: null, error: { message: 'answers boom' } },
+      )
+
+      const result = await listMyInternalExamHistory()
+      expect(result).toHaveLength(1)
+      expect(result[0]?.answeredCount).toBe(0)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[listMyInternalExamHistory] Answers query error:',
+        'answers boom',
+      )
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+})

--- a/apps/web/app/app/internal-exam/queries.ts
+++ b/apps/web/app/app/internal-exam/queries.ts
@@ -1,0 +1,200 @@
+import { createServerSupabaseClient } from '@repo/db/server'
+
+// SECURITY: code values are NEVER returned from this query. Admin distributes
+// codes out-of-band; student types via the redemption modal. Shape omits `code`.
+export type AvailableInternalExam = {
+  id: string
+  subjectId: string
+  subjectName: string
+  subjectShort: string
+  expiresAt: string
+  issuedAt: string
+}
+
+export type InternalExamHistoryEntry = {
+  id: string
+  subjectId: string
+  subjectName: string
+  subjectShort: string
+  startedAt: string
+  endedAt: string | null
+  scorePercentage: number | null
+  passed: boolean | null
+  totalQuestions: number
+  answeredCount: number
+  attemptNumber: number
+}
+
+type SubjectRel = { name?: unknown; short?: unknown } | null
+
+function readSubjectField(rel: SubjectRel, field: 'name' | 'short'): string {
+  const value = rel?.[field]
+  return typeof value === 'string' ? value : ''
+}
+
+// internal_exam_codes is not in generated types; mirror admin/internal-exams/queries.ts.
+type ChainBuilder = {
+  select: (cols: string) => ChainBuilder
+  eq: (col: string, val: unknown) => ChainBuilder
+  is: (col: string, val: unknown) => ChainBuilder
+  gt: (col: string, val: unknown) => ChainBuilder
+  in: (col: string, values: unknown[]) => ChainBuilder
+  order: (col: string, opts: { ascending: boolean }) => ChainBuilder
+  limit: (n: number) => ChainBuilder
+}
+
+type AnyClient = { from: (t: string) => ChainBuilder }
+
+type QueryResult = { data: unknown; error: { message: string } | null }
+async function runQuery(builder: ChainBuilder): Promise<QueryResult> {
+  return (await (builder as unknown as PromiseLike<QueryResult>)) ?? { data: null, error: null }
+}
+
+type AvailableRow = {
+  id: string
+  subject_id: string
+  expires_at: string
+  issued_at: string
+  easa_subjects: SubjectRel
+}
+
+type SessionRow = {
+  id: string
+  subject_id: string | null
+  started_at: string
+  ended_at: string | null
+  score_percentage: number | null
+  passed: boolean | null
+  total_questions: number
+  easa_subjects: SubjectRel
+}
+
+type AnswerRow = { session_id: string | null }
+
+/**
+ * Returns the current student's unconsumed, unvoided, unexpired internal-exam
+ * codes. NEVER returns the code value itself — that is a privileged secret the
+ * admin gives to the student out-of-band.
+ */
+export async function listAvailableInternalExams(): Promise<AvailableInternalExam[]> {
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return []
+
+  const client = supabase as unknown as AnyClient
+  const builder = client
+    .from('internal_exam_codes')
+    .select('id, subject_id, expires_at, issued_at, easa_subjects(name, short)')
+    .eq('student_id', user.id)
+    .is('consumed_at', null)
+    .is('voided_at', null)
+    .gt('expires_at', new Date().toISOString())
+    .is('deleted_at', null)
+    .order('expires_at', { ascending: true })
+    .limit(100)
+
+  const { data, error } = await runQuery(builder)
+  if (error) {
+    console.error('[listAvailableInternalExams] Query error:', error.message)
+    return []
+  }
+
+  const rows = Array.isArray(data) ? (data as AvailableRow[]) : []
+  return rows.map((row) => ({
+    id: row.id,
+    subjectId: row.subject_id,
+    subjectName: readSubjectField(row.easa_subjects, 'name') || 'Unknown subject',
+    subjectShort: readSubjectField(row.easa_subjects, 'short'),
+    expiresAt: row.expires_at,
+    issuedAt: row.issued_at,
+  }))
+}
+
+/**
+ * Computes per-subject 1-indexed attempt numbers in TS from started_at order.
+ * attemptNumber=1 is the OLDEST attempt for that subject.
+ */
+function computeAttemptNumbers(rows: SessionRow[]): Map<string, number> {
+  // Sort ascending so attempt 1 = oldest. Group by subject.
+  const ascending = [...rows].sort((a, b) =>
+    a.started_at < b.started_at ? -1 : a.started_at > b.started_at ? 1 : 0,
+  )
+  const counters = new Map<string, number>()
+  const result = new Map<string, number>()
+  for (const row of ascending) {
+    const key = row.subject_id ?? '__no_subject__'
+    const next = (counters.get(key) ?? 0) + 1
+    counters.set(key, next)
+    result.set(row.id, next)
+  }
+  return result
+}
+
+/**
+ * Returns the current student's internal-exam session history, newest first.
+ * `attemptNumber` is computed per subject (1 = oldest attempt for that subject).
+ */
+export async function listMyInternalExamHistory(): Promise<InternalExamHistoryEntry[]> {
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return []
+
+  const client = supabase as unknown as AnyClient
+  const sessionBuilder = client
+    .from('quiz_sessions')
+    .select(
+      'id, subject_id, started_at, ended_at, score_percentage, passed, total_questions, easa_subjects(name, short)',
+    )
+    .eq('student_id', user.id)
+    .eq('mode', 'internal_exam')
+    .is('deleted_at', null)
+    .order('started_at', { ascending: false })
+    .limit(200)
+
+  const { data: sessionData, error: sessionError } = await runQuery(sessionBuilder)
+  if (sessionError) {
+    console.error('[listMyInternalExamHistory] Query error:', sessionError.message)
+    return []
+  }
+
+  const rows = Array.isArray(sessionData) ? (sessionData as SessionRow[]) : []
+  if (rows.length === 0) return []
+
+  const attemptByRow = computeAttemptNumbers(rows)
+
+  const sessionIds = rows.map((r) => r.id)
+  const answersBuilder = client
+    .from('quiz_session_answers')
+    .select('session_id')
+    .in('session_id', sessionIds)
+
+  const { data: answersData, error: answersError } = await runQuery(answersBuilder)
+  if (answersError) {
+    console.error('[listMyInternalExamHistory] Answers query error:', answersError.message)
+  }
+
+  const answeredBySession = new Map<string, number>()
+  const answers = Array.isArray(answersData) ? (answersData as AnswerRow[]) : []
+  for (const a of answers) {
+    if (!a.session_id) continue
+    answeredBySession.set(a.session_id, (answeredBySession.get(a.session_id) ?? 0) + 1)
+  }
+
+  return rows.map((row) => ({
+    id: row.id,
+    subjectId: row.subject_id ?? '',
+    subjectName: readSubjectField(row.easa_subjects, 'name') || 'Unknown subject',
+    subjectShort: readSubjectField(row.easa_subjects, 'short'),
+    startedAt: row.started_at,
+    endedAt: row.ended_at,
+    scorePercentage: row.score_percentage,
+    passed: row.passed,
+    totalQuestions: row.total_questions,
+    answeredCount: answeredBySession.get(row.id) ?? 0,
+    attemptNumber: attemptByRow.get(row.id) ?? 1,
+  }))
+}

--- a/apps/web/app/app/internal-exam/report/_components/report-footer.test.tsx
+++ b/apps/web/app/app/internal-exam/report/_components/report-footer.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string
+    children: React.ReactNode
+    className?: string
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+import { ReportFooter } from './report-footer'
+
+describe('ReportFooter', () => {
+  it('renders a link back to the internal exam reports tab', () => {
+    render(<ReportFooter />)
+    const link = screen.getByRole('link', { name: /back to internal exam reports/i })
+    expect(link).toBeInTheDocument()
+  })
+
+  it('points to the internal exam reports tab URL', () => {
+    render(<ReportFooter />)
+    const link = screen.getByRole('link', { name: /back to internal exam reports/i })
+    expect(link).toHaveAttribute('href', '/app/internal-exam?tab=reports')
+  })
+})

--- a/apps/web/app/app/internal-exam/report/_components/report-footer.tsx
+++ b/apps/web/app/app/internal-exam/report/_components/report-footer.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export function ReportFooter() {
+  return (
+    <div className="flex justify-center">
+      <Link
+        href="/app/internal-exam?tab=reports"
+        className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        Back to Internal Exam Reports
+      </Link>
+    </div>
+  )
+}

--- a/apps/web/app/app/internal-exam/report/page.tsx
+++ b/apps/web/app/app/internal-exam/report/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from 'next/navigation'
+import { QuestionBreakdown } from '@/app/app/quiz/report/_components/question-breakdown'
+import { ResultSummary } from '@/app/app/quiz/report/_components/result-summary'
+import { getQuizReportSummary, PAGE_SIZE } from '@/lib/queries/quiz-report'
+import { getQuizReportQuestions } from '@/lib/queries/quiz-report-questions'
+import { parsePageParam } from '@/lib/utils/parse-page-param'
+import { ReportFooter } from './_components/report-footer'
+
+export default async function InternalExamReportPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ session?: string; page?: string }>
+}) {
+  const { session: sessionId, page: pageParam } = await searchParams
+  if (!sessionId) redirect('/app/internal-exam?tab=reports')
+
+  const summary = await getQuizReportSummary(sessionId)
+  if (!summary) redirect('/app/internal-exam?tab=reports')
+  // Defense-in-depth: this URL is only for internal_exam sessions.
+  if (summary.mode !== 'internal_exam') redirect(`/app/quiz/report?session=${sessionId}`)
+
+  const page = parsePageParam(pageParam)
+  const questionsResult = await getQuizReportQuestions({ sessionId, page })
+  if (!questionsResult.ok) redirect('/app/internal-exam?tab=reports')
+
+  const totalPages = Math.max(1, Math.ceil(questionsResult.totalCount / PAGE_SIZE))
+  if (page > totalPages) {
+    redirect(`/app/internal-exam/report?session=${sessionId}&page=${totalPages}`)
+  }
+
+  return (
+    <main className="space-y-6">
+      <ResultSummary summary={summary} />
+      <QuestionBreakdown
+        questions={questionsResult.questions}
+        page={page}
+        totalCount={questionsResult.totalCount}
+        pageSize={PAGE_SIZE}
+      />
+      <ReportFooter />
+    </main>
+  )
+}

--- a/apps/web/app/app/internal-exam/report/page.tsx
+++ b/apps/web/app/app/internal-exam/report/page.tsx
@@ -6,13 +6,15 @@ import { getQuizReportQuestions } from '@/lib/queries/quiz-report-questions'
 import { parsePageParam } from '@/lib/utils/parse-page-param'
 import { ReportFooter } from './_components/report-footer'
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export default async function InternalExamReportPage({
   searchParams,
 }: {
   searchParams: Promise<{ session?: string; page?: string }>
 }) {
   const { session: sessionId, page: pageParam } = await searchParams
-  if (!sessionId) redirect('/app/internal-exam?tab=reports')
+  if (!sessionId || !UUID_RE.test(sessionId)) redirect('/app/internal-exam?tab=reports')
 
   const summary = await getQuizReportSummary(sessionId)
   if (!summary) redirect('/app/internal-exam?tab=reports')

--- a/apps/web/app/app/quiz/_components/finish-quiz-dialog.test.tsx
+++ b/apps/web/app/app/quiz/_components/finish-quiz-dialog.test.tsx
@@ -15,6 +15,7 @@ type DialogProps = {
   onSave?: () => void
   onDiscard?: () => void
   isExam?: boolean
+  examMode?: 'mock_exam' | 'internal_exam'
   timeExpired?: boolean
 }
 
@@ -539,5 +540,44 @@ describe('FinishQuizDialog', () => {
   it('does not render a role="alert" element when there is no error', () => {
     renderDialog({ error: null })
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  // ---- Internal exam mode -------------------------------------------------
+
+  it('uses the "Finish Internal Exam" title when examMode is internal_exam', () => {
+    renderDialog({ isExam: true, examMode: 'internal_exam' })
+    expect(screen.getByRole('dialog', { name: /finish internal exam/i })).toBeInTheDocument()
+  })
+
+  it('uses the "Finish Practice Exam" title when examMode is mock_exam', () => {
+    renderDialog({ isExam: true, examMode: 'mock_exam' })
+    expect(screen.getByRole('dialog', { name: /finish practice exam/i })).toBeInTheDocument()
+  })
+
+  it('renders "Submit Internal Exam" on the primary action for internal_exam', () => {
+    renderDialog({ isExam: true, examMode: 'internal_exam', answeredCount: 5, totalQuestions: 5 })
+    expect(screen.getByRole('button', { name: /submit internal exam/i })).toBeInTheDocument()
+  })
+
+  it('hides the discard button entirely for internal_exam mode', () => {
+    renderDialog({ isExam: true, examMode: 'internal_exam' })
+    expect(screen.queryByRole('button', { name: /discard/i })).not.toBeInTheDocument()
+  })
+
+  it('still renders Return-to-exam (dismiss) for internal_exam mode', () => {
+    renderDialog({ isExam: true, examMode: 'internal_exam' })
+    expect(screen.getByRole('button', { name: /return to internal exam/i })).toBeInTheDocument()
+  })
+
+  it('shows the partial-answer warning for internal_exam when not all questions answered', () => {
+    renderDialog({
+      isExam: true,
+      examMode: 'internal_exam',
+      answeredCount: 2,
+      totalQuestions: 5,
+    })
+    fireEvent.click(screen.getByRole('button', { name: /submit internal exam/i }))
+    expect(screen.getByText(/3 questions are unanswered/i)).toBeInTheDocument()
+    expect(screen.getByText(/will be marked wrong/i)).toBeInTheDocument()
   })
 })

--- a/apps/web/app/app/quiz/_components/finish-quiz-dialog.tsx
+++ b/apps/web/app/app/quiz/_components/finish-quiz-dialog.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { type QuizMode as DbQuizMode, MODE_LABELS } from '@/lib/constants/exam-modes'
 import { useAutoSubmitCountdown } from '../_hooks/use-auto-submit-countdown'
 
 type FinishQuizDialogProps = {
@@ -14,6 +15,8 @@ type FinishQuizDialogProps = {
   onSave: () => void
   onDiscard: () => void
   isExam?: boolean
+  /** DB-level exam mode. Drives title and discard-button visibility. */
+  examMode?: DbQuizMode
   timeExpired?: boolean
 }
 
@@ -28,6 +31,7 @@ export function FinishQuizDialog({
   onSave,
   onDiscard,
   isExam,
+  examMode,
   timeExpired,
 }: FinishQuizDialogProps) {
   const [confirmingDiscard, setConfirmingDiscard] = useState(false)
@@ -49,8 +53,14 @@ export function FinishQuizDialog({
   if (!open) return null
 
   const unanswered = totalQuestions - answeredCount
-  const title = isExam ? 'Finish Practice Exam' : 'Finish Quiz'
+  const isInternalExam = isExam && examMode === 'internal_exam'
+  const examLabel = isExam ? (MODE_LABELS[examMode ?? 'mock_exam'] ?? 'Exam') : null
+  const title = isExam ? `Finish ${examLabel}` : 'Finish Quiz'
+  // canDismiss gates the backdrop close + Escape close + Return-to-quiz button.
+  // Internal exams DO allow dismissing the dialog (student returns to attempt) — discard
+  // is the only thing internal_exam disallows. That's gated separately via canDiscard.
   const canDismiss = !(timeExpired && isExam)
+  const canDiscard = canDismiss && !isInternalExam
 
   function handleClose() {
     if (!canDismiss) return
@@ -109,7 +119,7 @@ export function FinishQuizDialog({
           />
         )}
 
-        {confirmingDiscard && canDismiss && (
+        {confirmingDiscard && canDiscard && (
           <ConfirmPanel
             message={
               isExam
@@ -134,8 +144,10 @@ export function FinishQuizDialog({
           answeredCount={answeredCount}
           submitting={submitting}
           isExam={isExam}
+          examLabel={examLabel}
           timeExpired={timeExpired}
           canDismiss={canDismiss}
+          canDiscard={canDiscard}
           onSubmitClick={handleSubmitClick}
           onSave={onSave}
           onDiscardOpen={() => {
@@ -171,8 +183,10 @@ function DialogFooter({
   answeredCount,
   submitting,
   isExam,
+  examLabel,
   timeExpired,
   canDismiss,
+  canDiscard,
   onSubmitClick,
   onSave,
   onDiscardOpen,
@@ -181,8 +195,10 @@ function DialogFooter({
   answeredCount: number
   submitting: boolean
   isExam?: boolean
+  examLabel?: string | null
   timeExpired?: boolean
   canDismiss: boolean
+  canDiscard: boolean
   onSubmitClick: () => void
   onSave: () => void
   onDiscardOpen: () => void
@@ -199,7 +215,7 @@ function DialogFooter({
         {submitting
           ? 'Submitting...'
           : isExam
-            ? 'Submit Practice Exam'
+            ? `Submit ${examLabel ?? 'Exam'}`
             : answeredCount > 0
               ? 'Submit Quiz'
               : 'Answer at least one question'}
@@ -214,14 +230,14 @@ function DialogFooter({
           Save for Later
         </button>
       )}
-      {canDismiss && (
+      {canDiscard && (
         <button
           type="button"
           onClick={onDiscardOpen}
           disabled={submitting}
           className="w-full rounded-lg border border-destructive/30 bg-background px-4 py-2.5 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
         >
-          {isExam ? 'Discard Practice Exam' : 'Discard Quiz'}
+          {isExam ? `Discard ${examLabel ?? 'Exam'}` : 'Discard Quiz'}
         </button>
       )}
       {canDismiss && (
@@ -231,7 +247,7 @@ function DialogFooter({
           disabled={submitting}
           className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-sm font-medium transition-colors hover:bg-muted disabled:opacity-50"
         >
-          {isExam ? 'Return to Practice Exam' : 'Return to Quiz'}
+          {isExam ? `Return to ${examLabel ?? 'Exam'}` : 'Return to Quiz'}
         </button>
       )}
     </div>

--- a/apps/web/app/app/quiz/actions/discard.test.ts
+++ b/apps/web/app/app/quiz/actions/discard.test.ts
@@ -77,9 +77,35 @@ describe('discardQuiz', () => {
 
   // ---- session soft-delete -------------------------------------------------
 
+  /**
+   * Helper: build a quiz_sessions chain that:
+   *   - returns `selectResult` when the chain ends with `.maybeSingle()` (pre-fetch)
+   *   - returns `updateResult` otherwise (UPDATE ... .select('id'))
+   */
+  function quizSessionsDualChain(selectResult: unknown, updateResult: unknown) {
+    function makeChain(returnValue: unknown): unknown {
+      const awaitable = {
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable for Supabase chain mock
+        then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+          Promise.resolve(returnValue).then(resolve, reject),
+      }
+      return new Proxy(awaitable as Record<string, unknown>, {
+        get(target, prop) {
+          if (prop === 'then') return target.then
+          if (prop === 'maybeSingle') return () => makeChain(selectResult)
+          return (..._args: unknown[]) => makeChain(returnValue)
+        },
+      })
+    }
+    return makeChain(updateResult)
+  }
+
   it('soft-deletes the session and returns success when no draftId is provided', async () => {
     mockFrom.mockReturnValue(
-      buildChain({ data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null }),
+      quizSessionsDualChain(
+        { data: { id: '00000000-0000-4000-a000-000000000001', mode: 'quick_quiz' }, error: null },
+        { data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null },
+      ),
     )
 
     const result = await discardQuiz({
@@ -90,8 +116,44 @@ describe('discardQuiz', () => {
     expect(mockFrom).toHaveBeenCalledWith('quiz_sessions')
   })
 
+  it('soft-deletes a mock_exam (Practice Exam) session — regression guard', async () => {
+    mockFrom.mockReturnValue(
+      quizSessionsDualChain(
+        { data: { id: '00000000-0000-4000-a000-000000000001', mode: 'mock_exam' }, error: null },
+        { data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null },
+      ),
+    )
+
+    const result = await discardQuiz({
+      sessionId: '00000000-0000-4000-a000-000000000001',
+    })
+
+    expect(result).toEqual({ success: true })
+  })
+
+  it('rejects discard for internal_exam sessions (server-side guard)', async () => {
+    mockFrom.mockReturnValue(
+      quizSessionsDualChain(
+        {
+          data: { id: '00000000-0000-4000-a000-000000000001', mode: 'internal_exam' },
+          error: null,
+        },
+        // Should never be reached — UPDATE must not run.
+        { data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null },
+      ),
+    )
+
+    const result = await discardQuiz({
+      sessionId: '00000000-0000-4000-a000-000000000001',
+    })
+
+    expect(result).toEqual({ success: false, error: 'cannot_discard_internal_exam' })
+  })
+
   it('returns failure when session not found or not owned (zero rows affected)', async () => {
-    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    mockFrom.mockReturnValue(
+      quizSessionsDualChain({ data: null, error: null }, { data: [], error: null }),
+    )
 
     const result = await discardQuiz({
       sessionId: '00000000-0000-4000-a000-000000000001',
@@ -103,9 +165,30 @@ describe('discardQuiz', () => {
   it('returns failure when the session soft-delete query errors', async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === 'quiz_sessions')
-        return buildChain({ error: { message: 'constraint violation' } })
+        return quizSessionsDualChain(
+          {
+            data: { id: '00000000-0000-4000-a000-000000000001', mode: 'quick_quiz' },
+            error: null,
+          },
+          { error: { message: 'constraint violation' } },
+        )
       return buildChain({ error: null })
     })
+
+    const result = await discardQuiz({
+      sessionId: '00000000-0000-4000-a000-000000000001',
+    })
+
+    expect(result).toEqual({ success: false, error: 'Failed to discard quiz' })
+  })
+
+  it('returns failure when the session pre-fetch query errors', async () => {
+    mockFrom.mockReturnValue(
+      quizSessionsDualChain(
+        { data: null, error: { message: 'connection lost', code: 'XX000' } },
+        { data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null },
+      ),
+    )
 
     const result = await discardQuiz({
       sessionId: '00000000-0000-4000-a000-000000000001',
@@ -119,7 +202,13 @@ describe('discardQuiz', () => {
   it('deletes the draft and returns success when draftId is provided', async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === 'quiz_sessions')
-        return buildChain({ data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null })
+        return quizSessionsDualChain(
+          {
+            data: { id: '00000000-0000-4000-a000-000000000001', mode: 'quick_quiz' },
+            error: null,
+          },
+          { data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null },
+        )
       if (table === 'quiz_drafts') return buildChain({ error: null })
       throw new Error(`Unexpected table: ${table}`)
     })
@@ -136,7 +225,13 @@ describe('discardQuiz', () => {
   it('still returns success when draft deletion fails (non-fatal)', async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === 'quiz_sessions')
-        return buildChain({ data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null })
+        return quizSessionsDualChain(
+          {
+            data: { id: '00000000-0000-4000-a000-000000000001', mode: 'quick_quiz' },
+            error: null,
+          },
+          { data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null },
+        )
       if (table === 'quiz_drafts') return buildChain({ error: { message: 'draft not found' } })
       throw new Error(`Unexpected table: ${table}`)
     })
@@ -152,7 +247,10 @@ describe('discardQuiz', () => {
 
   it('does not query quiz_drafts when no draftId is provided', async () => {
     mockFrom.mockReturnValue(
-      buildChain({ data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null }),
+      quizSessionsDualChain(
+        { data: { id: '00000000-0000-4000-a000-000000000001', mode: 'quick_quiz' }, error: null },
+        { data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null },
+      ),
     )
 
     await discardQuiz({
@@ -169,7 +267,13 @@ describe('discardQuiz', () => {
 
     mockFrom.mockImplementation((table: string) => {
       if (table === 'quiz_sessions')
-        return buildChain({ data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null })
+        return quizSessionsDualChain(
+          {
+            data: { id: '00000000-0000-4000-a000-000000000001', mode: 'quick_quiz' },
+            error: null,
+          },
+          { data: [{ id: '00000000-0000-4000-a000-000000000001' }], error: null },
+        )
       if (table === 'quiz_drafts') {
         // Build a spy chain that records method names before forwarding
         const spyChain = (returnValue: unknown): unknown => {

--- a/apps/web/app/app/quiz/actions/discard.ts
+++ b/apps/web/app/app/quiz/actions/discard.ts
@@ -26,6 +26,35 @@ export async function discardQuiz(
       return { success: false, error: 'Invalid input' }
     }
 
+    // Pre-fetch the session to verify ownership and check mode before any UPDATE.
+    // Internal exams are protected: even if a UI bug exposes a discard button,
+    // the server rejects the action.
+    const { data: existing, error: fetchError } = await supabase
+      .from('quiz_sessions')
+      .select('id, mode')
+      .eq('id', input.sessionId)
+      .eq('student_id', user.id)
+      .is('ended_at', null)
+      .is('deleted_at', null)
+      .maybeSingle()
+
+    if (fetchError) {
+      console.error('[discardQuiz] Session lookup error:', fetchError.message, fetchError.code)
+      return { success: false, error: 'Failed to discard quiz' }
+    }
+    if (!existing) {
+      return { success: false, error: 'Session not found or already discarded' }
+    }
+    if (existing.mode === 'internal_exam') {
+      console.error(
+        '[discardQuiz] Rejected internal_exam discard for session',
+        input.sessionId,
+        'user',
+        user.id,
+      )
+      return { success: false, error: 'cannot_discard_internal_exam' }
+    }
+
     // Soft-delete the session — only if it belongs to this user and is still active
     const { data: sessionData, error: sessionError } = await supabase
       .from('quiz_sessions')

--- a/apps/web/app/app/quiz/report/_components/result-summary.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/result-summary.test.tsx
@@ -137,5 +137,20 @@ describe('ResultSummary', () => {
       render(<ResultSummary summary={makeSummary()} />)
       expect(screen.getByText('Quiz Complete')).toBeInTheDocument()
     })
+
+    it('renders "Practice Exam Complete" for mock_exam mode', () => {
+      render(<ResultSummary summary={makeSummary({ mode: 'mock_exam', passed: true })} />)
+      expect(screen.getByText('Practice Exam Complete')).toBeInTheDocument()
+    })
+
+    it('renders "Internal Exam Complete" for internal_exam mode', () => {
+      render(<ResultSummary summary={makeSummary({ mode: 'internal_exam', passed: true })} />)
+      expect(screen.getByText('Internal Exam Complete')).toBeInTheDocument()
+    })
+
+    it('shows the pass/fail badge for internal_exam mode', () => {
+      render(<ResultSummary summary={makeSummary({ mode: 'internal_exam', passed: false })} />)
+      expect(screen.getByText('FAILED')).toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/app/app/quiz/report/_components/result-summary.tsx
+++ b/apps/web/app/app/quiz/report/_components/result-summary.tsx
@@ -1,3 +1,4 @@
+import { isExamMode, MODE_LABELS } from '@/lib/constants/exam-modes'
 import type { QuizReportSummary } from '@/lib/queries/quiz-report'
 import { ScoreRing } from './score-ring'
 
@@ -37,13 +38,16 @@ type Props = Readonly<{ summary: QuizReportSummary }>
 export function ResultSummary({ summary }: Props) {
   const dateStr = summary.endedAt ?? summary.startedAt
   const skipped = summary.totalQuestions - summary.answeredCount
-  const isExam = summary.mode === 'mock_exam'
+  const isExam = isExamMode(summary.mode)
+  // summary.mode is typed `string`; isExamMode confirms it's a valid exam mode at runtime,
+  // so the narrow cast for MODE_LABELS lookup is safe.
+  const examLabel = isExam ? MODE_LABELS[summary.mode as 'mock_exam' | 'internal_exam'] : null
 
   return (
     <div className="rounded-xl border border-border bg-card p-6">
       <div className="mb-4">
         <p className="text-center font-semibold text-lg">
-          {isExam ? 'Practice Exam Complete' : 'Quiz Complete'}
+          {isExam ? `${examLabel} Complete` : 'Quiz Complete'}
         </p>
       </div>
 

--- a/apps/web/app/app/quiz/report/page.tsx
+++ b/apps/web/app/app/quiz/report/page.tsx
@@ -4,13 +4,15 @@ import { getQuizReportQuestions } from '@/lib/queries/quiz-report-questions'
 import { parsePageParam } from '@/lib/utils/parse-page-param'
 import { ReportCard } from './_components/report-card'
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export default async function QuizReportPage({
   searchParams,
 }: {
   searchParams: Promise<{ session?: string; page?: string }>
 }) {
   const { session: sessionId, page: pageParam } = await searchParams
-  if (!sessionId) redirect('/app/quiz')
+  if (!sessionId || !UUID_RE.test(sessionId)) redirect('/app/quiz')
 
   const summary = await getQuizReportSummary(sessionId)
   if (!summary) redirect('/app/quiz')

--- a/apps/web/app/app/quiz/session/_components/exam-session-header.test.tsx
+++ b/apps/web/app/app/quiz/session/_components/exam-session-header.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_components/exam-countdown-timer', () => ({
+  ExamCountdownTimer: ({ timeLimitSeconds }: { timeLimitSeconds: number }) => (
+    <span data-testid="countdown">{timeLimitSeconds}</span>
+  ),
+}))
+
+import { ExamBadge, ExamSessionHeader } from './exam-session-header'
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('ExamBadge', () => {
+  it('renders "PRACTICE EXAM" for mock_exam mode', () => {
+    render(<ExamBadge mode="mock_exam" />)
+    expect(screen.getByText('PRACTICE EXAM')).toBeInTheDocument()
+  })
+
+  it('renders "INTERNAL EXAM" for internal_exam mode', () => {
+    render(<ExamBadge mode="internal_exam" />)
+    expect(screen.getByText('INTERNAL EXAM')).toBeInTheDocument()
+  })
+
+  it('defaults to mock_exam label when no mode is provided', () => {
+    render(<ExamBadge />)
+    expect(screen.getByText('PRACTICE EXAM')).toBeInTheDocument()
+  })
+})
+
+describe('ExamSessionHeader', () => {
+  const baseProps = {
+    mode: 'mock_exam' as const,
+    timeLimitSeconds: 3600,
+    startedAt: Date.now(),
+    onExpired: vi.fn(),
+  }
+
+  it('shows the correct badge label for mock_exam mode', () => {
+    render(<ExamSessionHeader {...baseProps} />)
+    expect(screen.getByText('PRACTICE EXAM')).toBeInTheDocument()
+  })
+
+  it('shows the correct badge label for internal_exam mode', () => {
+    render(<ExamSessionHeader {...baseProps} mode="internal_exam" />)
+    expect(screen.getByText('INTERNAL EXAM')).toBeInTheDocument()
+  })
+
+  it('renders the countdown timer with the supplied time limit', () => {
+    render(<ExamSessionHeader {...baseProps} timeLimitSeconds={1800} />)
+    expect(screen.getByTestId('countdown')).toHaveTextContent('1800')
+  })
+})

--- a/apps/web/app/app/quiz/session/_components/exam-session-header.tsx
+++ b/apps/web/app/app/quiz/session/_components/exam-session-header.tsx
@@ -1,23 +1,26 @@
 'use client'
 
+import { MODE_LABELS, type QuizMode } from '@/lib/constants/exam-modes'
 import { ExamCountdownTimer } from '../../_components/exam-countdown-timer'
 
 type ExamSessionHeaderProps = {
+  mode: QuizMode
   timeLimitSeconds: number
   startedAt: number
   onExpired: () => void
   className?: string
 }
 
-export function ExamBadge() {
+export function ExamBadge({ mode = 'mock_exam' }: { mode?: QuizMode } = {}) {
   return (
     <span className="hidden md:inline-flex rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-400">
-      PRACTICE EXAM
+      {MODE_LABELS[mode].toUpperCase()}
     </span>
   )
 }
 
 export function ExamSessionHeader({
+  mode,
   timeLimitSeconds,
   startedAt,
   onExpired,
@@ -25,7 +28,7 @@ export function ExamSessionHeader({
 }: ExamSessionHeaderProps) {
   return (
     <div className={`flex items-center gap-2 ${className ?? ''}`}>
-      <ExamBadge />
+      <ExamBadge mode={mode} />
       <ExamCountdownTimer
         timeLimitSeconds={timeLimitSeconds}
         startedAt={startedAt}

--- a/apps/web/app/app/quiz/session/_components/quiz-session-header.tsx
+++ b/apps/web/app/app/quiz/session/_components/quiz-session-header.tsx
@@ -2,6 +2,7 @@
 
 import { SessionTimer } from '@/app/app/_components/session-timer'
 import { ThemeToggle } from '@/app/app/_components/theme-toggle'
+import { type QuizMode as DbQuizMode, MODE_LABELS } from '@/lib/constants/exam-modes'
 import { ExamCountdownTimer } from '../../_components/exam-countdown-timer'
 import type { QuestionTab } from '../../_components/question-tabs'
 import { QuestionTabs } from '../../_components/question-tabs'
@@ -9,6 +10,7 @@ import { ExamBadge } from './exam-session-header'
 
 type QuizSessionHeaderProps = {
   isExam: boolean
+  examMode?: DbQuizMode
   currentIndex: number
   totalQuestions: number
   submitting: boolean
@@ -22,6 +24,7 @@ type QuizSessionHeaderProps = {
 
 export function QuizSessionHeader({
   isExam,
+  examMode,
   currentIndex,
   totalQuestions,
   submitting,
@@ -32,6 +35,7 @@ export function QuizSessionHeader({
   onTimeExpired,
   onFinishClick,
 }: QuizSessionHeaderProps) {
+  const finishLabel = isExam ? `Finish ${MODE_LABELS[examMode ?? 'mock_exam']}` : 'Finish Test'
   return (
     <div className="relative flex items-center justify-between border-b border-border px-4 py-2">
       <div className="flex items-center gap-2">
@@ -40,7 +44,7 @@ export function QuizSessionHeader({
         </span>
         {isExam ? (
           <>
-            <ExamBadge />
+            <ExamBadge mode={examMode} />
             {timeLimitSeconds && (
               <ExamCountdownTimer
                 timeLimitSeconds={timeLimitSeconds}
@@ -70,7 +74,7 @@ export function QuizSessionHeader({
           disabled={submitting}
           className="shrink-0 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
         >
-          {isExam ? 'Finish Practice Exam' : 'Finish Test'}
+          {finishLabel}
         </button>
       </div>
     </div>

--- a/apps/web/app/app/quiz/session/_components/quiz-session-loader.tsx
+++ b/apps/web/app/app/quiz/session/_components/quiz-session-loader.tsx
@@ -90,6 +90,7 @@ export function QuizSessionLoader({ userId }: { userId: string }) {
       subjectName={bs.session.subjectName}
       subjectCode={bs.session.subjectCode}
       mode={bs.session.mode}
+      examMode={bs.session.examMode}
       timeLimitSeconds={bs.session.timeLimitSeconds}
       passMark={bs.session.passMark}
       startedAt={bs.session.startedAt}

--- a/apps/web/app/app/quiz/session/_components/quiz-session.tsx
+++ b/apps/web/app/app/quiz/session/_components/quiz-session.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef, useState } from 'react'
 import type { SessionQuestion } from '@/app/app/_types/session'
+import type { QuizMode as DbQuizMode } from '@/lib/constants/exam-modes'
 import { FinishQuizDialog } from '../../_components/finish-quiz-dialog'
 import { QuestionGrid } from '../../_components/question-grid'
 import { QuestionTabs } from '../../_components/question-tabs'
@@ -27,6 +28,7 @@ type QuizSessionProps = {
   subjectName?: string
   subjectCode?: string
   mode?: 'study' | 'exam'
+  examMode?: DbQuizMode
   timeLimitSeconds?: number
   passMark?: number
   startedAt?: string
@@ -56,10 +58,15 @@ export function QuizSession(props: QuizSessionProps) {
 
   if (!s.question) return null
 
+  // Default examMode to mock_exam in exam sessions when caller didn't supply it.
+  // (Existing exam sessions in localStorage written before this field landed.)
+  const examMode = s.isExam ? (props.examMode ?? 'mock_exam') : undefined
+
   return (
     <div className="flex flex-1 flex-col">
       <QuizSessionHeader
         isExam={s.isExam}
+        examMode={examMode}
         currentIndex={s.currentIndex}
         totalQuestions={props.questions.length}
         submitting={s.submitting}
@@ -140,6 +147,7 @@ export function QuizSession(props: QuizSessionProps) {
         onSave={s.handleSave}
         onDiscard={s.handleDiscard}
         isExam={s.isExam}
+        examMode={examMode}
         timeExpired={timeExpired}
       />
     </div>

--- a/apps/web/app/app/quiz/session/_hooks/quiz-submit.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/quiz-submit.test.ts
@@ -497,6 +497,19 @@ describe('handleSubmitSession', () => {
     expect(opts.setError).toHaveBeenCalledWith(null)
   })
 
+  it('navigates to /app/internal-exam/report after a successful internal-exam submission', async () => {
+    mockBatchSubmitQuiz.mockResolvedValue(BATCH_SUCCESS)
+    const opts = makeOpts({ isExam: true, examMode: 'internal_exam' })
+    await handleSubmitSession(opts)
+    expect(opts.router.push).toHaveBeenCalledWith(`/app/internal-exam/report?session=${SESSION_ID}`)
+  })
+
+  it('navigates to /app/internal-exam/report on zero-answer internal-exam timeout', async () => {
+    const opts = makeOpts({ answers: new Map(), isExam: true, examMode: 'internal_exam' })
+    await handleSubmitSession(opts)
+    expect(opts.router.push).toHaveBeenCalledWith(`/app/internal-exam/report?session=${SESSION_ID}`)
+  })
+
   it('shows error and stops loading when submission fails', async () => {
     mockBatchSubmitQuiz.mockResolvedValue({ success: false, error: 'session discarded' })
     const opts = makeOpts()

--- a/apps/web/app/app/quiz/session/_hooks/quiz-submit.ts
+++ b/apps/web/app/app/quiz/session/_hooks/quiz-submit.ts
@@ -1,4 +1,5 @@
 import type { useRouter } from 'next/navigation'
+import type { QuizMode as DbQuizMode } from '@/lib/constants/exam-modes'
 import { batchSubmitQuiz } from '../../actions/batch-submit'
 import { clearDeploymentPin } from '../../actions/clear-deployment-pin'
 import { discardQuiz } from '../../actions/discard'
@@ -105,7 +106,12 @@ export async function handleSubmitSession(opts: {
   setError: SetError
   onSuccess: () => void
   isExam?: boolean
+  examMode?: DbQuizMode
 }) {
+  // Internal exams have their own report URL namespace (/app/internal-exam/report).
+  // Practice exams + study mode use /app/quiz/report.
+  const reportPath =
+    opts.examMode === 'internal_exam' ? '/app/internal-exam/report' : '/app/quiz/report'
   if (opts.answers.size === 0 && !opts.isExam) {
     opts.setError('No answers to submit.')
     return
@@ -127,7 +133,7 @@ export async function handleSubmitSession(opts: {
     if (result.success) {
       opts.onSuccess()
       clearActiveSession(opts.userId)
-      opts.router.push(`/app/quiz/report?session=${opts.sessionId}`)
+      opts.router.push(`${reportPath}?session=${opts.sessionId}`)
       clearDeploymentPin().catch(() => {})
     } else {
       console.error('[handleSubmitSession] submitEmptyExamSession failed:', result.error)
@@ -147,7 +153,7 @@ export async function handleSubmitSession(opts: {
   const r = await submitQuizSession(opts.sessionId, opts.answers, opts.userId, opts.draftId)
   if (r.success) {
     opts.onSuccess()
-    opts.router.push(`/app/quiz/report?session=${opts.sessionId}`)
+    opts.router.push(`${reportPath}?session=${opts.sessionId}`)
   } else {
     opts.setError(r.error)
     opts.setSubmitting(false)

--- a/apps/web/app/app/quiz/session/_hooks/use-exam-state.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-exam-state.ts
@@ -42,6 +42,7 @@ export function useExamPipeline(opts: {
     subjectName: opts.quizOpts.subjectName,
     subjectCode: opts.quizOpts.subjectCode,
     isExam: true,
+    examMode: opts.quizOpts.examMode,
   })
 
   function handleSelectAnswer(id: string): Promise<boolean> {

--- a/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.ts
@@ -1,6 +1,7 @@
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 import { useRef, useState } from 'react'
 import type { SessionQuestion } from '@/app/app/_types/session'
+import type { QuizMode as DbQuizMode } from '@/lib/constants/exam-modes'
 import type { AnswerFeedback, DraftAnswer } from '../../types'
 import { handleDiscardSession, handleSaveSession, handleSubmitSession } from './quiz-submit'
 
@@ -17,6 +18,7 @@ export function useQuizSubmit(opts: {
   subjectName?: string
   subjectCode?: string
   isExam?: boolean
+  examMode?: DbQuizMode
 }) {
   const submitted = useRef(false)
   const [showFinishDialog, setShowFinishDialog] = useState(false)
@@ -36,6 +38,7 @@ export function useQuizSubmit(opts: {
       answers: safeAnswers,
       draftId: opts.draftId,
       isExam: opts.isExam,
+      examMode: opts.examMode,
       onSuccess: () => {
         submitted.current = true
         setShowFinishDialog(false)

--- a/apps/web/app/app/quiz/session/_utils/quiz-session-storage.ts
+++ b/apps/web/app/app/quiz/session/_utils/quiz-session-storage.ts
@@ -1,3 +1,4 @@
+import type { QuizMode as DbQuizMode } from '@/lib/constants/exam-modes'
 import type { AnswerFeedback, DraftAnswer } from '../../types'
 import {
   hasValidOptionalFields,
@@ -25,6 +26,10 @@ export type ActiveSession = {
   draftId?: string
   savedAt: number // Date.now()
   mode?: 'study' | 'exam'
+  // DB-level exam mode (mock_exam | internal_exam). Display-only; drives badge label
+  // and UI gating (e.g., hides Discard for internal_exam). Defaults to mock_exam when
+  // mode === 'exam' and examMode is absent.
+  examMode?: DbQuizMode
   // Exam-mode refresh recovery: timer needs deadline-relative state, independent of SessionData.
   startedAt?: string // ISO string from quiz_sessions.started_at; required for exam mode
   timeLimitSeconds?: number
@@ -44,6 +49,7 @@ export function buildHandoffPayload(userId: string, s: ActiveSession) {
     subjectName: s.subjectName,
     subjectCode: s.subjectCode,
     mode: s.mode,
+    examMode: s.examMode,
     timeLimitSeconds: s.timeLimitSeconds,
     passMark: s.passMark,
     startedAt: s.startedAt,
@@ -150,6 +156,7 @@ export type SessionData = {
   subjectName?: string
   subjectCode?: string
   mode?: 'study' | 'exam'
+  examMode?: DbQuizMode
   timeLimitSeconds?: number
   passMark?: number
   startedAt?: string
@@ -205,6 +212,7 @@ export function toSessionData(r: ActiveSession): SessionData {
     subjectName: r.subjectName,
     subjectCode: r.subjectCode,
     mode: r.mode,
+    examMode: r.examMode,
     startedAt: r.startedAt,
     timeLimitSeconds: r.timeLimitSeconds,
     passMark: r.passMark,
@@ -227,6 +235,7 @@ type BuildOpts = {
   subjectCode?: string
   draftId?: string
   mode?: 'study' | 'exam'
+  examMode?: DbQuizMode
   startedAt?: string
   timeLimitSeconds?: number
   passMark?: number
@@ -250,6 +259,7 @@ export function buildActiveSession(
     draftId: opts.draftId,
     savedAt: Date.now(),
     mode: opts.mode,
+    examMode: opts.examMode,
     startedAt: opts.startedAt,
     timeLimitSeconds: opts.timeLimitSeconds,
     passMark: opts.passMark,

--- a/apps/web/app/app/quiz/session/_utils/quiz-session-validators.ts
+++ b/apps/web/app/app/quiz/session/_utils/quiz-session-validators.ts
@@ -45,6 +45,7 @@ export function hasValidOptionalFields(d: Record<string, unknown>, questionCount
     isOptionalFieldValid(d, 'subjectName', (v) => typeof v === 'string') &&
     isOptionalFieldValid(d, 'subjectCode', (v) => typeof v === 'string') &&
     isOptionalFieldValid(d, 'mode', (v) => v === 'study' || v === 'exam') &&
+    isOptionalFieldValid(d, 'examMode', (v) => v === 'mock_exam' || v === 'internal_exam') &&
     isOptionalFieldValid(d, 'timeLimitSeconds', (v) => typeof v === 'number' && v > 0) &&
     isOptionalFieldValid(d, 'passMark', (v) => typeof v === 'number' && v > 0 && v <= 100) &&
     isOptionalFieldValid(d, 'startedAt', (v) => typeof v === 'string')

--- a/apps/web/app/app/quiz/types.ts
+++ b/apps/web/app/app/quiz/types.ts
@@ -114,6 +114,7 @@ export type QuizStateOpts = {
   subjectName?: string
   subjectCode?: string
   mode?: QuizMode
+  examMode?: import('@/lib/constants/exam-modes').QuizMode
   timeLimitSeconds?: number
   passMark?: number
   startedAt?: string

--- a/apps/web/app/app/reports/_components/reports-utils.ts
+++ b/apps/web/app/app/reports/_components/reports-utils.ts
@@ -2,6 +2,7 @@ export const MODE_LABELS: Record<string, string> = {
   smart_review: 'Study',
   quick_quiz: 'Study',
   mock_exam: 'Practice Exam',
+  internal_exam: 'Internal Exam',
 }
 
 export function formatDate(iso: string) {

--- a/apps/web/app/app/reports/_components/session-card.tsx
+++ b/apps/web/app/app/reports/_components/session-card.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link'
+import { isExamMode } from '@/lib/constants/exam-modes'
 import type { SessionReport } from '@/lib/queries/reports'
 import { scoreColor } from '@/lib/utils/score-color'
 import { formatDate, MODE_LABELS } from './reports-utils'
 
 export function SessionCard({ session: s }: Readonly<{ session: SessionReport }>) {
-  const exam = s.mode === 'mock_exam'
+  const exam = isExamMode(s.mode)
   const score = s.scorePercentage == null ? '\u2014' : `${Math.round(s.scorePercentage)}%`
   const color = s.scorePercentage == null ? undefined : scoreColor(s.scorePercentage)
 
@@ -23,7 +24,9 @@ export function SessionCard({ session: s }: Readonly<{ session: SessionReport }>
       <p className="mt-1 text-xs text-muted-foreground">
         Mode:{' '}
         {exam ? (
-          <span className="font-semibold uppercase text-amber-600">{MODE_LABELS.mock_exam}</span>
+          <span className="font-semibold uppercase text-amber-600">
+            {MODE_LABELS[s.mode] ?? MODE_LABELS.mock_exam}
+          </span>
         ) : (
           <span className="font-medium">{MODE_LABELS[s.mode] ?? s.mode}</span>
         )}

--- a/apps/web/app/app/reports/_components/session-table.test.tsx
+++ b/apps/web/app/app/reports/_components/session-table.test.tsx
@@ -95,6 +95,11 @@ describe('SessionTable', () => {
     expect(screen.getByText('Practice Exam')).toBeInTheDocument()
   })
 
+  it('renders an Internal Exam badge for internal_exam mode', () => {
+    render(<SessionTable {...SORT_PROPS} sessions={[makeSession({ mode: 'internal_exam' })]} />)
+    expect(screen.getByText('Internal Exam')).toBeInTheDocument()
+  })
+
   it('renders mode label for non-exam modes', () => {
     render(<SessionTable {...SORT_PROPS} sessions={[makeSession({ mode: 'quick_quiz' })]} />)
     expect(screen.getByText('Study')).toBeInTheDocument()

--- a/apps/web/app/app/reports/_components/session-table.tsx
+++ b/apps/web/app/app/reports/_components/session-table.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { SortableTableHead } from '@/app/app/admin/dashboard/_lib/sortable-head'
+import { isExamMode } from '@/lib/constants/exam-modes'
 import type { SessionReport, SortDir, SortKey } from '@/lib/queries/reports'
 import { scoreColor } from '@/lib/utils/score-color'
 import { formatDate, MODE_LABELS } from './reports-utils'
@@ -60,7 +61,7 @@ export function SessionTable({ sessions, sort, dir, onSort }: Props) {
 
 function SessionRow({ session: s }: Readonly<{ session: SessionReport }>) {
   const router = useRouter()
-  const exam = s.mode === 'mock_exam'
+  const exam = isExamMode(s.mode)
   const score = s.scorePercentage == null ? '\u2014' : `${Math.round(s.scorePercentage)}%`
   const color = s.scorePercentage == null ? undefined : scoreColor(s.scorePercentage)
   const href = `/app/quiz/report?session=${s.id}`
@@ -86,7 +87,7 @@ function SessionRow({ session: s }: Readonly<{ session: SessionReport }>) {
       </td>
       <td className="px-4 py-3">
         {exam ? (
-          <ExamBadge />
+          <ExamBadge mode={s.mode} />
         ) : (
           <span className="text-muted-foreground">{MODE_LABELS[s.mode] ?? s.mode}</span>
         )}
@@ -102,10 +103,10 @@ function SessionRow({ session: s }: Readonly<{ session: SessionReport }>) {
   )
 }
 
-function ExamBadge() {
+function ExamBadge({ mode }: Readonly<{ mode: string }>) {
   return (
     <span className="inline-block rounded-sm border border-amber-400 bg-amber-50 px-1.5 py-0.5 text-[11px] font-semibold uppercase leading-none tracking-wide text-amber-600">
-      {MODE_LABELS.mock_exam}
+      {MODE_LABELS[mode] ?? MODE_LABELS.mock_exam}
     </span>
   )
 }

--- a/apps/web/e2e/helpers/supabase.ts
+++ b/apps/web/e2e/helpers/supabase.ts
@@ -13,6 +13,15 @@ export const TEST_PASSWORD = 'e2e-test-password-2026!'
 export const LOGIN_TEST_EMAIL = 'e2e-login-test@lmsplus.local'
 export const LOGIN_TEST_PASSWORD = 'e2e-login-test-password-2026!'
 
+// Separate user for internal-exam specs in the admin-e2e project. The regular
+// e2e project's specs run first and rotate `e2e/.auth/user.json`'s session via
+// @supabase/ssr refresh, deleting the auth.sessions row referenced by the saved
+// access_token. By the time admin-e2e specs spawn a student context from
+// user.json, gotrue rejects the token (session_id no longer exists). Same
+// rationale as LOGIN_TEST_EMAIL above.
+export const INTERNAL_EXAM_STUDENT_EMAIL = 'e2e-internal-exam@lmsplus.local'
+export const INTERNAL_EXAM_STUDENT_PASSWORD = 'e2e-internal-exam-password-2026!'
+
 export function getAdminClient() {
   return createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
     auth: { autoRefreshToken: false, persistSession: false },
@@ -206,6 +215,76 @@ export async function ensureLoginTestUser() {
       .update({ organization_id: orgId })
       .eq('id', userId)
     if (updateError) throw new Error(`ensureLoginTestUser update org: ${updateError.message}`)
+  }
+
+  await ensureConsentRecords(admin, userId)
+  return { orgId, userId }
+}
+
+/** Ensure a separate internal-exam student exists (used by admin-e2e/internal-exam-* specs). */
+export async function ensureInternalExamStudentUser() {
+  const admin = getAdminClient()
+
+  const { data: org, error: orgError } = await admin
+    .from('organizations')
+    .select('id')
+    .eq('slug', 'egmont-aviation')
+    .single()
+
+  if (orgError || !org)
+    throw new Error(`ensureInternalExamStudentUser org lookup: ${orgError?.message}`)
+  const orgId = org.id
+
+  const { data: existingUsers, error: listError } = await admin.auth.admin.listUsers()
+  if (listError) throw new Error(`ensureInternalExamStudentUser listUsers: ${listError.message}`)
+  const existingAuth = existingUsers?.users.find(
+    (u: { email?: string }) => u.email === INTERNAL_EXAM_STUDENT_EMAIL,
+  )
+
+  let userId: string
+  if (existingAuth) {
+    userId = existingAuth.id
+    const { error: resetError } = await admin.auth.admin.updateUserById(userId, {
+      password: INTERNAL_EXAM_STUDENT_PASSWORD,
+    })
+    if (resetError)
+      throw new Error(`ensureInternalExamStudentUser reset password: ${resetError.message}`)
+  } else {
+    const { data: authData, error: authError } = await admin.auth.admin.createUser({
+      email: INTERNAL_EXAM_STUDENT_EMAIL,
+      password: INTERNAL_EXAM_STUDENT_PASSWORD,
+      email_confirm: true,
+    })
+    if (authError) throw new Error(`ensureInternalExamStudentUser auth: ${authError.message}`)
+    userId = authData.user.id
+  }
+
+  const { data: userRow, error: userRowError } = await admin
+    .from('users')
+    .select('id, organization_id')
+    .eq('id', userId)
+    .single()
+
+  if (userRowError && userRowError.code !== 'PGRST116') {
+    throw new Error(`ensureInternalExamStudentUser user lookup: ${userRowError.message}`)
+  }
+
+  if (!userRow) {
+    const { error: userError } = await admin.from('users').insert({
+      id: userId,
+      organization_id: orgId,
+      email: INTERNAL_EXAM_STUDENT_EMAIL,
+      full_name: 'E2E Internal Exam Student',
+      role: 'student',
+    })
+    if (userError) throw new Error(`ensureInternalExamStudentUser public: ${userError.message}`)
+  } else if (userRow.organization_id !== orgId) {
+    const { error: updateError } = await admin
+      .from('users')
+      .update({ organization_id: orgId })
+      .eq('id', userId)
+    if (updateError)
+      throw new Error(`ensureInternalExamStudentUser update org: ${updateError.message}`)
   }
 
   await ensureConsentRecords(admin, userId)

--- a/apps/web/e2e/internal-exam-lifecycle.spec.ts
+++ b/apps/web/e2e/internal-exam-lifecycle.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * E2E spec — Internal Exam end-to-end lifecycle.
+ *
+ * Covers: admin issues a code → student starts → submits → views report →
+ * sees the attempt listed in My Reports.
+ *
+ * Seed dependency: apps/web/scripts/seed-exam-eval.ts. The CI seed
+ * (apps/web/scripts/seed-e2e.ts) creates a MET exam_config which
+ * `start_internal_exam_session` reuses (same time/total/passmark fields).
+ * This spec assumes the existing admin/student fixture (admin@lmsplus.local
+ * + student@lmsplus.local) is loaded; it does not seed its own users.
+ *
+ * NOTE: requires migrations 057a..065 (internal_exam_codes table, RPCs
+ *       issue_internal_exam_code / start_internal_exam_session /
+ *       complete_internal_exam_session) to be applied. Until then the
+ *       Server Action calls will fail and these specs will not pass.
+ *
+ * Auth: uses both `e2e/.auth/admin.json` and `e2e/.auth/user.json`. The
+ * default `test.use({ storageState })` pins the page to admin; we open a
+ * second context with the student state for the second half of the flow.
+ */
+
+import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+// Default to admin storage; we open a separate student context inside each test.
+test.use({ storageState: 'e2e/.auth/admin.json' })
+
+const SUBJECT_LABEL_FRAGMENT = 'Meteorology'
+
+async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promise<string> {
+  await adminPage.goto('/app/admin/internal-exams')
+  await expect(adminPage.getByRole('heading', { name: 'Internal Exams' })).toBeVisible()
+
+  // Open the issue-code form.
+  const form = adminPage.getByTestId('issue-code-form')
+  await expect(form).toBeVisible()
+
+  // Pick the first available student.
+  const studentSelect = form.locator('[aria-label="Student"]')
+  await studentSelect.click()
+  await adminPage.locator('[data-slot="select-item"]').first().click()
+
+  // Pick the subject by name fragment.
+  const subjectSelect = form.locator('[aria-label="Subject"]')
+  await subjectSelect.click()
+  await adminPage
+    .locator('[data-slot="select-item"]')
+    .filter({ hasText: subjectFragment })
+    .first()
+    .click()
+
+  await form.getByRole('button', { name: 'Issue code' }).click()
+  await expect(adminPage.getByText('Internal exam code issued')).toBeVisible({ timeout: 10_000 })
+
+  const issuedCode = adminPage.getByTestId('issued-code-value')
+  await expect(issuedCode).toBeVisible()
+  const code = (await issuedCode.textContent())?.trim()
+  if (!code) throw new Error('issued code panel had no value')
+  return code
+}
+
+async function openStudentContext(browser: BrowserContext['browser']): Promise<{
+  context: BrowserContext
+  page: Page
+}> {
+  if (!browser) throw new Error('browser is null')
+  const context = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+  const page = await context.newPage()
+  return { context, page }
+}
+
+test.describe('internal exam — lifecycle', () => {
+  test.setTimeout(120_000)
+
+  test('admin issues code, student starts + submits, attempt appears in My Reports', async ({
+    page: adminPage,
+    context: adminCtx,
+  }) => {
+    // ── 1. Admin issues a code ──────────────────────────────────────────────
+    const code = await issueCodeAsAdmin(adminPage, SUBJECT_LABEL_FRAGMENT)
+    expect(code).toMatch(/^[A-HJKLMNPQRSTUVWXYZ23456789]{8}$/)
+
+    // ── 2. Student logs in via separate context (uses user.json storage) ────
+    const { context: studentCtx, page } = await openStudentContext(adminCtx.browser())
+
+    try {
+      await page.goto('/app/internal-exam')
+      await expect(page.getByRole('heading', { name: 'Internal Exam' })).toBeVisible()
+
+      // Available row should appear for the freshly issued code.
+      const availableList = page.getByTestId('available-list')
+      await expect(availableList).toBeVisible({ timeout: 10_000 })
+      const startBtn = page.getByTestId('start-button').first()
+      await expect(startBtn).toBeVisible()
+      await startBtn.click()
+
+      // Code-entry modal opens.
+      const form = page.getByTestId('code-entry-form')
+      await expect(form).toBeVisible()
+      await page.getByTestId('code-input').fill(code)
+      await page.getByRole('button', { name: 'Start exam' }).click()
+
+      // ── 3. Land on session page, answer first option, finish, submit ──────
+      await page.waitForURL(/\/app\/quiz\/session/, { timeout: 15_000 })
+      await expect(page.getByText(/Question \d/)).toBeVisible({ timeout: 10_000 })
+
+      // Answer one option (exam mode buffers selection client-side).
+      const answerBtns = page.locator('button:has(span.rounded-full)')
+      await answerBtns.first().click()
+      await page.waitForTimeout(300)
+
+      // Open the finish dialog and submit.
+      await page.getByRole('button', { name: 'Finish Internal Exam' }).click()
+      await page.getByRole('button', { name: 'Submit Quiz' }).click()
+
+      // ── 4. Land on /app/quiz/report with badge + pass/fail ────────────────
+      await page.waitForURL(/\/app\/quiz\/report\?session=/, { timeout: 30_000 })
+      await expect(page.getByText('Internal Exam Complete')).toBeVisible({ timeout: 10_000 })
+      // Pass or fail badge — both valid outcomes; assert one of them is rendered.
+      const badge = page.getByText(/^(PASSED|FAILED)$/)
+      await expect(badge).toBeVisible({ timeout: 10_000 })
+
+      // ── 5. Navigate to My Reports tab on /app/internal-exam ────────────────
+      await page.goto('/app/internal-exam')
+      await expect(page.getByRole('heading', { name: 'Internal Exam' })).toBeVisible()
+      await page.getByTestId('tab-reports').click()
+      await expect(page.getByTestId('tabpanel-reports')).toBeVisible()
+      // At least one attempt row should exist.
+      await expect(page.locator('[data-testid^="report-row-"]').first()).toBeVisible({
+        timeout: 10_000,
+      })
+    } finally {
+      await studentCtx.close()
+    }
+  })
+})

--- a/apps/web/e2e/internal-exam-lifecycle.spec.ts
+++ b/apps/web/e2e/internal-exam-lifecycle.spec.ts
@@ -15,12 +15,15 @@
  *       complete_internal_exam_session) to be applied. Until then the
  *       Server Action calls will fail and these specs will not pass.
  *
- * Auth: uses both `e2e/.auth/admin.json` and `e2e/.auth/user.json`. The
- * default `test.use({ storageState })` pins the page to admin; we open a
- * second context with the student state for the second half of the flow.
+ * Auth: uses `e2e/.auth/admin.json` and `e2e/.auth/internal-exam-student.json`.
+ * The default `test.use({ storageState })` pins the page to admin; we open a
+ * second context with the dedicated internal-exam student state for the
+ * student half of the flow. (Using user.json would race against
+ * session-rotation invalidation from the prior `e2e` project's specs.)
  */
 
 import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+import { INTERNAL_EXAM_STUDENT_EMAIL } from './helpers/supabase'
 
 test.describe.configure({ mode: 'serial' })
 
@@ -37,10 +40,14 @@ async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promi
   const form = adminPage.getByTestId('issue-code-form')
   await expect(form).toBeVisible()
 
-  // Pick the first available student.
+  // Pin selection to the dedicated internal-exam student fixture.
   const studentSelect = form.locator('[aria-label="Student"]')
   await studentSelect.click()
-  await adminPage.locator('[data-slot="select-item"]').first().click()
+  await adminPage
+    .locator('[data-slot="select-item"]')
+    .filter({ hasText: INTERNAL_EXAM_STUDENT_EMAIL })
+    .first()
+    .click()
 
   // Pick the subject by name fragment.
   const subjectSelect = form.locator('[aria-label="Subject"]')
@@ -66,7 +73,9 @@ async function openStudentContext(browser: BrowserContext['browser']): Promise<{
   page: Page
 }> {
   if (!browser) throw new Error('browser is null')
-  const context = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+  const context = await browser.newContext({
+    storageState: 'e2e/.auth/internal-exam-student.json',
+  })
   const page = await context.newPage()
   return { context, page }
 }

--- a/apps/web/e2e/internal-exam-no-discard-and-void.spec.ts
+++ b/apps/web/e2e/internal-exam-no-discard-and-void.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * E2E spec — Internal Exam: no-discard guarantee + admin void mid-session.
+ *
+ * Covers:
+ *   (a) During an active internal exam, the FinishQuizDialog must NOT show a
+ *       Discard button (only Submit + Return). Internal exams are by-design
+ *       non-discardable for the student — finish-quiz-dialog.tsx gates this on
+ *       canDiscard = canDismiss && !isInternalExam.
+ *   (b) When the admin voids the code mid-session, the student's next
+ *       interaction (continuing to answer + finishing) surfaces the
+ *       cancellation: server-side complete_internal_exam_session enforces
+ *       voided sessions, so the submit will surface an error or the session
+ *       lands on a report flagged as terminated.
+ *
+ * Seed dependency: apps/web/scripts/seed-exam-eval.ts. Assumes admin
+ * (admin@lmsplus.local) and the shared E2E student fixture.
+ *
+ * NOTE: requires migrations 057a..065 to be applied before this spec passes.
+ *
+ * Auth: admin storage is the default; a separate student context is opened
+ * for the in-session checks.
+ */
+
+import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+
+test.use({ storageState: 'e2e/.auth/admin.json' })
+
+const SUBJECT_LABEL_FRAGMENT = 'Meteorology'
+
+async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promise<string> {
+  await adminPage.goto('/app/admin/internal-exams')
+  await expect(adminPage.getByRole('heading', { name: 'Internal Exams' })).toBeVisible()
+  const form = adminPage.getByTestId('issue-code-form')
+  await form.locator('[aria-label="Student"]').click()
+  await adminPage.locator('[data-slot="select-item"]').first().click()
+  await form.locator('[aria-label="Subject"]').click()
+  await adminPage
+    .locator('[data-slot="select-item"]')
+    .filter({ hasText: subjectFragment })
+    .first()
+    .click()
+  await form.getByRole('button', { name: 'Issue code' }).click()
+  await expect(adminPage.getByText('Internal exam code issued')).toBeVisible({ timeout: 10_000 })
+  const code = (await adminPage.getByTestId('issued-code-value').textContent())?.trim()
+  if (!code) throw new Error('issued code panel had no value')
+  return code
+}
+
+async function openStudentContext(
+  browser: BrowserContext['browser'],
+): Promise<{ context: BrowserContext; page: Page }> {
+  if (!browser) throw new Error('browser is null')
+  const context = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+  const page = await context.newPage()
+  return { context, page }
+}
+
+async function startInternalExamAsStudent(page: Page, code: string): Promise<void> {
+  await page.goto('/app/internal-exam')
+  await expect(page.getByRole('heading', { name: 'Internal Exam' })).toBeVisible()
+  await page.getByTestId('start-button').first().click()
+  await expect(page.getByTestId('code-entry-form')).toBeVisible()
+  await page.getByTestId('code-input').fill(code)
+  await page.getByRole('button', { name: 'Start exam' }).click()
+  await page.waitForURL(/\/app\/quiz\/session/, { timeout: 15_000 })
+  await expect(page.getByText(/Question \d/)).toBeVisible({ timeout: 10_000 })
+}
+
+test.describe('internal exam — no-discard + admin void', () => {
+  test.setTimeout(120_000)
+
+  // ── (a) Discard button is hidden in the finish dialog ─────────────────────
+
+  test('FinishQuizDialog hides Discard but shows Submit and Return during an active internal exam', async ({
+    page: adminPage,
+    context: adminCtx,
+  }) => {
+    const code = await issueCodeAsAdmin(adminPage, SUBJECT_LABEL_FRAGMENT)
+
+    const { context: studentCtx, page } = await openStudentContext(adminCtx.browser())
+    try {
+      await startInternalExamAsStudent(page, code)
+
+      // Open the finish dialog from the session header.
+      await page.getByRole('button', { name: 'Finish Internal Exam' }).click()
+
+      // Submit + Return must be visible. Discard must NOT.
+      await expect(page.getByRole('button', { name: 'Submit Quiz' })).toBeVisible({
+        timeout: 5_000,
+      })
+      await expect(page.getByRole('button', { name: 'Return to Internal Exam' })).toBeVisible()
+      await expect(page.getByRole('button', { name: /^Discard /i })).toHaveCount(0)
+    } finally {
+      await studentCtx.close()
+    }
+  })
+
+  // ── (b) Admin voids the code mid-session ──────────────────────────────────
+
+  test('admin voiding the code mid-session surfaces the cancellation to the student', async ({
+    page: adminPage,
+    context: adminCtx,
+  }) => {
+    const code = await issueCodeAsAdmin(adminPage, SUBJECT_LABEL_FRAGMENT)
+
+    const { context: studentCtx, page } = await openStudentContext(adminCtx.browser())
+    try {
+      await startInternalExamAsStudent(page, code)
+
+      // Buffer an answer so the session is not 0-answer.
+      await page.locator('button:has(span.rounded-full)').first().click()
+      await page.waitForTimeout(300)
+
+      // Admin: navigate to internal-exams, void the freshly issued code.
+      await adminPage.goto('/app/admin/internal-exams')
+      await expect(adminPage.getByRole('heading', { name: 'Internal Exams' })).toBeVisible()
+
+      // Find the row containing this code and click its Void button.
+      const codeRow = adminPage.locator('tr', { hasText: code })
+      await expect(codeRow).toBeVisible({ timeout: 10_000 })
+      await codeRow.getByRole('button', { name: 'Void' }).click()
+
+      // Void dialog opens — fill reason and submit.
+      const reasonInput = adminPage.getByLabel('Reason')
+      await reasonInput.fill('E2E spec — voiding mid-session for cancellation surface test')
+      await adminPage.getByRole('button', { name: 'Void code' }).click()
+      await expect(adminPage.getByText(/Code voided/)).toBeVisible({ timeout: 10_000 })
+
+      // Student: attempt to submit the in-flight session — voided codes must
+      // either land on a terminated report OR surface a server-side error.
+      await page.getByRole('button', { name: 'Finish Internal Exam' }).click()
+      await page.getByRole('button', { name: 'Submit Quiz' }).click()
+
+      const reportUrl = page.waitForURL(/\/app\/quiz\/report/, { timeout: 30_000 })
+      const errorText = page
+        .getByText(/voided|cancelled|cancel/i)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 })
+
+      await Promise.race([reportUrl, errorText])
+    } finally {
+      await studentCtx.close()
+    }
+  })
+})

--- a/apps/web/e2e/internal-exam-no-discard-and-void.spec.ts
+++ b/apps/web/e2e/internal-exam-no-discard-and-void.spec.ts
@@ -13,15 +13,17 @@
  *       lands on a report flagged as terminated.
  *
  * Seed dependency: apps/web/scripts/seed-exam-eval.ts. Assumes admin
- * (admin@lmsplus.local) and the shared E2E student fixture.
+ * (admin@lmsplus.local) and the dedicated internal-exam student fixture
+ * (e2e-internal-exam@lmsplus.local) — see helpers/supabase.ts.
  *
  * NOTE: requires migrations 057a..065 to be applied before this spec passes.
  *
  * Auth: admin storage is the default; a separate student context is opened
- * for the in-session checks.
+ * for the in-session checks (uses internal-exam-student.json, not user.json).
  */
 
 import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+import { INTERNAL_EXAM_STUDENT_EMAIL } from './helpers/supabase'
 
 test.use({ storageState: 'e2e/.auth/admin.json' })
 
@@ -32,7 +34,11 @@ async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promi
   await expect(adminPage.getByRole('heading', { name: 'Internal Exams' })).toBeVisible()
   const form = adminPage.getByTestId('issue-code-form')
   await form.locator('[aria-label="Student"]').click()
-  await adminPage.locator('[data-slot="select-item"]').first().click()
+  await adminPage
+    .locator('[data-slot="select-item"]')
+    .filter({ hasText: INTERNAL_EXAM_STUDENT_EMAIL })
+    .first()
+    .click()
   await form.locator('[aria-label="Subject"]').click()
   await adminPage
     .locator('[data-slot="select-item"]')
@@ -50,7 +56,9 @@ async function openStudentContext(
   browser: BrowserContext['browser'],
 ): Promise<{ context: BrowserContext; page: Page }> {
   if (!browser) throw new Error('browser is null')
-  const context = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+  const context = await browser.newContext({
+    storageState: 'e2e/.auth/internal-exam-student.json',
+  })
   const page = await context.newPage()
   return { context, page }
 }

--- a/apps/web/e2e/internal-exam-reports-separation.spec.ts
+++ b/apps/web/e2e/internal-exam-reports-separation.spec.ts
@@ -8,23 +8,21 @@
  *   - /app/internal-exam My Reports tab lists ONLY the internal attempt.
  *
  * Seed dependency: apps/web/scripts/seed-exam-eval.ts. Assumes admin
- * (admin@lmsplus.local) and the shared E2E student fixture.
+ * (admin@lmsplus.local) and the dedicated internal-exam student fixture
+ * (e2e-internal-exam@lmsplus.local) — see helpers/supabase.ts.
  *
  * NOTE: requires migrations 057a..065 to be applied before this spec passes.
  *
  * Auth: admin storage is the default; a separate student context is opened
- * for the student-side assertions.
+ * (internal-exam-student.json) for the student-side assertions.
  */
 
 import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+import { INTERNAL_EXAM_STUDENT_EMAIL } from './helpers/supabase'
 
 test.use({ storageState: 'e2e/.auth/admin.json' })
 
 const SUBJECT_LABEL_FRAGMENT = 'Meteorology'
-// Pin the admin's student-select dropdown to the seeded E2E student so we
-// don't accidentally issue a code to a different student depending on alphabetical
-// order or seed drift. Match the full name from helpers/supabase.ts.
-const STUDENT_LABEL_FRAGMENT = 'E2E Test Student'
 
 async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promise<string> {
   await adminPage.goto('/app/admin/internal-exams')
@@ -33,7 +31,7 @@ async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promi
   await form.locator('[aria-label="Student"]').click()
   await adminPage
     .locator('[data-slot="select-item"]')
-    .filter({ hasText: STUDENT_LABEL_FRAGMENT })
+    .filter({ hasText: INTERNAL_EXAM_STUDENT_EMAIL })
     .first()
     .click()
   await form.locator('[aria-label="Subject"]').click()
@@ -53,7 +51,9 @@ async function openStudentContext(
   browser: BrowserContext['browser'],
 ): Promise<{ context: BrowserContext; page: Page }> {
   if (!browser) throw new Error('browser is null')
-  const context = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+  const context = await browser.newContext({
+    storageState: 'e2e/.auth/internal-exam-student.json',
+  })
   const page = await context.newPage()
   return { context, page }
 }

--- a/apps/web/e2e/internal-exam-reports-separation.spec.ts
+++ b/apps/web/e2e/internal-exam-reports-separation.spec.ts
@@ -107,10 +107,15 @@ test.describe('internal exam — reports separation', () => {
       await page.goto('/app/reports')
       await expect(page.getByRole('heading', { name: 'Reports' })).toBeVisible()
 
-      // Practice Exam label should be present.
-      await expect(page.getByText('Practice Exam').first()).toBeVisible({ timeout: 10_000 })
-      // Internal Exam label must NOT appear.
-      await expect(page.getByText('Internal Exam', { exact: true })).toHaveCount(0)
+      // Scope assertions to the page's <main> region so we don't pick up sidebar
+      // nav links or other layout chrome.
+      const reportsMain = page.getByRole('main')
+      // Practice Exam label should be present in the reports list.
+      await expect(reportsMain.getByText('Practice Exam').first()).toBeVisible({
+        timeout: 10_000,
+      })
+      // Internal Exam label must NOT appear inside the reports list itself.
+      await expect(reportsMain.getByText('Internal Exam', { exact: true })).toHaveCount(0)
 
       // ── /app/internal-exam My Reports tab lists ONLY internal_exam ──────────
       await page.goto('/app/internal-exam')

--- a/apps/web/e2e/internal-exam-reports-separation.spec.ts
+++ b/apps/web/e2e/internal-exam-reports-separation.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * E2E spec — Internal Exam reports are separated from Practice Exam reports.
+ *
+ * Covers: a student with both a `mock_exam` (practice) attempt AND an
+ * `internal_exam` attempt sees:
+ *   - /app/reports lists ONLY the practice attempt (filter excludes
+ *     internal_exam — see lib/queries/reports.ts).
+ *   - /app/internal-exam My Reports tab lists ONLY the internal attempt.
+ *
+ * Seed dependency: apps/web/scripts/seed-exam-eval.ts. Assumes admin
+ * (admin@lmsplus.local) and the shared E2E student fixture.
+ *
+ * NOTE: requires migrations 057a..065 to be applied before this spec passes.
+ *
+ * Auth: admin storage is the default; a separate student context is opened
+ * for the student-side assertions.
+ */
+
+import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+
+test.use({ storageState: 'e2e/.auth/admin.json' })
+
+const SUBJECT_LABEL_FRAGMENT = 'Meteorology'
+
+async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promise<string> {
+  await adminPage.goto('/app/admin/internal-exams')
+  await expect(adminPage.getByRole('heading', { name: 'Internal Exams' })).toBeVisible()
+  const form = adminPage.getByTestId('issue-code-form')
+  await form.locator('[aria-label="Student"]').click()
+  await adminPage.locator('[data-slot="select-item"]').first().click()
+  await form.locator('[aria-label="Subject"]').click()
+  await adminPage
+    .locator('[data-slot="select-item"]')
+    .filter({ hasText: subjectFragment })
+    .first()
+    .click()
+  await form.getByRole('button', { name: 'Issue code' }).click()
+  await expect(adminPage.getByText('Internal exam code issued')).toBeVisible({ timeout: 10_000 })
+  const code = (await adminPage.getByTestId('issued-code-value').textContent())?.trim()
+  if (!code) throw new Error('issued code panel had no value')
+  return code
+}
+
+async function openStudentContext(
+  browser: BrowserContext['browser'],
+): Promise<{ context: BrowserContext; page: Page }> {
+  if (!browser) throw new Error('browser is null')
+  const context = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+  const page = await context.newPage()
+  return { context, page }
+}
+
+async function runPracticeExamToCompletion(page: Page): Promise<void> {
+  await page.goto('/app/quiz')
+  await expect(page.getByRole('heading', { name: 'Quiz' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Practice Exam', exact: true }).click()
+  await page.locator('[data-testid="subject-trigger"]').click()
+  await page.locator('[data-testid="subject-option"]').filter({ hasText: '050' }).first().click()
+  await expect(page.getByText('Practice Exam Parameters')).toBeVisible({ timeout: 5_000 })
+  await page.getByRole('button', { name: 'Start Practice Exam' }).click()
+  await page.waitForURL(/\/app\/quiz\/session/, { timeout: 15_000 })
+  await expect(page.getByText(/Question \d/)).toBeVisible({ timeout: 10_000 })
+
+  await page.locator('button:has(span.rounded-full)').first().click()
+  await page.waitForTimeout(300)
+  await page.getByRole('button', { name: 'Finish Practice Exam' }).click()
+  await page.getByRole('button', { name: 'Submit Quiz' }).click()
+  await page.waitForURL(/\/app\/quiz\/report\?session=/, { timeout: 30_000 })
+}
+
+async function runInternalExamToCompletion(page: Page, code: string): Promise<void> {
+  await page.goto('/app/internal-exam')
+  await expect(page.getByRole('heading', { name: 'Internal Exam' })).toBeVisible()
+  await page.getByTestId('start-button').first().click()
+  await expect(page.getByTestId('code-entry-form')).toBeVisible()
+  await page.getByTestId('code-input').fill(code)
+  await page.getByRole('button', { name: 'Start exam' }).click()
+  await page.waitForURL(/\/app\/quiz\/session/, { timeout: 15_000 })
+  await expect(page.getByText(/Question \d/)).toBeVisible({ timeout: 10_000 })
+
+  await page.locator('button:has(span.rounded-full)').first().click()
+  await page.waitForTimeout(300)
+  await page.getByRole('button', { name: 'Finish Internal Exam' }).click()
+  await page.getByRole('button', { name: 'Submit Quiz' }).click()
+  await page.waitForURL(/\/app\/quiz\/report\?session=/, { timeout: 30_000 })
+}
+
+test.describe('internal exam — reports separation', () => {
+  test.setTimeout(180_000)
+
+  test('practice attempt shows only on /app/reports; internal attempt only on /app/internal-exam', async ({
+    page: adminPage,
+    context: adminCtx,
+  }) => {
+    const code = await issueCodeAsAdmin(adminPage, SUBJECT_LABEL_FRAGMENT)
+
+    const { context: studentCtx, page } = await openStudentContext(adminCtx.browser())
+    try {
+      // Run a practice exam first — this creates a mock_exam quiz_sessions row.
+      await runPracticeExamToCompletion(page)
+
+      // Run an internal exam — this creates an internal_exam quiz_sessions row.
+      await runInternalExamToCompletion(page, code)
+
+      // ── /app/reports lists ONLY mock_exam (practice) attempts ───────────────
+      await page.goto('/app/reports')
+      await expect(page.getByRole('heading', { name: 'Reports' })).toBeVisible()
+
+      // Practice Exam label should be present.
+      await expect(page.getByText('Practice Exam').first()).toBeVisible({ timeout: 10_000 })
+      // Internal Exam label must NOT appear.
+      await expect(page.getByText('Internal Exam', { exact: true })).toHaveCount(0)
+
+      // ── /app/internal-exam My Reports tab lists ONLY internal_exam ──────────
+      await page.goto('/app/internal-exam')
+      await expect(page.getByRole('heading', { name: 'Internal Exam' })).toBeVisible()
+      await page.getByTestId('tab-reports').click()
+      await expect(page.getByTestId('tabpanel-reports')).toBeVisible()
+
+      // At least one internal-exam report row.
+      const reportRows = page.locator('[data-testid^="report-row-"]')
+      await expect(reportRows.first()).toBeVisible({ timeout: 10_000 })
+      // There must be NO "Practice Exam" copy in the My Reports tab — internal
+      // exam history is internal-only.
+      await expect(
+        page.getByTestId('tabpanel-reports').getByText('Practice Exam', { exact: true }),
+      ).toHaveCount(0)
+    } finally {
+      await studentCtx.close()
+    }
+  })
+})

--- a/apps/web/e2e/internal-exam-reports-separation.spec.ts
+++ b/apps/web/e2e/internal-exam-reports-separation.spec.ts
@@ -21,13 +21,21 @@ import { type BrowserContext, expect, type Page, test } from '@playwright/test'
 test.use({ storageState: 'e2e/.auth/admin.json' })
 
 const SUBJECT_LABEL_FRAGMENT = 'Meteorology'
+// Pin the admin's student-select dropdown to the seeded E2E student so we
+// don't accidentally issue a code to a different student depending on alphabetical
+// order or seed drift. Match the full name from helpers/supabase.ts.
+const STUDENT_LABEL_FRAGMENT = 'E2E Test Student'
 
 async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promise<string> {
   await adminPage.goto('/app/admin/internal-exams')
   await expect(adminPage.getByRole('heading', { name: 'Internal Exams' })).toBeVisible()
   const form = adminPage.getByTestId('issue-code-form')
   await form.locator('[aria-label="Student"]').click()
-  await adminPage.locator('[data-slot="select-item"]').first().click()
+  await adminPage
+    .locator('[data-slot="select-item"]')
+    .filter({ hasText: STUDENT_LABEL_FRAGMENT })
+    .first()
+    .click()
   await form.locator('[aria-label="Subject"]').click()
   await adminPage
     .locator('[data-slot="select-item"]')

--- a/apps/web/e2e/internal-exam-resume.spec.ts
+++ b/apps/web/e2e/internal-exam-resume.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * E2E spec — Internal Exam mid-session resume.
+ *
+ * Covers: a student starts an internal exam, reloads the browser tab mid-flow,
+ * and is restored to /app/quiz/session via the sessionStorage handoff. If the
+ * handoff was lost, the recovery banner on /app/internal-exam is the fallback.
+ *
+ * Seed dependency: apps/web/scripts/seed-exam-eval.ts. Assumes admin
+ * (admin@lmsplus.local) and student (e2e-test@lmsplus.local) fixture users
+ * exist in the Egmont Aviation org with at least one active exam_config.
+ *
+ * NOTE: requires migrations 057a..065 to be applied before this spec passes.
+ *
+ * Auth: this spec uses the admin storage state to issue a code, then opens a
+ * separate student context for the resume verification.
+ */
+
+import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+
+test.use({ storageState: 'e2e/.auth/admin.json' })
+
+const SUBJECT_LABEL_FRAGMENT = 'Meteorology'
+
+async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promise<string> {
+  await adminPage.goto('/app/admin/internal-exams')
+  await expect(adminPage.getByRole('heading', { name: 'Internal Exams' })).toBeVisible()
+  const form = adminPage.getByTestId('issue-code-form')
+  await form.locator('[aria-label="Student"]').click()
+  await adminPage.locator('[data-slot="select-item"]').first().click()
+  await form.locator('[aria-label="Subject"]').click()
+  await adminPage
+    .locator('[data-slot="select-item"]')
+    .filter({ hasText: subjectFragment })
+    .first()
+    .click()
+  await form.getByRole('button', { name: 'Issue code' }).click()
+  await expect(adminPage.getByText('Internal exam code issued')).toBeVisible({ timeout: 10_000 })
+  const code = (await adminPage.getByTestId('issued-code-value').textContent())?.trim()
+  if (!code) throw new Error('issued code panel had no value')
+  return code
+}
+
+async function openStudentContext(
+  browser: BrowserContext['browser'],
+): Promise<{ context: BrowserContext; page: Page }> {
+  if (!browser) throw new Error('browser is null')
+  const context = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+  const page = await context.newPage()
+  return { context, page }
+}
+
+async function startInternalExamAsStudent(page: Page, code: string): Promise<void> {
+  await page.goto('/app/internal-exam')
+  await expect(page.getByRole('heading', { name: 'Internal Exam' })).toBeVisible()
+  await page.getByTestId('start-button').first().click()
+  await expect(page.getByTestId('code-entry-form')).toBeVisible()
+  await page.getByTestId('code-input').fill(code)
+  await page.getByRole('button', { name: 'Start exam' }).click()
+  await page.waitForURL(/\/app\/quiz\/session/, { timeout: 15_000 })
+  await expect(page.getByText(/Question \d/)).toBeVisible({ timeout: 10_000 })
+}
+
+test.describe('internal exam — refresh resume', () => {
+  test.setTimeout(120_000)
+
+  test('reloading mid-session restores the session page (or surfaces the recovery banner)', async ({
+    page: adminPage,
+    context: adminCtx,
+  }) => {
+    const code = await issueCodeAsAdmin(adminPage, SUBJECT_LABEL_FRAGMENT)
+
+    const { context: studentCtx, page } = await openStudentContext(adminCtx.browser())
+    try {
+      await startInternalExamAsStudent(page, code)
+
+      // Buffer one answer so there's state worth recovering.
+      await page.locator('button:has(span.rounded-full)').first().click()
+      await page.waitForTimeout(300)
+
+      // Force a full reload — sessionStorage survives in-tab reloads, so the
+      // session page should rehydrate via the handoff. If the handoff is lost
+      // (e.g. fresh tab), the /app/internal-exam page exposes a recovery banner.
+      await page.reload()
+
+      const questionText = page.getByText(/Question \d/)
+      const recoveryBanner = page.getByTestId('internal-exam-recovery-banner')
+      await expect(questionText.or(recoveryBanner)).toBeVisible({ timeout: 15_000 })
+
+      if (await recoveryBanner.isVisible().catch(() => false)) {
+        // Banner path — clicking Resume must land back on /app/quiz/session.
+        await page.getByTestId('resume-internal-exam-link').click()
+        await page.waitForURL(/\/app\/quiz\/session/, { timeout: 10_000 })
+        await expect(page.getByText(/Question \d/)).toBeVisible({ timeout: 10_000 })
+      }
+      // Otherwise: warm rehydrate path — the question is already visible.
+    } finally {
+      await studentCtx.close()
+    }
+  })
+
+  test('navigating to /app/internal-exam mid-session shows the recovery banner', async ({
+    page: adminPage,
+    context: adminCtx,
+  }) => {
+    const code = await issueCodeAsAdmin(adminPage, SUBJECT_LABEL_FRAGMENT)
+
+    const { context: studentCtx, page } = await openStudentContext(adminCtx.browser())
+    try {
+      await startInternalExamAsStudent(page, code)
+
+      // Clear the warm sessionStorage handoff so only the server-side active
+      // session remains. The /app/internal-exam page must surface a banner.
+      await page.evaluate(() => {
+        for (const key of Object.keys(sessionStorage)) {
+          if (key.startsWith('quiz-session:')) sessionStorage.removeItem(key)
+        }
+      })
+
+      await page.goto('/app/internal-exam')
+      await expect(page.getByRole('heading', { name: 'Internal Exam' })).toBeVisible()
+      await expect(page.getByTestId('internal-exam-recovery-banner')).toBeVisible({
+        timeout: 10_000,
+      })
+
+      // Resume button navigates back to the session page.
+      await page.getByTestId('resume-internal-exam-link').click()
+      await page.waitForURL(/\/app\/quiz\/session/, { timeout: 10_000 })
+      await expect(page.getByText(/Question \d/)).toBeVisible({ timeout: 10_000 })
+    } finally {
+      await studentCtx.close()
+    }
+  })
+})

--- a/apps/web/e2e/internal-exam-resume.spec.ts
+++ b/apps/web/e2e/internal-exam-resume.spec.ts
@@ -6,16 +6,18 @@
  * handoff was lost, the recovery banner on /app/internal-exam is the fallback.
  *
  * Seed dependency: apps/web/scripts/seed-exam-eval.ts. Assumes admin
- * (admin@lmsplus.local) and student (e2e-test@lmsplus.local) fixture users
- * exist in the Egmont Aviation org with at least one active exam_config.
+ * (admin@lmsplus.local) and the dedicated internal-exam student fixture
+ * (e2e-internal-exam@lmsplus.local) exist in the Egmont Aviation org with at
+ * least one active exam_config.
  *
  * NOTE: requires migrations 057a..065 to be applied before this spec passes.
  *
  * Auth: this spec uses the admin storage state to issue a code, then opens a
- * separate student context for the resume verification.
+ * separate student context (internal-exam-student.json) for the resume check.
  */
 
 import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+import { INTERNAL_EXAM_STUDENT_EMAIL } from './helpers/supabase'
 
 test.use({ storageState: 'e2e/.auth/admin.json' })
 
@@ -26,7 +28,11 @@ async function issueCodeAsAdmin(adminPage: Page, subjectFragment: string): Promi
   await expect(adminPage.getByRole('heading', { name: 'Internal Exams' })).toBeVisible()
   const form = adminPage.getByTestId('issue-code-form')
   await form.locator('[aria-label="Student"]').click()
-  await adminPage.locator('[data-slot="select-item"]').first().click()
+  await adminPage
+    .locator('[data-slot="select-item"]')
+    .filter({ hasText: INTERNAL_EXAM_STUDENT_EMAIL })
+    .first()
+    .click()
   await form.locator('[aria-label="Subject"]').click()
   await adminPage
     .locator('[data-slot="select-item"]')
@@ -44,7 +50,9 @@ async function openStudentContext(
   browser: BrowserContext['browser'],
 ): Promise<{ context: BrowserContext; page: Page }> {
   if (!browser) throw new Error('browser is null')
-  const context = await browser.newContext({ storageState: 'e2e/.auth/user.json' })
+  const context = await browser.newContext({
+    storageState: 'e2e/.auth/internal-exam-student.json',
+  })
   const page = await context.newPage()
   return { context, page }
 }

--- a/apps/web/e2e/internal-exam-student-auth.setup.ts
+++ b/apps/web/e2e/internal-exam-student-auth.setup.ts
@@ -1,0 +1,22 @@
+import { expect, test as setup } from '@playwright/test'
+import {
+  ensureInternalExamStudentUser,
+  INTERNAL_EXAM_STUDENT_EMAIL,
+  INTERNAL_EXAM_STUDENT_PASSWORD,
+} from './helpers/supabase'
+
+const AUTH_FILE = 'e2e/.auth/internal-exam-student.json'
+
+setup('create internal-exam student authenticated session', async ({ page }) => {
+  await ensureInternalExamStudentUser()
+
+  await page.goto('/')
+  await page.getByLabel('Email address').fill(INTERNAL_EXAM_STUDENT_EMAIL)
+  await page.getByLabel('Password', { exact: true }).fill(INTERNAL_EXAM_STUDENT_PASSWORD)
+  await page.getByRole('button', { name: 'Sign in' }).click()
+
+  await page.waitForURL('**/app/dashboard', { timeout: 15_000 })
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+
+  await page.context().storageState({ path: AUTH_FILE })
+})

--- a/apps/web/e2e/redteam/helpers/seed.ts
+++ b/apps/web/e2e/redteam/helpers/seed.ts
@@ -5,6 +5,11 @@ export const VICTIM_EMAIL = 'redteam-victim@lmsplus.local'
 export const ATTACKER_PASSWORD = 'redteam-attacker-2026!'
 export const VICTIM_PASSWORD = 'redteam-victim-2026!'
 
+export const ADMIN_EMAIL = 'redteam-admin@lmsplus.local'
+export const ADMIN_PASSWORD = 'redteam-admin-2026!'
+export const CROSS_ORG_ADMIN_EMAIL = 'redteam-crossorg-admin@lmsplus.local'
+export const CROSS_ORG_ADMIN_PASSWORD = 'redteam-crossorg-admin-2026!'
+
 const OTHER_ORG_SLUG = 'redteam-other-org'
 
 export async function seedRedTeamUsers(): Promise<{
@@ -90,6 +95,139 @@ export async function createCrossOrgUser(): Promise<{
   return { userId, orgId, email, password }
 }
 
+/**
+ * Ensure an admin user exists in the egmont-aviation org.
+ * Used by internal-exam red-team specs that need to call admin-only RPCs.
+ */
+export async function seedRedTeamAdmin(): Promise<{
+  adminUserId: string
+  orgId: string
+  email: string
+  password: string
+}> {
+  const admin = getAdminClient()
+  const { data: org, error: orgError } = await admin
+    .from('organizations')
+    .select('id')
+    .eq('slug', 'egmont-aviation')
+    .single()
+  if (orgError || !org) throw new Error(`Could not find egmont-aviation org: ${orgError?.message}`)
+  const orgId = org.id
+
+  const adminUserId = await upsertUser(admin, ADMIN_EMAIL, ADMIN_PASSWORD, orgId, 'admin')
+  return { adminUserId, orgId, email: ADMIN_EMAIL, password: ADMIN_PASSWORD }
+}
+
+/**
+ * Ensure an admin user exists in the OTHER (cross-org) org.
+ * Used to test cross-org admin paths (e.g. void_internal_exam_code with foreign org code).
+ */
+export async function seedCrossOrgAdmin(): Promise<{
+  adminUserId: string
+  orgId: string
+  email: string
+  password: string
+}> {
+  const admin = getAdminClient()
+  const { data: existingOtherOrg } = await admin
+    .from('organizations')
+    .select('id')
+    .eq('slug', OTHER_ORG_SLUG)
+    .maybeSingle()
+
+  let orgId: string
+  if (existingOtherOrg) {
+    orgId = existingOtherOrg.id
+  } else {
+    const { data: newOrg, error: newOrgError } = await admin
+      .from('organizations')
+      .insert({ name: 'Red Team Other Org', slug: OTHER_ORG_SLUG })
+      .select('id')
+      .single()
+    if (newOrgError || !newOrg)
+      throw new Error(`Could not create redteam-other-org: ${newOrgError?.message}`)
+    orgId = newOrg.id
+  }
+
+  const adminUserId = await upsertUser(
+    admin,
+    CROSS_ORG_ADMIN_EMAIL,
+    CROSS_ORG_ADMIN_PASSWORD,
+    orgId,
+    'admin',
+  )
+  return { adminUserId, orgId, email: CROSS_ORG_ADMIN_EMAIL, password: CROSS_ORG_ADMIN_PASSWORD }
+}
+
+/**
+ * Ensure an enabled exam_config (with at least one distribution row) exists for
+ * (orgId, subjectId). Idempotent. Returns the exam_config id.
+ *
+ * Used by internal-exam red-team specs that exercise issue/start RPCs which
+ * require an exam_config row to be present.
+ */
+export async function ensureExamConfig(
+  orgId: string,
+  subjectId: string,
+  topicId: string,
+): Promise<string> {
+  const admin = getAdminClient()
+
+  const { data: existing, error: existingError } = await admin
+    .from('exam_configs')
+    .select('id, enabled')
+    .eq('organization_id', orgId)
+    .eq('subject_id', subjectId)
+    .is('deleted_at', null)
+    .maybeSingle()
+  if (existingError) throw new Error(`ensureExamConfig select: ${existingError.message}`)
+
+  let configId: string
+  if (existing) {
+    configId = existing.id
+    if (!existing.enabled) {
+      const { error: enableError } = await admin
+        .from('exam_configs')
+        .update({ enabled: true })
+        .eq('id', configId)
+      if (enableError) throw new Error(`ensureExamConfig enable: ${enableError.message}`)
+    }
+  } else {
+    const { data: created, error: createError } = await admin
+      .from('exam_configs')
+      .insert({
+        organization_id: orgId,
+        subject_id: subjectId,
+        enabled: true,
+        total_questions: 1,
+        time_limit_seconds: 600,
+        pass_mark: 75,
+      })
+      .select('id')
+      .single()
+    if (createError || !created) throw new Error(`ensureExamConfig insert: ${createError?.message}`)
+    configId = created.id
+  }
+
+  // Ensure at least one distribution row.
+  const { data: dist } = await admin
+    .from('exam_config_distributions')
+    .select('id')
+    .eq('exam_config_id', configId)
+    .limit(1)
+  if (!dist || dist.length === 0) {
+    const { error: distError } = await admin.from('exam_config_distributions').insert({
+      exam_config_id: configId,
+      topic_id: topicId,
+      subtopic_id: null,
+      question_count: 1,
+    })
+    if (distError) throw new Error(`ensureExamConfig distribution: ${distError.message}`)
+  }
+
+  return configId
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -99,6 +237,7 @@ async function upsertUser(
   email: string,
   password: string,
   orgId: string,
+  role: 'student' | 'admin' = 'student',
 ): Promise<string> {
   // Check if auth user already exists
   const { data: list, error: listError } = await admin.auth.admin.listUsers()
@@ -106,10 +245,12 @@ async function upsertUser(
 
   const existing = list.users.find((u) => u.email === email)
   if (existing) {
-    // Ensure public.users row exists (may have been cleaned up)
+    // Ensure public.users row exists (may have been cleaned up) AND has the
+    // expected role + org. Re-running the helper across spec files must be
+    // idempotent; a user that drifted (org changed, role demoted) gets fixed.
     const { data: userRow } = await admin
       .from('users')
-      .select('id')
+      .select('id, organization_id, role')
       .eq('id', existing.id)
       .maybeSingle()
     if (!userRow) {
@@ -118,10 +259,17 @@ async function upsertUser(
         organization_id: orgId,
         email,
         full_name: `Red Team ${email.split('@')[0]}`,
-        role: 'student',
+        role,
       })
       if (insertError)
         throw new Error(`Could not insert user row for ${email}: ${insertError.message}`)
+    } else if (userRow.organization_id !== orgId || userRow.role !== role) {
+      const { error: updateError } = await admin
+        .from('users')
+        .update({ organization_id: orgId, role })
+        .eq('id', existing.id)
+      if (updateError)
+        throw new Error(`Could not realign user row for ${email}: ${updateError.message}`)
     }
     return existing.id
   }
@@ -143,7 +291,7 @@ async function upsertUser(
     organization_id: orgId,
     email,
     full_name: `Red Team ${email.split('@')[0]}`,
-    role: 'student',
+    role,
   })
   if (insertError) throw new Error(`Could not insert user row for ${email}: ${insertError.message}`)
 

--- a/apps/web/e2e/redteam/rpc-internal-exam-codes.spec.ts
+++ b/apps/web/e2e/redteam/rpc-internal-exam-codes.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * Red Team Spec: internal_exam_codes Table — RLS Read/Write Isolation
+ *
+ * Vectors BE / BF / BG (HIGH): direct table access on internal_exam_codes.
+ *  - BE: unauthenticated SELECT must return 0 rows (or error).
+ *  - BF: authenticated student INSERT/UPDATE/DELETE must be blocked at the
+ *        RLS layer (no INSERT/DELETE policy; UPDATE policy gates on is_admin()).
+ *  - BG: student-B SELECT of student-A's code row must return 0 rows.
+ *
+ * Status: Expected to PASS — table has RLS enabled, no INSERT/DELETE policy,
+ * UPDATE policy requires is_admin(). If any assertion fails it is an RLS gap.
+ */
+
+import { expect, test } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+import { getAdminClient } from '../helpers/supabase'
+import { createAuthenticatedClient } from './helpers/redteam-client'
+import {
+  ATTACKER_EMAIL,
+  ATTACKER_PASSWORD,
+  seedRedTeamUsers,
+  VICTIM_EMAIL,
+  VICTIM_PASSWORD,
+} from './helpers/seed'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://localhost:54321'
+const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+const unauthClient = createClient(SUPABASE_URL, ANON_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+test.describe('Red Team: internal_exam_codes table RLS', () => {
+  let attackerClient: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let victimClient: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let admin: ReturnType<typeof getAdminClient>
+  let victimCodeId: string
+  let victimCodeText: string
+  let attackerCodeId: string
+
+  test.beforeAll(async () => {
+    const { attackerUserId, victimUserId, orgId } = await seedRedTeamUsers()
+    attackerClient = await createAuthenticatedClient(ATTACKER_EMAIL, ATTACKER_PASSWORD)
+    victimClient = await createAuthenticatedClient(VICTIM_EMAIL, VICTIM_PASSWORD)
+    admin = getAdminClient()
+
+    // Resolve a real subject from egmont-aviation
+    const { data: subjects } = await admin.from('easa_subjects').select('id').limit(1)
+    expect(subjects).not.toBeNull()
+    const subjectId = subjects![0].id
+
+    // Seed two active codes (one per student) directly via service-role.
+    // Direct INSERT bypasses RLS — that's fine; we're constructing fixture data,
+    // not exercising the issue RPC here.
+    victimCodeText = `RT${Date.now().toString(36).toUpperCase().slice(-6)}V`
+    const { data: vRow, error: vErr } = await admin
+      .from('internal_exam_codes')
+      .insert({
+        code: victimCodeText,
+        subject_id: subjectId,
+        student_id: victimUserId,
+        issued_by: victimUserId, // not exercised by RLS, just FK satisfaction
+        expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        organization_id: orgId,
+      })
+      .select('id')
+      .single()
+    if (vErr || !vRow) throw new Error(`Could not seed victim code: ${vErr?.message}`)
+    victimCodeId = vRow.id
+
+    const attackerCodeText = `RT${Date.now().toString(36).toUpperCase().slice(-6)}A`
+    const { data: aRow, error: aErr } = await admin
+      .from('internal_exam_codes')
+      .insert({
+        code: attackerCodeText,
+        subject_id: subjectId,
+        student_id: attackerUserId,
+        issued_by: attackerUserId,
+        expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        organization_id: orgId,
+      })
+      .select('id')
+      .single()
+    if (aErr || !aRow) throw new Error(`Could not seed attacker code: ${aErr?.message}`)
+    attackerCodeId = aRow.id
+  })
+
+  test('unauthenticated client sees 0 rows from internal_exam_codes (Vector BE)', async () => {
+    const { data, error } = await unauthClient
+      .from('internal_exam_codes')
+      .select('id, code, student_id')
+      .limit(50)
+
+    // RLS returns empty for anon — not an error
+    expect(error).toBeNull()
+    expect(data?.length ?? 0).toBe(0)
+  })
+
+  test('student-B cannot SELECT student-A code via direct table read (Vector BG)', async () => {
+    // Attacker probes by victim code id — the only allowed SELECT path is
+    // student_read_active_codes (student_id = auth.uid()) or admin policy. The
+    // attacker is neither; result must be 0 rows.
+    const { data, error } = await attackerClient
+      .from('internal_exam_codes')
+      .select('id, code, student_id')
+      .eq('id', victimCodeId)
+
+    expect(error).toBeNull()
+    expect(data?.length ?? 0).toBe(0)
+  })
+
+  test('student sees only their own active code via direct SELECT', async () => {
+    // Sanity: the policy correctly admits the student's own row.
+    const { data, error } = await attackerClient
+      .from('internal_exam_codes')
+      .select('id, student_id')
+      .eq('id', attackerCodeId)
+
+    expect(error).toBeNull()
+    expect(data?.length ?? 0).toBe(1)
+  })
+
+  test('student cannot INSERT directly into internal_exam_codes (Vector BF)', async () => {
+    // Table has no INSERT policy and no INSERT GRANT to authenticated.
+    // The attempt must fail with an RLS / permission error — never silently succeed.
+    const { data: meRes } = await attackerClient.auth.getUser()
+    const myId = meRes?.user?.id ?? ''
+    const { data: subjects } = await admin.from('easa_subjects').select('id').limit(1)
+    const subjectId = subjects![0].id
+    const { data: org } = await admin
+      .from('users')
+      .select('organization_id')
+      .eq('id', myId)
+      .single()
+    const orgId = org?.organization_id
+
+    const forgedCode = `FORGED${Date.now().toString(36).toUpperCase().slice(-4)}`
+    const { error } = await attackerClient.from('internal_exam_codes').insert({
+      code: forgedCode,
+      subject_id: subjectId,
+      student_id: myId,
+      issued_by: myId,
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      organization_id: orgId,
+    })
+
+    // Must error (no INSERT GRANT). PostgREST returns code 42501 (permission denied)
+    // or RLS-violation error. Either way, error must not be null.
+    expect(error).not.toBeNull()
+
+    // Belt-and-braces: verify no row with this code exists in the DB.
+    const { data: probe } = await admin
+      .from('internal_exam_codes')
+      .select('id')
+      .eq('code', forgedCode)
+    expect(probe?.length ?? 0).toBe(0)
+  })
+
+  test('student cannot UPDATE another student code via direct write (Vector BF)', async () => {
+    // UPDATE policy requires is_admin(); student attempts must be silently
+    // filtered (0 rows affected) per RLS USING clause behaviour — verify the
+    // row is unchanged in the DB.
+    const { data: before } = await admin
+      .from('internal_exam_codes')
+      .select('voided_at, void_reason')
+      .eq('id', victimCodeId)
+      .single()
+
+    await attackerClient
+      .from('internal_exam_codes')
+      .update({ voided_at: new Date().toISOString(), void_reason: 'red team forge' })
+      .eq('id', victimCodeId)
+
+    const { data: after } = await admin
+      .from('internal_exam_codes')
+      .select('voided_at, void_reason')
+      .eq('id', victimCodeId)
+      .single()
+
+    expect(after?.voided_at ?? null).toEqual(before?.voided_at ?? null)
+    expect(after?.void_reason ?? null).toEqual(before?.void_reason ?? null)
+  })
+
+  test('student cannot UPDATE their own code (admin-only UPDATE policy) (Vector BF)', async () => {
+    // Even on rows the student can SELECT (their own active code), the UPDATE
+    // policy gates on is_admin(). A student updating their own row must result
+    // in zero affected rows — no privilege escalation via own-row mutation.
+    const { data: before } = await admin
+      .from('internal_exam_codes')
+      .select('void_reason')
+      .eq('id', attackerCodeId)
+      .single()
+
+    await attackerClient
+      .from('internal_exam_codes')
+      .update({ void_reason: 'self-void attempt' })
+      .eq('id', attackerCodeId)
+
+    const { data: after } = await admin
+      .from('internal_exam_codes')
+      .select('void_reason')
+      .eq('id', attackerCodeId)
+      .single()
+
+    expect(after?.void_reason ?? null).toEqual(before?.void_reason ?? null)
+  })
+
+  test('student cannot DELETE rows from internal_exam_codes (Vector BF)', async () => {
+    // No DELETE policy and no DELETE GRANT — attempts must error or be no-ops.
+    await victimClient.from('internal_exam_codes').delete().eq('id', victimCodeId)
+
+    // Verify row still exists.
+    const { data: after } = await admin
+      .from('internal_exam_codes')
+      .select('id')
+      .eq('id', victimCodeId)
+      .maybeSingle()
+    expect(after?.id).toBe(victimCodeId)
+  })
+})

--- a/apps/web/e2e/redteam/rpc-internal-exam-codes.spec.ts
+++ b/apps/web/e2e/redteam/rpc-internal-exam-codes.spec.ts
@@ -46,8 +46,10 @@ test.describe('Red Team: internal_exam_codes table RLS', () => {
 
     // Resolve a real subject from egmont-aviation
     const { data: subjects } = await admin.from('easa_subjects').select('id').limit(1)
-    expect(subjects).not.toBeNull()
-    const subjectId = subjects![0].id
+    if (!subjects || subjects.length === 0) {
+      throw new Error('seed: no easa_subjects rows available for red-team setup')
+    }
+    const subjectId = subjects[0]!.id
 
     // Seed two active codes (one per student) directly via service-role.
     // Direct INSERT bypasses RLS — that's fine; we're constructing fixture data,
@@ -126,7 +128,10 @@ test.describe('Red Team: internal_exam_codes table RLS', () => {
     const { data: meRes } = await attackerClient.auth.getUser()
     const myId = meRes?.user?.id ?? ''
     const { data: subjects } = await admin.from('easa_subjects').select('id').limit(1)
-    const subjectId = subjects![0].id
+    if (!subjects || subjects.length === 0) {
+      throw new Error('seed: no easa_subjects rows available for INSERT vector')
+    }
+    const subjectId = subjects[0]!.id
     const { data: org } = await admin
       .from('users')
       .select('organization_id')

--- a/apps/web/e2e/redteam/rpc-internal-exam-codes.spec.ts
+++ b/apps/web/e2e/redteam/rpc-internal-exam-codes.spec.ts
@@ -126,7 +126,8 @@ test.describe('Red Team: internal_exam_codes table RLS', () => {
     // Table has no INSERT policy and no INSERT GRANT to authenticated.
     // The attempt must fail with an RLS / permission error — never silently succeed.
     const { data: meRes } = await attackerClient.auth.getUser()
-    const myId = meRes?.user?.id ?? ''
+    const myId = meRes?.user?.id
+    if (!myId) throw new Error('seed: attackerClient has no authenticated user')
     const { data: subjects } = await admin.from('easa_subjects').select('id').limit(1)
     if (!subjects || subjects.length === 0) {
       throw new Error('seed: no easa_subjects rows available for INSERT vector')
@@ -138,6 +139,7 @@ test.describe('Red Team: internal_exam_codes table RLS', () => {
       .eq('id', myId)
       .single()
     const orgId = org?.organization_id
+    if (!orgId) throw new Error('seed: attacker user has no organization_id')
 
     const forgedCode = `FORGED${Date.now().toString(36).toUpperCase().slice(-4)}`
     const { error } = await attackerClient.from('internal_exam_codes').insert({
@@ -149,9 +151,13 @@ test.describe('Red Team: internal_exam_codes table RLS', () => {
       organization_id: orgId,
     })
 
-    // Must error (no INSERT GRANT). PostgREST returns code 42501 (permission denied)
-    // or RLS-violation error. Either way, error must not be null.
+    // Must error with a permission/RLS class — not a NOT NULL or FK error
+    // that would mean the test is "passing" for the wrong reason.
     expect(error).not.toBeNull()
+    expect(
+      error?.code === '42501' ||
+        /permission denied|row-level security|rls/i.test(error?.message ?? ''),
+    ).toBe(true)
 
     // Belt-and-braces: verify no row with this code exists in the DB.
     const { data: probe } = await admin

--- a/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
+++ b/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
@@ -124,27 +124,36 @@ test.describe('Red Team: issue_internal_exam_code RPC', () => {
     }
 
     // Other red-team specs (e.g. rpc-question-membership) pick the second subject
-    // returned by `select('id').limit(2)` and expect it to have at least one topic.
-    // When our subjects upsert above runs in a CI Supabase that had only one
-    // pre-existing subject, RT-FIXTURE-2 ends up as that "second subject" — but
-    // it has no topics by default, breaking those specs. Seed a topic for it.
+    // returned by `select('id').limit(2)` and expect it to have at least one topic
+    // AND at least one question linked to that topic. When our subjects upsert above
+    // runs in a CI Supabase that had only one pre-existing subject, RT-FIXTURE-2 ends
+    // up as that "second subject" — but it has no topics or questions by default,
+    // breaking those specs. Seed both.
+    let unconfTopicId: string
     const { data: unconfTopics } = await admin
       .from('easa_topics')
       .select('id')
       .eq('subject_id', unconfiguredSubjectId)
       .limit(1)
-    if (!unconfTopics || unconfTopics.length === 0) {
-      const { error: unconfTopicErr } = await admin.from('easa_topics').insert({
-        subject_id: unconfiguredSubjectId,
-        code: 'RT-T2',
-        name: 'Red Team Fixture Topic 2',
-        sort_order: 9002,
-      })
-      if (unconfTopicErr) {
+    if (unconfTopics && unconfTopics.length > 0) {
+      unconfTopicId = unconfTopics[0].id
+    } else {
+      const { data: insertedUnconfTopic, error: unconfTopicErr } = await admin
+        .from('easa_topics')
+        .insert({
+          subject_id: unconfiguredSubjectId,
+          code: 'RT-T2',
+          name: 'Red Team Fixture Topic 2',
+          sort_order: 9002,
+        })
+        .select('id')
+        .single()
+      if (unconfTopicErr || !insertedUnconfTopic) {
         throw new Error(
-          `seed: failed to insert fixture topic for unconfigured subject: ${unconfTopicErr.message}`,
+          `seed: failed to insert fixture topic for unconfigured subject: ${unconfTopicErr?.message}`,
         )
       }
+      unconfTopicId = insertedUnconfTopic.id
     }
 
     // Seed an enabled exam_config for the configured subject in the egmont org.
@@ -154,6 +163,47 @@ test.describe('Red Team: issue_internal_exam_code RPC', () => {
       .eq('slug', 'egmont-aviation')
       .single()
     const egmontOrgId = orgRow!.id
+
+    // Ensure rpc-question-membership has at least one question on the unconfigured
+    // subject's topic. Idempotent — only inserts if no question exists.
+    const { data: existingUnconfQ } = await admin
+      .from('questions')
+      .select('id')
+      .eq('topic_id', unconfTopicId)
+      .is('deleted_at', null)
+      .limit(1)
+    if (!existingUnconfQ || existingUnconfQ.length === 0) {
+      const { data: bankRow } = await admin
+        .from('question_banks')
+        .select('id')
+        .eq('organization_id', egmontOrgId)
+        .is('deleted_at', null)
+        .limit(1)
+        .maybeSingle()
+      if (bankRow) {
+        const { error: unconfQErr } = await admin.from('questions').insert({
+          organization_id: egmontOrgId,
+          bank_id: bankRow.id,
+          question_number: 'RT-FOREIGN-1',
+          subject_id: unconfiguredSubjectId,
+          topic_id: unconfTopicId,
+          question_text: 'Red team fixture: foreign-subject question.',
+          options: [
+            { id: 'a', text: 'A', correct: true },
+            { id: 'b', text: 'B', correct: false },
+            { id: 'c', text: 'C', correct: false },
+            { id: 'd', text: 'D', correct: false },
+          ],
+          explanation_text: 'Fixture only.',
+          difficulty: 'medium',
+          status: 'active',
+          created_by: egmontStudentId,
+        })
+        if (unconfQErr) {
+          throw new Error(`seed: failed to insert foreign-subject question: ${unconfQErr.message}`)
+        }
+      }
+    }
     await ensureExamConfig(egmontOrgId, configuredSubjectId, topicId)
 
     // Ensure NO active exam_config exists for the unconfigured subject. Soft-delete

--- a/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
+++ b/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Red Team Spec: issue_internal_exam_code RPC
+ *
+ * Vectors BH / BI (HIGH): admin-only RPC that issues a single-use code.
+ *  - BH(1): unauthenticated → 'not_authenticated'
+ *  - BH(2): authenticated student (non-admin) → 'not_admin'
+ *  - BI:    cross-org admin issuing for foreign-org student → 'student_not_found'
+ *  - extra: missing exam_config → 'exam_config_required'
+ *
+ * Status: Expected to PASS — every guard is in the SECURITY DEFINER body of
+ * `issue_internal_exam_code`. Failure means the auth/admin/org/exam-config
+ * gates are not firing as documented.
+ */
+
+import { expect, test } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+import { getAdminClient } from '../helpers/supabase'
+import { createAuthenticatedClient } from './helpers/redteam-client'
+import {
+  ATTACKER_EMAIL,
+  ATTACKER_PASSWORD,
+  createCrossOrgUser,
+  ensureExamConfig,
+  seedCrossOrgAdmin,
+  seedRedTeamAdmin,
+  seedRedTeamUsers,
+} from './helpers/seed'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://localhost:54321'
+const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+const unauthClient = createClient(SUPABASE_URL, ANON_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+test.describe('Red Team: issue_internal_exam_code RPC', () => {
+  let admin: ReturnType<typeof getAdminClient>
+  let attackerStudentClient: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let adminClientAuthed: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let crossOrgAdminClient: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let egmontStudentId: string
+  let crossOrgStudentId: string
+  let configuredSubjectId: string
+  let unconfiguredSubjectId: string
+
+  test.beforeAll(async () => {
+    admin = getAdminClient()
+
+    const { victimUserId } = await seedRedTeamUsers()
+    egmontStudentId = victimUserId
+
+    const { email: adminEmail, password: adminPassword } = await seedRedTeamAdmin()
+    const crossOrg = await seedCrossOrgAdmin()
+    // Reuse the cross-org student helper (creates a student in the other org).
+    const crossOrgUser = await createCrossOrgUser()
+    crossOrgStudentId = crossOrgUser.userId
+
+    attackerStudentClient = await createAuthenticatedClient(ATTACKER_EMAIL, ATTACKER_PASSWORD)
+    adminClientAuthed = await createAuthenticatedClient(adminEmail, adminPassword)
+    crossOrgAdminClient = await createAuthenticatedClient(crossOrg.email, crossOrg.password)
+
+    // Resolve subjects/topics for the egmont org.
+    const { data: subjects } = await admin
+      .from('easa_subjects')
+      .select('id')
+      .order('sort_order', { ascending: true })
+      .limit(2)
+    expect(subjects).not.toBeNull()
+    expect(subjects!.length).toBeGreaterThanOrEqual(2)
+    configuredSubjectId = subjects![0].id
+    unconfiguredSubjectId = subjects![1].id
+
+    const { data: topics } = await admin
+      .from('easa_topics')
+      .select('id')
+      .eq('subject_id', configuredSubjectId)
+      .limit(1)
+    const topicId = topics?.[0]?.id ?? configuredSubjectId
+
+    // Seed an enabled exam_config for the configured subject in the egmont org.
+    const { data: orgRow } = await admin
+      .from('organizations')
+      .select('id')
+      .eq('slug', 'egmont-aviation')
+      .single()
+    const egmontOrgId = orgRow!.id
+    await ensureExamConfig(egmontOrgId, configuredSubjectId, topicId)
+
+    // Ensure NO active exam_config exists for the unconfigured subject. Soft-delete
+    // any pre-existing row to keep the test deterministic.
+    await admin
+      .from('exam_configs')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('organization_id', egmontOrgId)
+      .eq('subject_id', unconfiguredSubjectId)
+      .is('deleted_at', null)
+  })
+
+  test('unauthenticated call returns not_authenticated (Vector BH-1)', async () => {
+    const { data, error } = await unauthClient.rpc('issue_internal_exam_code', {
+      p_subject_id: configuredSubjectId,
+      p_student_id: egmontStudentId,
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/not_authenticated/i)
+    expect(data).toBeNull()
+  })
+
+  test('authenticated student (non-admin) cannot issue codes (Vector BH-2)', async () => {
+    const { data, error } = await attackerStudentClient.rpc('issue_internal_exam_code', {
+      p_subject_id: configuredSubjectId,
+      p_student_id: egmontStudentId,
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/not_admin/i)
+    expect(data).toBeNull()
+  })
+
+  test('admin cannot issue code for student in different org (Vector BI)', async () => {
+    // The egmont admin targets a student in the cross-org tenant. The RPC must
+    // reject with 'student_not_found' (existence-hiding).
+    const { data, error } = await adminClientAuthed.rpc('issue_internal_exam_code', {
+      p_subject_id: configuredSubjectId,
+      p_student_id: crossOrgStudentId,
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/student_not_found/i)
+    expect(data).toBeNull()
+  })
+
+  test('cross-org admin cannot issue code for egmont student (mirror of BI)', async () => {
+    // The cross-org admin targets the egmont student. Same expected outcome.
+    const { data, error } = await crossOrgAdminClient.rpc('issue_internal_exam_code', {
+      p_subject_id: configuredSubjectId,
+      p_student_id: egmontStudentId,
+    })
+
+    expect(error).not.toBeNull()
+    // Either student_not_found (org mismatch) or subject_not_found (subject not
+    // visible to other org). Both are valid existence-hiding outcomes; pin the
+    // primary expectation but accept the alternate.
+    expect(error?.message ?? '').toMatch(/student_not_found|subject_not_found/i)
+    expect(data).toBeNull()
+  })
+
+  test('admin issuing for valid student but missing exam_config returns exam_config_required', async () => {
+    const { data, error } = await adminClientAuthed.rpc('issue_internal_exam_code', {
+      p_subject_id: unconfiguredSubjectId,
+      p_student_id: egmontStudentId,
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/exam_config_required/i)
+    expect(data).toBeNull()
+  })
+
+  test('admin happy path returns a code with the same expected shape', async () => {
+    // Sanity: the RPC actually issues a code on the valid path. This anchors
+    // the negative tests above — without it, all four could pass for the wrong
+    // reason (RPC always errors).
+    const { data, error } = await adminClientAuthed.rpc('issue_internal_exam_code', {
+      p_subject_id: configuredSubjectId,
+      p_student_id: egmontStudentId,
+    })
+
+    expect(error).toBeNull()
+    expect(Array.isArray(data)).toBe(true)
+    const row = (data as Array<{ code_id: string; code: string; expires_at: string }> | null)?.[0]
+    expect(row).toBeTruthy()
+    expect(typeof row?.code).toBe('string')
+    expect(row?.code.length).toBe(8)
+    expect(typeof row?.code_id).toBe('string')
+    expect(typeof row?.expires_at).toBe('string')
+  })
+})

--- a/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
+++ b/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
@@ -59,12 +59,39 @@ test.describe('Red Team: issue_internal_exam_code RPC', () => {
     adminClientAuthed = await createAuthenticatedClient(adminEmail, adminPassword)
     crossOrgAdminClient = await createAuthenticatedClient(crossOrg.email, crossOrg.password)
 
-    // Resolve subjects/topics for the egmont org.
-    const { data: subjects } = await admin
+    // Resolve subjects/topics for the egmont org. Need at least 2 distinct
+    // subjects (one configured, one unconfigured). CI Supabase seeds may carry
+    // only one — top up with throwaway rows when needed.
+    let { data: subjects } = await admin
       .from('easa_subjects')
       .select('id')
       .order('sort_order', { ascending: true })
       .limit(2)
+    if (!subjects || subjects.length < 2) {
+      await admin.from('easa_subjects').upsert(
+        [
+          {
+            code: 'RT-FIXTURE-1',
+            name: 'Red Team Fixture Subject 1',
+            short: 'RTF1',
+            sort_order: 9001,
+          },
+          {
+            code: 'RT-FIXTURE-2',
+            name: 'Red Team Fixture Subject 2',
+            short: 'RTF2',
+            sort_order: 9002,
+          },
+        ],
+        { onConflict: 'code', ignoreDuplicates: true },
+      )
+      const refetched = await admin
+        .from('easa_subjects')
+        .select('id')
+        .order('sort_order', { ascending: true })
+        .limit(2)
+      subjects = refetched.data
+    }
     expect(subjects).not.toBeNull()
     expect(subjects!.length).toBeGreaterThanOrEqual(2)
     configuredSubjectId = subjects![0].id
@@ -75,7 +102,24 @@ test.describe('Red Team: issue_internal_exam_code RPC', () => {
       .select('id')
       .eq('subject_id', configuredSubjectId)
       .limit(1)
-    const topicId = topics?.[0]?.id ?? configuredSubjectId
+    // Don't fall back to configuredSubjectId — easa_topics.id and easa_subjects.id
+    // are distinct relations; ensureExamConfig would FK-fail downstream.
+    let topicId = topics?.[0]?.id
+    if (!topicId) {
+      const { data: insertedTopic, error: topicErr } = await admin
+        .from('easa_topics')
+        .insert({
+          subject_id: configuredSubjectId,
+          code: 'RT-T1',
+          name: 'Red Team Fixture Topic 1',
+        })
+        .select('id')
+        .single()
+      if (topicErr || !insertedTopic) {
+        throw new Error(`seed: failed to insert fixture topic: ${topicErr?.message}`)
+      }
+      topicId = insertedTopic.id
+    }
 
     // Seed an enabled exam_config for the configured subject in the egmont org.
     const { data: orgRow } = await admin

--- a/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
+++ b/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
@@ -112,6 +112,8 @@ test.describe('Red Team: issue_internal_exam_code RPC', () => {
           subject_id: configuredSubjectId,
           code: 'RT-T1',
           name: 'Red Team Fixture Topic 1',
+          // easa_topics.sort_order is INT NOT NULL with no default (mig 001).
+          sort_order: 9001,
         })
         .select('id')
         .single()

--- a/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
+++ b/apps/web/e2e/redteam/rpc-issue-internal-exam-code.spec.ts
@@ -123,6 +123,30 @@ test.describe('Red Team: issue_internal_exam_code RPC', () => {
       topicId = insertedTopic.id
     }
 
+    // Other red-team specs (e.g. rpc-question-membership) pick the second subject
+    // returned by `select('id').limit(2)` and expect it to have at least one topic.
+    // When our subjects upsert above runs in a CI Supabase that had only one
+    // pre-existing subject, RT-FIXTURE-2 ends up as that "second subject" — but
+    // it has no topics by default, breaking those specs. Seed a topic for it.
+    const { data: unconfTopics } = await admin
+      .from('easa_topics')
+      .select('id')
+      .eq('subject_id', unconfiguredSubjectId)
+      .limit(1)
+    if (!unconfTopics || unconfTopics.length === 0) {
+      const { error: unconfTopicErr } = await admin.from('easa_topics').insert({
+        subject_id: unconfiguredSubjectId,
+        code: 'RT-T2',
+        name: 'Red Team Fixture Topic 2',
+        sort_order: 9002,
+      })
+      if (unconfTopicErr) {
+        throw new Error(
+          `seed: failed to insert fixture topic for unconfigured subject: ${unconfTopicErr.message}`,
+        )
+      }
+    }
+
     // Seed an enabled exam_config for the configured subject in the egmont org.
     const { data: orgRow } = await admin
       .from('organizations')

--- a/apps/web/e2e/redteam/rpc-start-internal-exam-session.spec.ts
+++ b/apps/web/e2e/redteam/rpc-start-internal-exam-session.spec.ts
@@ -44,6 +44,7 @@ async function seedCode(
     orgId: string
     expiresInMs?: number
     consumedAt?: string | null
+    consumedSessionId?: string | null
     voidedAt?: string | null
     voidedBy?: string | null
   },
@@ -65,7 +66,34 @@ async function seedCode(
     expires_at: expiresAt,
     organization_id: opts.orgId,
   }
-  if (opts.consumedAt) insertRow.consumed_at = opts.consumedAt
+  if (opts.consumedAt) {
+    insertRow.consumed_at = opts.consumedAt
+    // CHECK constraint consumed_pair_consistency requires consumed_session_id
+    // and consumed_at to be NULL together or both set together. When the caller
+    // doesn't provide a real session id, synthesise a placeholder quiz_session
+    // so the seed satisfies the constraint and the RPC's read-side guard runs.
+    let sessionId = opts.consumedSessionId
+    if (!sessionId) {
+      const { data: sessionRow, error: sessionErr } = await admin
+        .from('quiz_sessions')
+        .insert({
+          organization_id: opts.orgId,
+          student_id: opts.studentId,
+          mode: 'internal_exam',
+          subject_id: opts.subjectId,
+          config: { question_ids: [] },
+          total_questions: 0,
+          ended_at: opts.consumedAt,
+        })
+        .select('id')
+        .single()
+      if (sessionErr || !sessionRow) {
+        throw new Error(`seedCode placeholder session: ${sessionErr?.message}`)
+      }
+      sessionId = sessionRow.id
+    }
+    insertRow.consumed_session_id = sessionId
+  }
   if (opts.voidedAt) {
     insertRow.voided_at = opts.voidedAt
     insertRow.voided_by = opts.voidedBy ?? opts.studentId
@@ -112,7 +140,15 @@ test.describe('Red Team: start_internal_exam_session RPC', () => {
       .select('id')
       .eq('subject_id', subjectId)
       .limit(1)
-    const topicId = topics?.[0]?.id ?? subjectId
+    // Don't fall back to subjectId — easa_topics.id and easa_subjects.id are
+    // distinct relations; a fallback would FK-fail downstream with a confusing
+    // error instead of a clear setup failure.
+    const topicId = topics?.[0]?.id
+    if (!topicId) {
+      throw new Error(
+        `seed: no easa_topics row for subject ${subjectId} — red-team fixtures need at least one topic`,
+      )
+    }
 
     await ensureExamConfig(orgId, subjectId, topicId)
   })

--- a/apps/web/e2e/redteam/rpc-start-internal-exam-session.spec.ts
+++ b/apps/web/e2e/redteam/rpc-start-internal-exam-session.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Red Team Spec: start_internal_exam_session RPC
+ *
+ * Vectors BJ / BK / BL / BM (HIGH/MEDIUM): student-facing RPC that redeems a
+ * single-use code and creates an internal_exam quiz_session.
+ *  - BJ: unauthenticated → 'not_authenticated'
+ *  - BK: student-B uses student-A's code → 'code_not_yours' (cross-student)
+ *  - BL(1): expired code → 'code_expired'
+ *  - BL(2): voided code  → 'code_voided'
+ *  - BM:  double-redemption / consumed code → 'code_already_used'
+ *  - extra: starting a second concurrent code while a session is already
+ *           active for the same subject → 'active_session_exists'
+ *
+ * Status: Expected to PASS — every guard is in the SECURITY DEFINER body.
+ */
+
+import { expect, test } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+import { getAdminClient } from '../helpers/supabase'
+import { createAuthenticatedClient } from './helpers/redteam-client'
+import {
+  ATTACKER_EMAIL,
+  ATTACKER_PASSWORD,
+  ensureExamConfig,
+  seedRedTeamUsers,
+  VICTIM_EMAIL,
+  VICTIM_PASSWORD,
+} from './helpers/seed'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://localhost:54321'
+const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+const unauthClient = createClient(SUPABASE_URL, ANON_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+type CodeRow = { id: string; code: string }
+
+async function seedCode(
+  admin: ReturnType<typeof getAdminClient>,
+  opts: {
+    studentId: string
+    subjectId: string
+    orgId: string
+    expiresInMs?: number
+    consumedAt?: string | null
+    voidedAt?: string | null
+    voidedBy?: string | null
+  },
+): Promise<CodeRow> {
+  const code = `RT${Math.random()
+    .toString(36)
+    .toUpperCase()
+    .replace(/[^A-Z2-9]/g, 'A')
+    .slice(0, 6)}`
+  const expiresAt = new Date(Date.now() + (opts.expiresInMs ?? 60 * 60 * 1000)).toISOString()
+  const insertRow: Record<string, unknown> = {
+    code,
+    subject_id: opts.subjectId,
+    student_id: opts.studentId,
+    issued_by: opts.studentId, // FK satisfaction; not exercised by the RPC
+    expires_at: expiresAt,
+    organization_id: opts.orgId,
+  }
+  if (opts.consumedAt) insertRow.consumed_at = opts.consumedAt
+  if (opts.voidedAt) {
+    insertRow.voided_at = opts.voidedAt
+    insertRow.voided_by = opts.voidedBy ?? opts.studentId
+  }
+  const { data, error } = await admin
+    .from('internal_exam_codes')
+    .insert(insertRow)
+    .select('id, code')
+    .single()
+  if (error || !data) throw new Error(`seedCode: ${error?.message}`)
+  return data
+}
+
+test.describe('Red Team: start_internal_exam_session RPC', () => {
+  let admin: ReturnType<typeof getAdminClient>
+  let attackerClient: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let victimClient: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let attackerUserId: string
+  let victimUserId: string
+  let orgId: string
+  let subjectId: string
+
+  test.beforeAll(async () => {
+    admin = getAdminClient()
+
+    const seed = await seedRedTeamUsers()
+    attackerUserId = seed.attackerUserId
+    victimUserId = seed.victimUserId
+    orgId = seed.orgId
+
+    attackerClient = await createAuthenticatedClient(ATTACKER_EMAIL, ATTACKER_PASSWORD)
+    victimClient = await createAuthenticatedClient(VICTIM_EMAIL, VICTIM_PASSWORD)
+
+    // Resolve subject + topic from egmont and ensure an exam_config exists so
+    // the RPC can reach the active-session / consumption code paths.
+    const { data: subjects } = await admin.from('easa_subjects').select('id').limit(1)
+    expect(subjects).not.toBeNull()
+    subjectId = subjects![0].id
+
+    const { data: topics } = await admin
+      .from('easa_topics')
+      .select('id')
+      .eq('subject_id', subjectId)
+      .limit(1)
+    const topicId = topics?.[0]?.id ?? subjectId
+
+    await ensureExamConfig(orgId, subjectId, topicId)
+  })
+
+  test('unauthenticated call returns not_authenticated (Vector BJ)', async () => {
+    const { data, error } = await unauthClient.rpc('start_internal_exam_session', {
+      p_code: 'NEVERUSED',
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/not_authenticated/i)
+    expect(data).toBeNull()
+  })
+
+  test('student-B using student-A code is rejected without disclosing existence (Vector BK)', async () => {
+    const code = await seedCode(admin, {
+      studentId: victimUserId,
+      subjectId,
+      orgId,
+    })
+
+    // Attacker (student-B) tries to redeem the victim's code.
+    const { data, error } = await attackerClient.rpc('start_internal_exam_session', {
+      p_code: code.code,
+    })
+
+    expect(error).not.toBeNull()
+    // The RPC raises 'code_not_yours'; spec-design also accepts 'code_not_found'
+    // as an existence-hiding alternative. Either is a valid generic error and
+    // must NOT leak any session id, exam config, or question ids.
+    expect(error?.message ?? '').toMatch(/code_not_yours|code_not_found/i)
+    expect(data).toBeNull()
+
+    // Belt-and-braces: no session was created for the attacker against the
+    // victim's code.
+    const { data: probe } = await admin
+      .from('quiz_sessions')
+      .select('id')
+      .eq('student_id', attackerUserId)
+      .eq('mode', 'internal_exam')
+      .is('deleted_at', null)
+    expect((probe ?? []).length).toBe(0)
+  })
+
+  test('expired code is rejected with code_expired (Vector BL-1)', async () => {
+    // Insert a code that was already expired one minute ago.
+    const code = await seedCode(admin, {
+      studentId: victimUserId,
+      subjectId,
+      orgId,
+      expiresInMs: -60_000,
+    })
+
+    const { data, error } = await victimClient.rpc('start_internal_exam_session', {
+      p_code: code.code,
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/code_expired/i)
+    expect(data).toBeNull()
+  })
+
+  test('voided code is rejected with code_voided (Vector BL-2)', async () => {
+    const code = await seedCode(admin, {
+      studentId: victimUserId,
+      subjectId,
+      orgId,
+      voidedAt: new Date().toISOString(),
+      voidedBy: victimUserId,
+    })
+
+    const { data, error } = await victimClient.rpc('start_internal_exam_session', {
+      p_code: code.code,
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/code_voided/i)
+    expect(data).toBeNull()
+  })
+
+  test('already-consumed code is rejected with code_already_used (Vector BM)', async () => {
+    // Seed a code marked consumed via direct admin insert (skips the FOR UPDATE
+    // lock that the RPC uses; the read-side guard `IF v_code_consumed IS NOT NULL`
+    // is what we're exercising).
+    const code = await seedCode(admin, {
+      studentId: victimUserId,
+      subjectId,
+      orgId,
+      consumedAt: new Date().toISOString(),
+    })
+
+    const { data, error } = await victimClient.rpc('start_internal_exam_session', {
+      p_code: code.code,
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/code_already_used/i)
+    expect(data).toBeNull()
+  })
+
+  test('second valid code for same subject while a session is active raises active_session_exists', async () => {
+    // Issue two valid (non-consumed, non-voided, future-expiry) codes for the
+    // same student + subject. Redeem the first to create an active session,
+    // then attempt the second — must hit the duplicate-active guard.
+    const code1 = await seedCode(admin, {
+      studentId: attackerUserId,
+      subjectId,
+      orgId,
+    })
+    const code2 = await seedCode(admin, {
+      studentId: attackerUserId,
+      subjectId,
+      orgId,
+    })
+
+    const first = await attackerClient.rpc('start_internal_exam_session', {
+      p_code: code1.code,
+    })
+    // The first redemption requires sufficient questions in the configured
+    // distribution. If the test fixture lacks them, the RPC raises
+    // 'insufficient_questions_for_exam' before reaching the active-session
+    // guard. Skip the assertion in that case (covered by SQL integration tests).
+    if (first.error && /insufficient_questions/i.test(first.error.message)) {
+      test.info().annotations.push({
+        type: 'skip',
+        description: 'insufficient seeded questions for exam_config — fixture limitation',
+      })
+      return
+    }
+    expect(first.error).toBeNull()
+
+    const second = await attackerClient.rpc('start_internal_exam_session', {
+      p_code: code2.code,
+    })
+    expect(second.error).not.toBeNull()
+    expect(second.error?.message ?? '').toMatch(/active_session_exists/i)
+    expect(second.data).toBeNull()
+  })
+})

--- a/apps/web/e2e/redteam/rpc-start-internal-exam-session.spec.ts
+++ b/apps/web/e2e/redteam/rpc-start-internal-exam-session.spec.ts
@@ -48,8 +48,11 @@ async function seedCode(
     voidedBy?: string | null
   },
 ): Promise<CodeRow> {
-  const code = `RT${Math.random()
-    .toString(36)
+  // crypto.randomUUID() is collision-resistant; Math.random() can collide
+  // across rapid test runs in the same describe block.
+  const code = `RT${crypto
+    .randomUUID()
+    .replace(/-/g, '')
     .toUpperCase()
     .replace(/[^A-Z2-9]/g, 'A')
     .slice(0, 6)}`
@@ -99,8 +102,10 @@ test.describe('Red Team: start_internal_exam_session RPC', () => {
     // Resolve subject + topic from egmont and ensure an exam_config exists so
     // the RPC can reach the active-session / consumption code paths.
     const { data: subjects } = await admin.from('easa_subjects').select('id').limit(1)
-    expect(subjects).not.toBeNull()
-    subjectId = subjects![0].id
+    if (!subjects || subjects.length === 0) {
+      throw new Error('seed: no easa_subjects rows available for red-team setup')
+    }
+    subjectId = subjects[0]!.id
 
     const { data: topics } = await admin
       .from('easa_topics')
@@ -231,10 +236,10 @@ test.describe('Red Team: start_internal_exam_session RPC', () => {
     // 'insufficient_questions_for_exam' before reaching the active-session
     // guard. Skip the assertion in that case (covered by SQL integration tests).
     if (first.error && /insufficient_questions/i.test(first.error.message)) {
-      test.info().annotations.push({
-        type: 'skip',
-        description: 'insufficient seeded questions for exam_config — fixture limitation',
-      })
+      test.skip(
+        true,
+        'insufficient seeded questions for exam_config — fixture limitation; covered by SQL integration tests',
+      )
       return
     }
     expect(first.error).toBeNull()

--- a/apps/web/e2e/redteam/rpc-void-internal-exam-code.spec.ts
+++ b/apps/web/e2e/redteam/rpc-void-internal-exam-code.spec.ts
@@ -42,8 +42,11 @@ async function seedCode(
   admin: ReturnType<typeof getAdminClient>,
   opts: SeedOpts,
 ): Promise<{ id: string; code: string }> {
-  const code = `RT${Math.random()
-    .toString(36)
+  // crypto.randomUUID() is collision-resistant; Math.random() can collide
+  // across rapid test runs in the same describe block.
+  const code = `RT${crypto
+    .randomUUID()
+    .replace(/-/g, '')
     .toUpperCase()
     .replace(/[^A-Z2-9]/g, 'A')
     .slice(0, 6)}`
@@ -124,8 +127,10 @@ test.describe('Red Team: void_internal_exam_code RPC', () => {
     crossOrgAdminClient = await createAuthenticatedClient(crossOrg.email, crossOrg.password)
 
     const { data: subjects } = await admin.from('easa_subjects').select('id').limit(1)
-    expect(subjects).not.toBeNull()
-    subjectId = subjects![0].id
+    if (!subjects || subjects.length === 0) {
+      throw new Error('seed: no easa_subjects rows available for red-team setup')
+    }
+    subjectId = subjects[0]!.id
 
     const { data: topics } = await admin
       .from('easa_topics')

--- a/apps/web/e2e/redteam/rpc-void-internal-exam-code.spec.ts
+++ b/apps/web/e2e/redteam/rpc-void-internal-exam-code.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * Red Team Spec: void_internal_exam_code RPC
+ *
+ * Vectors BN/BO/BP (HIGH). Admin-only RPC that voids a code and (optionally)
+ * ends the linked active session. Tests cover:
+ *  - BN(1) unauthenticated → not_authenticated
+ *  - BN(2) student → not_admin
+ *  - BO    cross-org admin → code_not_found (existence-hiding)
+ *  - BP    consumed + finished session → cannot_void_finished_attempt
+ *  - positive — consumed + active session ends with passed=false.
+ */
+
+import { expect, test } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+import { getAdminClient } from '../helpers/supabase'
+import { createAuthenticatedClient } from './helpers/redteam-client'
+import {
+  ATTACKER_EMAIL,
+  ATTACKER_PASSWORD,
+  ensureExamConfig,
+  seedCrossOrgAdmin,
+  seedRedTeamAdmin,
+  seedRedTeamUsers,
+} from './helpers/seed'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://localhost:54321'
+const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+const unauthClient = createClient(SUPABASE_URL, ANON_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+type SeedOpts = {
+  studentId: string
+  subjectId: string
+  orgId: string
+  issuedBy: string
+  consumedSessionId?: string
+}
+
+async function seedCode(
+  admin: ReturnType<typeof getAdminClient>,
+  opts: SeedOpts,
+): Promise<{ id: string; code: string }> {
+  const code = `RT${Math.random()
+    .toString(36)
+    .toUpperCase()
+    .replace(/[^A-Z2-9]/g, 'A')
+    .slice(0, 6)}`
+  const row: Record<string, unknown> = {
+    code,
+    subject_id: opts.subjectId,
+    student_id: opts.studentId,
+    issued_by: opts.issuedBy,
+    expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    organization_id: opts.orgId,
+    ...(opts.consumedSessionId
+      ? { consumed_at: new Date().toISOString(), consumed_session_id: opts.consumedSessionId }
+      : {}),
+  }
+  const { data, error } = await admin
+    .from('internal_exam_codes')
+    .insert(row)
+    .select('id, code')
+    .single()
+  if (error || !data) throw new Error(`seedCode: ${error?.message}`)
+  return data
+}
+
+async function seedSession(
+  admin: ReturnType<typeof getAdminClient>,
+  opts: { studentId: string; subjectId: string; orgId: string; ended?: boolean },
+): Promise<string> {
+  const row: Record<string, unknown> = {
+    organization_id: opts.orgId,
+    student_id: opts.studentId,
+    mode: 'internal_exam',
+    subject_id: opts.subjectId,
+    config: { question_ids: [], pass_mark: 75 },
+    total_questions: 1,
+    time_limit_seconds: 600,
+    ...(opts.ended
+      ? {
+          ended_at: new Date().toISOString(),
+          score_percentage: 100,
+          passed: true,
+          correct_count: 1,
+        }
+      : {}),
+  }
+  const { data, error } = await admin.from('quiz_sessions').insert(row).select('id').single()
+  if (error || !data) throw new Error(`seedSession: ${error?.message}`)
+  return data.id
+}
+
+test.describe('Red Team: void_internal_exam_code RPC', () => {
+  let admin: ReturnType<typeof getAdminClient>
+  let attackerStudentClient: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let adminClientAuthed: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let crossOrgAdminClient: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let adminUserId: string
+  let victimUserId: string
+  let orgId: string
+  let subjectId: string
+
+  test.beforeAll(async () => {
+    admin = getAdminClient()
+
+    const seed = await seedRedTeamUsers()
+    victimUserId = seed.victimUserId
+    orgId = seed.orgId
+
+    const {
+      adminUserId: aId,
+      email: adminEmail,
+      password: adminPassword,
+    } = await seedRedTeamAdmin()
+    adminUserId = aId
+
+    const crossOrg = await seedCrossOrgAdmin()
+
+    attackerStudentClient = await createAuthenticatedClient(ATTACKER_EMAIL, ATTACKER_PASSWORD)
+    adminClientAuthed = await createAuthenticatedClient(adminEmail, adminPassword)
+    crossOrgAdminClient = await createAuthenticatedClient(crossOrg.email, crossOrg.password)
+
+    const { data: subjects } = await admin.from('easa_subjects').select('id').limit(1)
+    expect(subjects).not.toBeNull()
+    subjectId = subjects![0].id
+
+    const { data: topics } = await admin
+      .from('easa_topics')
+      .select('id')
+      .eq('subject_id', subjectId)
+      .limit(1)
+    const topicId = topics?.[0]?.id ?? subjectId
+
+    // Egmont org needs the exam_config so subject is "exam-eligible".
+    await ensureExamConfig(orgId, subjectId, topicId)
+  })
+
+  // Compact factories — every test uses the same victim+subject+org+issuer.
+  const validCode = () =>
+    seedCode(admin, { studentId: victimUserId, subjectId, orgId, issuedBy: adminUserId })
+  const codeForSession = (consumedSessionId: string) =>
+    seedCode(admin, {
+      studentId: victimUserId,
+      subjectId,
+      orgId,
+      issuedBy: adminUserId,
+      consumedSessionId,
+    })
+  const session = (ended?: boolean) =>
+    seedSession(admin, { studentId: victimUserId, subjectId, orgId, ended })
+
+  test('unauthenticated call returns not_authenticated (Vector BN-1)', async () => {
+    const code = await validCode()
+    const { data, error } = await unauthClient.rpc('void_internal_exam_code', {
+      p_code_id: code.id,
+      p_reason: 'red team',
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/not_authenticated/i)
+    expect(data).toBeNull()
+  })
+
+  test('authenticated student (non-admin) cannot void a code (Vector BN-2)', async () => {
+    const code = await validCode()
+    const { data, error } = await attackerStudentClient.rpc('void_internal_exam_code', {
+      p_code_id: code.id,
+      p_reason: 'red team',
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/not_admin/i)
+    expect(data).toBeNull()
+  })
+
+  test('cross-org admin cannot void code in foreign org (Vector BO)', async () => {
+    const code = await validCode()
+    const { data, error } = await crossOrgAdminClient.rpc('void_internal_exam_code', {
+      p_code_id: code.id,
+      p_reason: 'red team cross-org void',
+    })
+
+    expect(error).not.toBeNull()
+    // Existence-hiding: must report code_not_found, not a more specific error.
+    expect(error?.message ?? '').toMatch(/code_not_found/i)
+    expect(data).toBeNull()
+
+    const { data: row } = await admin
+      .from('internal_exam_codes')
+      .select('voided_at')
+      .eq('id', code.id)
+      .single()
+    expect(row?.voided_at ?? null).toBeNull()
+  })
+
+  test('void on consumed code with finished session raises cannot_void_finished_attempt (Vector BP)', async () => {
+    const sessionId = await session(true)
+    const code = await codeForSession(sessionId)
+
+    const { data, error } = await adminClientAuthed.rpc('void_internal_exam_code', {
+      p_code_id: code.id,
+      p_reason: 'attempted retroactive void',
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toMatch(/cannot_void_finished_attempt/i)
+    expect(data).toBeNull()
+
+    // Score must NOT have changed.
+    const { data: sessionRow } = await admin
+      .from('quiz_sessions')
+      .select('score_percentage, passed')
+      .eq('id', sessionId)
+      .single()
+    expect(sessionRow?.score_percentage).toBe(100)
+    expect(sessionRow?.passed).toBe(true)
+  })
+
+  test('positive path: voiding a code with an active session ends it with passed=false', async () => {
+    const sessionId = await session()
+    const code = await codeForSession(sessionId)
+
+    const { data, error } = await adminClientAuthed.rpc('void_internal_exam_code', {
+      p_code_id: code.id,
+      p_reason: 'positive path',
+    })
+
+    expect(error).toBeNull()
+    const result = (
+      data as Array<{ code_id: string; session_id: string; session_ended: boolean }> | null
+    )?.[0]
+    expect(result?.code_id).toBe(code.id)
+    expect(result?.session_id).toBe(sessionId)
+    expect(result?.session_ended).toBe(true)
+
+    // DB asserts: session ended with passed=false, code voided by this admin.
+    const { data: sessionRow } = await admin
+      .from('quiz_sessions')
+      .select('ended_at, passed')
+      .eq('id', sessionId)
+      .single()
+    expect(sessionRow?.ended_at).not.toBeNull()
+    expect(sessionRow?.passed).toBe(false)
+
+    const { data: codeRow } = await admin
+      .from('internal_exam_codes')
+      .select('voided_at, voided_by, void_reason')
+      .eq('id', code.id)
+      .single()
+    expect(codeRow?.voided_at).not.toBeNull()
+    expect(codeRow?.voided_by).toBe(adminUserId)
+    expect(codeRow?.void_reason).toBe('positive path')
+  })
+})

--- a/apps/web/lib/constants/exam-modes.test.ts
+++ b/apps/web/lib/constants/exam-modes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { EXAM_MODES, isExamMode, MODE_LABELS, type QuizMode } from './exam-modes'
+
+describe('MODE_LABELS', () => {
+  it('provides a label for every quiz_sessions.mode value', () => {
+    const expectedKeys: QuizMode[] = ['smart_review', 'quick_quiz', 'mock_exam', 'internal_exam']
+    for (const key of expectedKeys) {
+      expect(MODE_LABELS[key]).toBeDefined()
+    }
+    // Guard against accidental extra keys drifting away from the DB enum.
+    expect(Object.keys(MODE_LABELS).sort()).toEqual([...expectedKeys].sort())
+  })
+
+  it('renders the expected human-readable label per mode', () => {
+    expect(MODE_LABELS.smart_review).toBe('Smart Review')
+    expect(MODE_LABELS.quick_quiz).toBe('Quick Quiz')
+    expect(MODE_LABELS.mock_exam).toBe('Practice Exam')
+    expect(MODE_LABELS.internal_exam).toBe('Internal Exam')
+  })
+
+  it('uses non-empty strings for every label', () => {
+    for (const label of Object.values(MODE_LABELS)) {
+      expect(typeof label).toBe('string')
+      expect(label.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('isExamMode', () => {
+  it('returns true for exam modes', () => {
+    expect(isExamMode('mock_exam')).toBe(true)
+    expect(isExamMode('internal_exam')).toBe(true)
+  })
+
+  it('returns false for non-exam modes', () => {
+    expect(isExamMode('quick_quiz')).toBe(false)
+    expect(isExamMode('smart_review')).toBe(false)
+  })
+
+  it('returns false for unknown strings', () => {
+    expect(isExamMode('garbage')).toBe(false)
+    expect(isExamMode('')).toBe(false)
+  })
+
+  it('exposes EXAM_MODES that match the type guard', () => {
+    for (const mode of EXAM_MODES) {
+      expect(isExamMode(mode)).toBe(true)
+    }
+  })
+})

--- a/apps/web/lib/constants/exam-modes.ts
+++ b/apps/web/lib/constants/exam-modes.ts
@@ -1,0 +1,13 @@
+export const MODE_LABELS = {
+  smart_review: 'Smart Review',
+  quick_quiz: 'Quick Quiz',
+  mock_exam: 'Practice Exam',
+  internal_exam: 'Internal Exam',
+} as const
+
+export type QuizMode = keyof typeof MODE_LABELS
+
+export const EXAM_MODES = ['mock_exam', 'internal_exam'] as const
+
+export const isExamMode = (mode: string): mode is 'mock_exam' | 'internal_exam' =>
+  (EXAM_MODES as readonly string[]).includes(mode)

--- a/apps/web/lib/queries/reports.test.ts
+++ b/apps/web/lib/queries/reports.test.ts
@@ -154,4 +154,57 @@ describe('getSessionReports', () => {
     const result = await getSessionReports(DEFAULT_OPTS)
     expect(result).toMatchObject({ ok: true, sessions: [], totalCount: 0 })
   })
+
+  // ---- internal_exam exclusion --------------------------------------------
+
+  it('filters out internal_exam rows from the session list', async () => {
+    mockRpc.mockResolvedValue({
+      data: [
+        makeRpcRow({ id: 'sess-quick', mode: 'quick_quiz' }),
+        makeRpcRow({ id: 'sess-internal', mode: 'internal_exam' }),
+        makeRpcRow({ id: 'sess-mock', mode: 'mock_exam' }),
+        makeRpcRow({ id: 'sess-smart', mode: 'smart_review' }),
+      ],
+      error: null,
+    })
+
+    const result = await getSessionReports(DEFAULT_OPTS)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const ids = result.sessions.map((s) => s.id)
+    expect(ids).not.toContain('sess-internal')
+    expect(ids).toEqual(['sess-quick', 'sess-mock', 'sess-smart'])
+  })
+
+  it('retains mock_exam, quick_quiz, and smart_review rows when filtering', async () => {
+    mockRpc.mockResolvedValue({
+      data: [
+        makeRpcRow({ id: 'sess-mock', mode: 'mock_exam' }),
+        makeRpcRow({ id: 'sess-quick', mode: 'quick_quiz' }),
+        makeRpcRow({ id: 'sess-smart', mode: 'smart_review' }),
+      ],
+      error: null,
+    })
+
+    const result = await getSessionReports(DEFAULT_OPTS)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.sessions).toHaveLength(3)
+    expect(result.sessions.map((s) => s.mode).sort()).toEqual(
+      ['mock_exam', 'quick_quiz', 'smart_review'].sort(),
+    )
+  })
+
+  it('returns empty sessions when every row is internal_exam', async () => {
+    mockRpc.mockResolvedValue({
+      data: [
+        makeRpcRow({ id: 'a', mode: 'internal_exam' }),
+        makeRpcRow({ id: 'b', mode: 'internal_exam' }),
+      ],
+      error: null,
+    })
+
+    const result = await getSessionReports(DEFAULT_OPTS)
+    expect(result).toMatchObject({ ok: true, sessions: [], totalCount: 0 })
+  })
 })

--- a/apps/web/lib/queries/reports.test.ts
+++ b/apps/web/lib/queries/reports.test.ts
@@ -174,6 +174,9 @@ describe('getSessionReports', () => {
     const ids = result.sessions.map((s) => s.id)
     expect(ids).not.toContain('sess-internal')
     expect(ids).toEqual(['sess-quick', 'sess-mock', 'sess-smart'])
+    // totalCount comes from the RPC window function (total_count field on the
+    // first surviving row); makeRpcRow seeds it as 1.
+    expect(result.totalCount).toBe(1)
   })
 
   it('retains mock_exam, quick_quiz, and smart_review rows when filtering', async () => {

--- a/apps/web/lib/queries/reports.ts
+++ b/apps/web/lib/queries/reports.ts
@@ -85,7 +85,11 @@ export async function getSessionReports(opts: SessionReportsOpts): Promise<Sessi
     return { ok: false, error: 'Failed to load reports' }
   }
 
-  const rows = Array.isArray(data) ? (data as RpcRow[]) : []
+  const allRows = Array.isArray(data) ? (data as RpcRow[]) : []
+
+  // Internal exam attempts live in the dedicated student "My Reports" tab and the
+  // admin attempts table — they must NOT pollute the practice/quiz session reports list.
+  const rows = allRows.filter((r) => r.mode !== 'internal_exam')
 
   if (rows.length === 0) {
     // Could be empty result or out-of-range page — for out-of-range we need to know totalCount.

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
     { name: 'setup', testMatch: 'auth.setup.ts' },
     { name: 'admin-setup', testMatch: 'admin-auth.setup.ts' },
     {
+      name: 'internal-exam-student-setup',
+      testMatch: 'internal-exam-student-auth.setup.ts',
+    },
+    {
       name: 'e2e',
       testMatch: '**/*.spec.ts',
       testIgnore: [
@@ -40,9 +44,11 @@ export default defineConfig({
       name: 'admin-e2e',
       testMatch: ['**/admin-*.spec.ts', '**/internal-exam-*.spec.ts'],
       testIgnore: '**/redteam/**',
-      // setup is required so that e2e/.auth/user.json exists for the
-      // student-side context opened inside the internal-exam-* specs.
-      dependencies: ['setup', 'admin-setup'],
+      // internal-exam-student-setup creates a dedicated student fixture for the
+      // student-side context spawned inside the internal-exam-* specs. Using a
+      // dedicated user (not user.json) avoids session-rotation invalidation
+      // caused by the prior `e2e` project's specs running against user.json.
+      dependencies: ['admin-setup', 'internal-exam-student-setup'],
     },
     {
       name: 'redteam',

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -26,14 +26,23 @@ export default defineConfig({
     {
       name: 'e2e',
       testMatch: '**/*.spec.ts',
-      testIgnore: ['**/redteam/**', '**/admin-*.spec.ts'],
+      testIgnore: [
+        '**/redteam/**',
+        '**/admin-*.spec.ts',
+        // Internal Exam cross-role specs need both admin + student auth
+        // states; they run under the admin-e2e project (depends on
+        // admin-setup) and open a separate student context inside the test.
+        '**/internal-exam-*.spec.ts',
+      ],
       dependencies: ['setup'],
     },
     {
       name: 'admin-e2e',
-      testMatch: '**/admin-*.spec.ts',
+      testMatch: ['**/admin-*.spec.ts', '**/internal-exam-*.spec.ts'],
       testIgnore: '**/redteam/**',
-      dependencies: ['admin-setup'],
+      // setup is required so that e2e/.auth/user.json exists for the
+      // student-side context opened inside the internal-exam-* specs.
+      dependencies: ['setup', 'admin-setup'],
     },
     {
       name: 'redteam',

--- a/docs/database.md
+++ b/docs/database.md
@@ -475,28 +475,40 @@ Immutable append-only GDPR consent audit log. Tracks user acceptance of Terms of
 
 ### internal_exam_codes
 
-Single-use 8-character codes for starting `internal_exam` mode sessions. Admins issue codes, students consume them once to start a session. Codes expire after 24 hours.
+Single-use 8-character codes for starting `internal_exam` mode sessions. Admins issue a code targeting a specific student + subject; the student consumes the code once to start a session. Codes expire after 24 hours.
 
 | Column | Type | Constraints |
 |--------|------|-------------|
 | id | UUID | PK, default gen_random_uuid() |
-| organization_id | UUID | FK → organizations(id), NOT NULL |
-| code | TEXT | NOT NULL, 8 chars from ABCDEFGHJKLMNPQRSTUVWXYZ23456789, UNIQUE |
-| issued_by | UUID | FK → users(id), NOT NULL (admin who issued the code) |
-| consumed_by | UUID | FK → users(id), NULL (student who consumed the code) |
-| session_id | UUID | FK → quiz_sessions(id), NULL (the resulting session) |
+| code | TEXT | NOT NULL, 8 chars from `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` (Crockford-style; excludes `0/O/I/1`), UNIQUE |
+| subject_id | UUID | FK → easa_subjects(id), NOT NULL |
+| student_id | UUID | FK → users(id), NOT NULL (target student) |
+| issued_by | UUID | FK → users(id), NOT NULL (admin who issued) |
 | issued_at | TIMESTAMPTZ | NOT NULL, default now() |
-| consumed_at | TIMESTAMPTZ | NULL (timestamp of consumption) |
-| voided_at | TIMESTAMPTZ | NULL (timestamp if voided by admin) |
-| voided_by | UUID | FK → users(id), NULL (admin who voided the code) |
+| expires_at | TIMESTAMPTZ | NOT NULL (issued_at + 24h) |
+| consumed_at | TIMESTAMPTZ | NULL — set when student starts a session |
+| consumed_session_id | UUID | FK → quiz_sessions(id), NULL — paired with `consumed_at` via CHECK |
+| voided_at | TIMESTAMPTZ | NULL — set when admin voids the code |
+| voided_by | UUID | FK → users(id), NULL — paired with `voided_at` via CHECK |
+| void_reason | TEXT | NULL — admin-supplied reason on void |
+| organization_id | UUID | FK → organizations(id), NOT NULL |
+| deleted_at | TIMESTAMPTZ | NULL |
 
-**RLS policies:**
-- SELECT: students see only own-consumed codes; admins see org-scoped codes via `is_admin()`
-- INSERT: denied (all writes via SECURITY DEFINER RPCs only)
-- UPDATE: denied (immutable)
-- DELETE: denied (immutable)
+**Constraints:**
+- `consumed_pair_consistency` CHECK — `(consumed_at IS NULL) = (consumed_session_id IS NULL)`
+- `voided_pair_consistency` CHECK — `(voided_at IS NULL) = (voided_by IS NULL)`
 
-**Pattern:** Accessed via three SECURITY DEFINER RPCs: `issue_internal_exam_code()` (admin), `start_internal_exam_session()` (student), `void_internal_exam_code()` (admin). No direct client writes.
+**Indexes:**
+- `idx_internal_exam_codes_active` on `(student_id, expires_at)` WHERE active (not consumed/voided/expired/deleted)
+- `idx_internal_exam_codes_org` on `(organization_id)` WHERE `deleted_at IS NULL`
+
+**RLS policies (FORCE RLS, migration `20260429000009`):**
+- SELECT (student): `student_id = auth.uid()` AND active (not consumed, not voided, not expired, not deleted)
+- SELECT (admin): `is_admin()` AND org-scoped
+- UPDATE (admin): `is_admin()` AND org-scoped (USING + WITH CHECK)
+- No INSERT or DELETE policies — issuance/consumption/void happen via SECURITY DEFINER RPCs only.
+
+**Pattern:** Accessed via three SECURITY DEFINER RPCs: `issue_internal_exam_code()` (admin), `start_internal_exam_session()` (student), `void_internal_exam_code()` (admin). The `start_internal_exam_session` RPC additionally guards against duplicate active sessions via the `WHERE consumed_at IS NULL` race-clause on the consumption UPDATE (migration `20260429000010`).
 
 ---
 
@@ -586,6 +598,7 @@ ORDER BY deleted_at DESC;
 | `exam_configs` | Yes | Per-subject exam configuration; soft-deleted when org removes exam mode |
 | `exam_config_distributions` | Hard DELETE (approved exception) | No `deleted_at`; replaced atomically by `upsert_exam_config` RPC. Also cascades from parent `exam_configs` via `ON DELETE CASCADE` |
 | `question_comments` | Hard DELETE (explicit exception — low audit value) | deleted_at exists as safety net but not used by application code |
+| `internal_exam_codes` | Yes | Issued codes form an audit trail; admin void uses `voided_at`/`void_reason`, soft-delete reserved for compliance archival |
 
 > **Admin write access (migration 039):** `easa_subjects`, `easa_topics`, and `easa_subtopics` have RLS policies granting INSERT/UPDATE/DELETE to users where `is_admin()` returns `true`. All other users have SELECT-only access. These policies exist to support the Admin Syllabus Manager feature.
 
@@ -1250,6 +1263,63 @@ Completes a `mock_exam` session whose deadline has passed. Computes score from a
 **Return shape:** `{ session_id, score_percentage, passed, total_questions, answered_count }` — identical to `complete_empty_exam_session` for caller symmetry.
 
 **`start_exam_session` interaction (migration 050):** The replaced `start_exam_session` adds `'started_at'` to its return jsonb and, before raising the duplicate-active-session guard, looks up any same-subject `mock_exam` session that is past its deadline and calls `complete_overdue_exam_session` on it. The `started_at` field lets the client compute remaining time from the server clock instead of trusting its own local clock at start. Existing callers that ignore unknown jsonb keys (e.g. `start-exam.ts` Zod `safeParse` of a closed object) are unaffected — the schema strips unknown keys by default.
+
+**Internal-exam extension (migration `20260429000008`):** `complete_overdue_exam_session` and `complete_empty_exam_session` were widened from `mode = 'mock_exam'` to `mode IN ('mock_exam', 'internal_exam')`. The audit `event_type` is branched: `internal_exam.expired` / `internal_exam.completed` for internal-exam sessions, the existing `exam.*` events for mock-exam sessions.
+
+---
+
+#### Internal Exam RPCs (mode `internal_exam`)
+
+Three SECURITY DEFINER RPCs implement the internal-exam lifecycle. All three set `search_path = public`, gate via `auth.uid()`, and apply `deleted_at IS NULL` filters on every SELECT (including `actor_role` audit subqueries) per security.md rules 7, 9, 10.
+
+##### `issue_internal_exam_code(p_subject_id, p_student_id)`
+
+Admin-only. Generates a single-use 8-char code (Crockford-style alphabet, excludes `0/O/I/1`), inserts it with a 24-hour `expires_at`, and writes an `internal_exam.code_issued` audit event. Up-to-5 retries on UNIQUE collision; raises `code_generation_failed` if all retries collide.
+
+**Guards:** `not_authenticated`, `not_admin`, `admin_not_found`, `student_not_found` (must be same-org student), `subject_not_found`, `exam_config_required` (an enabled `exam_configs` row must exist for the org+subject).
+
+**Returns:** `(code_id uuid, code text, expires_at timestamptz)`.
+
+##### `start_internal_exam_session(p_code)`
+
+Student-facing. Validates the code, atomically consumes it, and creates a fresh `quiz_sessions` row with `mode = 'internal_exam'`. Question selection mirrors `start_exam_session` exactly — same `exam_config_distributions` algorithm, same `q.status = 'active'` and soft-delete filters.
+
+**Validation order (each raises a distinct domain error string):** `code_not_found`, `code_not_yours`, `code_voided`, `code_already_used`, `code_expired`. Then resolves student org (`user not found or inactive`) and exam config (`exam_config_required`, `insufficient_questions_for_exam`).
+
+**Race-safe consumption:** the row is `SELECT ... FOR UPDATE` locked; consumption is `UPDATE ... WHERE id = v_code_id AND consumed_at IS NULL` and raises `code_already_used` if `ROW_COUNT = 0`. Active duplicate-session guard (migration `20260429000010`): before issuing, the RPC looks up any same-subject `internal_exam` session past `(time_limit_seconds + 30)` seconds and calls `complete_overdue_exam_session` on it (mirrors `start_exam_session`).
+
+**Audit:** `internal_exam.started` with `{ code_id, subject_id, total_questions, pass_mark }`.
+
+**Returns:** `(session_id uuid, question_ids uuid[], time_limit_seconds int, total_questions int, pass_mark int, started_at timestamptz)`.
+
+##### `void_internal_exam_code(p_code_id, p_reason)`
+
+Admin-only. Three branches:
+
+1. **Unconsumed** — sets `voided_at`, `voided_by`, `void_reason`. Audits `internal_exam.code_voided`.
+2. **Consumed + active session** — locks the linked `quiz_sessions` row, computes a final score from existing `quiz_session_answers` (unanswered = wrong, identical to `complete_overdue_exam_session`), forces `passed = false`, sets `ended_at`, then voids the code. Writes **two** audit events: `internal_exam.expired` (session) and `internal_exam.code_voided` (code).
+3. **Consumed + finished session** — refuses with `cannot_void_finished_attempt`. The RPC never retroactively changes a closed attempt.
+
+**Guards:** `not_authenticated`, `not_admin`, `admin_not_found`, `code_not_found` (also raised for cross-org access — same error to avoid leaking existence), `code_voided` (already voided), `cannot_void_finished_attempt`.
+
+**Returns:** `(code_id uuid, session_id uuid, session_ended boolean)`.
+
+---
+
+#### `is_admin()` — admin role check (soft-delete fix, migration `20260429000001`)
+
+`CREATE OR REPLACE FUNCTION public.is_admin()` body now includes `AND deleted_at IS NULL` on the `users` lookup. A soft-deleted admin row no longer satisfies `is_admin()`, closing a soft-delete bypass for every admin RLS policy and every admin-gated SECURITY DEFINER RPC. Promoted ahead of the new admin RPCs that depend on it.
+
+---
+
+#### `batch_submit_quiz` — internal-exam extension (migration `20260429000007`)
+
+`CREATE OR REPLACE` of the version in `056` (mock-exam pass-computation revision). Two changes:
+
+1. **All-answered guard restricted to `mock_exam`.** `internal_exam` is allowed to submit with `answered < total` (deliberate — internal exams support partial submission). Mock-exam still requires `answered_count = total_questions` after the +30s grace window.
+2. **Pass computation extended.** `passed` is computed for both `mock_exam` and `internal_exam` (`score_percentage >= pass_mark`); for partial internal-exam submissions an under-`pass_mark` score auto-fails.
+
+Audit `event_type` branches: `internal_exam.completed` for internal-exam sessions, `exam.completed` / `quiz_session.batch_submitted` for the existing modes.
 
 ---
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1304,6 +1304,18 @@ Admin-only. Three branches:
 
 **Returns:** `(code_id uuid, session_id uuid, session_ended boolean)`.
 
+##### `start_internal_exam_session` — column qualification fix (migration `20260430000005`)
+
+**Bug (CodeRabbit PR #576 round-2 + CI red-team failure):** The RPC `RETURNS TABLE(... time_limit_seconds int, ..., started_at timestamptz)` exposes those names as return-value variables. The function body's auto-complete SELECT referenced `time_limit_seconds` and `started_at` unqualified, creating ambiguity when checking whether an active session is past its grace window. Postgres raised error 42702 ("column reference is ambiguous") when the red-team spec exercised that code path.
+
+**Fix:** `CREATE OR REPLACE` with `public.quiz_sessions AS qs` alias and full qualification on all column references (e.g., `qs.time_limit_seconds`). Function body otherwise unchanged from migration `20260429000010`.
+
+##### `void_internal_exam_code` — org-scope defense-in-depth (migration `20260430000006`)
+
+**Enhancement (CodeRabbit PR #576 round-2, Major):** The RPC validates that the code's `organization_id` matches the admin's, then locks and updates the linked `quiz_sessions` row by id only. This is a SECURITY DEFINER function bypassing RLS. If a future bug ever stored a cross-org `consumed_session_id`, the RPC would expire a foreign-org session.
+
+**Fix:** `CREATE OR REPLACE` with explicit `qs.organization_id = v_admin_org` filter on both the SELECT and UPDATE of the linked session. Also asserts `ROW_COUNT > 0` after the UPDATE (raises `session_state_changed` if a concurrent writer stole the row). Function body otherwise unchanged from migration `20260429000009`.
+
 ---
 
 #### `is_admin()` — admin role check (soft-delete fix, migration `20260429000001`)

--- a/docs/database.md
+++ b/docs/database.md
@@ -606,6 +606,8 @@ ORDER BY deleted_at DESC;
 
 > **Storage: `question-images` bucket (migrations 053, 055, 20260410000009):** Admin INSERT/UPDATE/DELETE policies enforce org-scoped path isolation — images are stored at `{org_id}/{filename}` and policies check `(storage.foldername(name))[1]` matches the admin's org. Authenticated SELECT allows all users to read images (for quiz display). The upload action (`uploadQuestionImage`) resolves the admin's org and prefixes the path automatically.
 
+> **Admin cross-row reads on `users` (binding pattern):** When an admin Server Action reads or *embeds* the `users` table to fetch peer rows (not just the calling admin's own row), use `adminClient` from `@repo/db/admin` — never the user-scoped supabase client. The `users.tenant_isolation` policy uses a self-referential subquery `(SELECT organization_id FROM users WHERE id = auth.uid())`, and PostgreSQL's planner is unreliable when an RLS policy references the same table for cross-row reads. Self-row reads work; cross-row reads silently return `null` / empty arrays. PostgREST applies RLS to embedded resources too, so even joining `users(...)` from another table triggers the same failure mode. Defense in depth: gate the path with `requireAdmin()` first, then apply `.eq('organization_id', organizationId)` on every adminClient query. Established call sites: `apps/web/app/app/admin/students/queries.ts`, `apps/web/app/app/admin/dashboard/queries.ts`, `apps/web/app/app/admin/internal-exams/queries.ts`.
+
 ---
 
 ## 4. RPC Conventions

--- a/docs/database.md
+++ b/docs/database.md
@@ -237,7 +237,7 @@ CREATE TABLE quiz_sessions (
   id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   organization_id  UUID NOT NULL REFERENCES organizations(id),
   student_id       UUID NOT NULL REFERENCES users(id),
-  mode             TEXT NOT NULL CHECK (mode IN ('smart_review', 'quick_quiz', 'mock_exam')),
+  mode             TEXT NOT NULL CHECK (mode IN ('smart_review', 'quick_quiz', 'mock_exam', 'internal_exam')),
   subject_id       UUID REFERENCES easa_subjects(id) NULL,  -- NULL for smart_review
   topic_id         UUID REFERENCES easa_topics(id) NULL,
   config           JSONB NOT NULL DEFAULT '{}',             -- question IDs locked at start
@@ -473,6 +473,31 @@ Immutable append-only GDPR consent audit log. Tracks user acceptance of Terms of
 
 **Pattern:** Identical to `audit_events` — immutable, no direct client writes, controlled via SECURITY DEFINER RPCs.
 
+### internal_exam_codes
+
+Single-use 8-character codes for starting `internal_exam` mode sessions. Admins issue codes, students consume them once to start a session. Codes expire after 24 hours.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| id | UUID | PK, default gen_random_uuid() |
+| organization_id | UUID | FK → organizations(id), NOT NULL |
+| code | TEXT | NOT NULL, 8 chars from ABCDEFGHJKLMNPQRSTUVWXYZ23456789, UNIQUE |
+| issued_by | UUID | FK → users(id), NOT NULL (admin who issued the code) |
+| consumed_by | UUID | FK → users(id), NULL (student who consumed the code) |
+| session_id | UUID | FK → quiz_sessions(id), NULL (the resulting session) |
+| issued_at | TIMESTAMPTZ | NOT NULL, default now() |
+| consumed_at | TIMESTAMPTZ | NULL (timestamp of consumption) |
+| voided_at | TIMESTAMPTZ | NULL (timestamp if voided by admin) |
+| voided_by | UUID | FK → users(id), NULL (admin who voided the code) |
+
+**RLS policies:**
+- SELECT: students see only own-consumed codes; admins see org-scoped codes via `is_admin()`
+- INSERT: denied (all writes via SECURITY DEFINER RPCs only)
+- UPDATE: denied (immutable)
+- DELETE: denied (immutable)
+
+**Pattern:** Accessed via three SECURITY DEFINER RPCs: `issue_internal_exam_code()` (admin), `start_internal_exam_session()` (student), `void_internal_exam_code()` (admin). No direct client writes.
+
 ---
 
 ## 3. Soft Delete
@@ -593,6 +618,9 @@ verb_noun pattern:
   upsert_exam_config         ← write, atomic: upsert exam_configs + replace exam_config_distributions (admin-only, SECURITY DEFINER)
   complete_empty_exam_session ← write, atomic: 0-answer exam expiry → 0%/FAIL + audit (idempotent)
   complete_overdue_exam_session ← write, atomic: close past-deadline mock_exam session, score from existing answers, audit exam.expired (idempotent)
+  issue_internal_exam_code   ← write, admin-only: generate 8-char single-use code, 24h validity, 5-retry collision handling, audit internal_exam.code_issued
+  start_internal_exam_session ← write, student: validate & consume code, auto-complete overdue prior session, build question set from exam config, atomic code consumption via WHERE-clause race guard
+  void_internal_exam_code    ← write, admin-only: void unconsumed code or active session (sets session.passed = false), audit internal_exam.code_voided
   complete_quiz_session      ← write, atomic: session end + score + audit + last_active_at stamp (DEPRECATED — use batch_submit_quiz)
   soft_delete_question       ← write, sets deleted_at
   get_student_progress       ← read, aggregated progress view
@@ -1469,9 +1497,9 @@ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public
 #### `is_admin()` — Admin role check helper
 
 Returns `boolean`. SECURITY DEFINER with `SET search_path = public`.
-Checks `auth.uid()` against `users.role = 'admin'`. Returns `false` (not an exception) when no user is authenticated, so it is safe to call from RLS policies without causing errors for unauthenticated requests.
+Checks `auth.uid()` against `users.role = 'admin'` AND `deleted_at IS NULL` (migration 20260429000001). Returns `false` (not an exception) when no user is authenticated, so it is safe to call from RLS policies without causing errors for unauthenticated requests.
 
-Used by RLS policies on `easa_subjects`, `easa_topics`, and `easa_subtopics` to gate INSERT/UPDATE/DELETE to admin users only (migration 039).
+Used by RLS policies on `easa_subjects`, `easa_topics`, `easa_subtopics`, and `internal_exam_codes` to gate INSERT/UPDATE/DELETE to active admin users only.
 
 ```sql
 CREATE OR REPLACE FUNCTION is_admin()
@@ -1480,7 +1508,7 @@ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public
 AS $$
 BEGIN
   RETURN EXISTS (
-    SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin'
+    SELECT 1 FROM users WHERE id = auth.uid() AND role = 'admin' AND deleted_at IS NULL
   );
 END;
 $$;

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -611,6 +611,26 @@ Full audit completed — 46 files reviewed. Score: 9.5/10. Full report: `docs/se
 **Rationale**: The handoff format already requires non-empty `questionIds` (established in Phase 1). Reading them server-side at resume time is the simplest correct approach — no new RPC, no extra table, no client-side secret exposure. Cold-start and cross-tab recovery both work through this path.
 **Implementation**: `getActiveExamSession` + `ResumeExamBanner` updated; round-trip test in `resume-exam-banner.test.tsx` pins the validator contract.
 
+### Decision 37: Internal Exam Mode foundation — single-use code-based exam access (2026-04-29)
+
+**Date**: 2026-04-29
+
+**Context**: Official exam delivery (separate from Practice Exam) requires instructor-controlled student access. Single-use 8-character codes ensure one-off exam sessions with controlled demographics and audit trails.
+
+**Decision — Wave 1 (DB + RPCs only, code-first)**:
+- New `internal_exam_codes` table with 8-char unique codes (alphabet: A-Z minus O/I, digits 2-9), issued_by/consumed_by/voided_by audit columns, 24h expiry, immutable per RLS
+- `quiz_sessions.mode` CHECK extended: `'smart_review' | 'quick_quiz' | 'mock_exam' | 'internal_exam'`
+- New admin-only RPC `issue_internal_exam_code()`: generate code, 5-retry collision handling, audit `internal_exam.code_issued`
+- New student RPC `start_internal_exam_session()`: validate code, consume atomically via WHERE-clause race guard, auto-complete overdue prior session, build question set from exam config (identical to `start_exam_session`), return sessionId
+- New admin RPC `void_internal_exam_code()`: three branches (unconsumed, active-void→session.passed=false, finished), audit event
+- Extended `batch_submit_quiz()`: `internal_exam` mode allows partial submissions (no all-answered guard), score = correct/total (unanswered = wrong, same as mock_exam), audit event branched on mode
+- Extended `complete_overdue_exam_session()`: same RPC signature, now handles both `mock_exam` and `internal_exam` modes
+- `is_admin()` RPC: added `deleted_at IS NULL` filter (closes soft-delete bypass for admin checks, regression from soft-delete matrix)
+
+**Waves 2–7**: UI and integration tests follow.
+
+**Rationale**: Single-use codes prevent reuse and ensure each student gets unique exam audit records. The code-first approach validates DB design before building Server Actions and UI.
+
 ---
 
-*Last updated: 2026-04-27 — Decision 36: Practice Exam resume = sessionStorage handoff + server-side question IDs*
+*Last updated: 2026-04-29 — Decision 37: Internal Exam Mode foundation*

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -629,8 +629,18 @@ Full audit completed — 46 files reviewed. Score: 9.5/10. Full report: `docs/se
 
 **Waves 2–7**: UI and integration tests follow.
 
+**Product decisions (locked):**
+
+- **Crockford-style 8-character code.** Alphabet `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` — excludes `0/O/I/1` to avoid mis-reads when the admin verbally relays a code. 8 chars × 32 symbols = 32^8 ≈ 1.1 trillion entropy; a 5-retry collision loop is sufficient.
+- **24-hour validity, single-use.** Codes expire 24h after issue and are single-use only. No extension, no re-redeem. A student needing a retake gets a new code.
+- **Plaintext storage.** Codes are stored unhashed in `internal_exam_codes.code`. Justified by short window (24h) + admin's need to re-display a freshly issued code. Read-path queries never return the value to students.
+- **Code never displayed in student lists.** The student "Available" tab shows subject + expiry only. Code value is shown to the student exactly once, by the admin, out-of-band.
+- **No discard for internal-exam sessions.** `discardSession` Server Action rejects `mode = 'internal_exam'`; the in-session discard button is hidden by mode. Internal-exam attempts are auditable artefacts.
+- **Separate reports tab.** Internal-exam sessions are excluded from existing reports/progress queries and surfaced under a dedicated "My Reports" tab on `/app/internal-exam`. Practice and internal exams are reported separately.
+- **Admin-only issue/void.** Both lifecycle endpoints gate via `is_admin()` + org-scope. Voiding an active session forces `passed = false` with score computed from existing answers; voiding a finished session is refused (`cannot_void_finished_attempt`).
+
 **Rationale**: Single-use codes prevent reuse and ensure each student gets unique exam audit records. The code-first approach validates DB design before building Server Actions and UI.
 
 ---
 
-*Last updated: 2026-04-29 — Decision 37: Internal Exam Mode foundation*
+*Last updated: 2026-04-29 — Decision 37: Internal Exam Mode foundation + product decisions*

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -886,13 +886,18 @@ Supabase session via `@supabase/ssr` package (server-side session management for
 /app/
 ├── dashboard/              ← progress overview, recent sessions, quick actions
 ├── quiz/                   ← Quiz config (subject, count, randomized mode)
-│   └── session/            ← active quiz session (immediate feedback + in-session explanation)
+│   ├── session/            ← active quiz session (immediate feedback + in-session explanation)
+│   └── report/             ← per-question breakdown (mode-aware: practice/quick/review/mock_exam)
+├── internal-exam/          ← student internal-exam landing (Available + My Reports tabs)
+│   └── report/             ← internal-exam report (mode-guarded; redirects non-internal_exam to /quiz/report)
 ├── progress/               ← detailed progress per subject/topic/subtopic
 ├── reports/                ← session history with sortable columns, links to quiz reports
 ├── settings/               ← student profile & settings: display name edit, password change (#368)
 └── admin/                  ← admin-only (proxy guard + requireAdmin())
     ├── syllabus/           ← CRUD for subjects/topics/subtopics (#171)
-    └── questions/          ← question editor: create, edit, list, filter, bulk actions (#271)
+    ├── questions/          ← question editor: create, edit, list, filter, bulk actions (#271)
+    └── internal-exams/     ← admin internal-exam management (Codes + Attempts tabs, #541)
+        └── report/         ← admin per-question breakdown for an internal-exam attempt (org-scoped)
 ```
 
 ### Components (in `packages/ui/`)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1020,7 +1020,7 @@ From setup audit (2026-03-11), updated 2026-03-19:
 
 ---
 
-*Last updated: 2026-04-28 — PR #523 (Practice Exam Mode student session) merged as `9dae1e0`. Epic #180 closed. Eval-deferred bugs: #575 (reload loses answers), #539 (no change-answer path mid-flow). See PR #523 Round 7 section below for delivery detail.*
+*PR #523 status (2026-04-28): Practice Exam Mode student session merged as `9dae1e0`. Epic #180 closed. Eval-deferred bugs: #575 (reload loses answers), #539 (no change-answer path mid-flow). See PR #523 Round 7 section below for delivery detail.*
 
 ---
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1020,7 +1020,7 @@ From setup audit (2026-03-11), updated 2026-03-19:
 
 ---
 
-*Last updated: 2026-04-28 — PR #523 round 8 triaged + fixed; CI E2E unblock pushed. See PR #523 Round 7 section below.*
+*Last updated: 2026-04-28 — PR #523 (Practice Exam Mode student session) merged as `9dae1e0`. Epic #180 closed. Eval-deferred bugs: #575 (reload loses answers), #539 (no change-answer path mid-flow). See PR #523 Round 7 section below for delivery detail.*
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -503,6 +503,12 @@ CREATE POLICY "audit_read_instructors" ON audit_events
 | `quiz_session.completed` | Student finishes session (score recorded) |
 | `exam.started` | Mock exam begins |
 | `exam.completed` | Mock exam ends (score + pass/fail recorded) |
+| `exam.expired` | Mock exam past deadline auto-completed (Layer 1) |
+| `internal_exam.code_issued` | Admin issues an `internal_exam_codes` row |
+| `internal_exam.started` | Student consumes a code; new `internal_exam` session created |
+| `internal_exam.completed` | Internal-exam session submitted (score + pass/fail recorded) |
+| `internal_exam.expired` | Internal-exam session ended past deadline (Layer 1) or via admin void of an active session |
+| `internal_exam.code_voided` | Admin voids a code (always written; on active-void, paired with `internal_exam.expired` for the session) |
 | `question.created` | Instructor adds a question |
 | `question.edited` | Instructor modifies a question |
 | `question.deleted` | Instructor deletes a question |
@@ -551,6 +557,23 @@ Any Server Action that operates on a quiz session or its questions must verify *
 **Enforced in:** `checkAnswer`, `fetchExplanation` (commit 306f44a, 2026-03-13). The `batch_submit_quiz` RPC enforces the same four checks at the SQL layer.
 
 **Runtime guard:** When reading `config.question_ids` from the DB, use `Array.isArray()` before `.includes()` — the `as unknown as` TypeScript cast provides no runtime guarantee against malformed JSONB.
+
+---
+
+## 11b. Internal Exam Mode
+
+`mode = 'internal_exam'` reuses the mock-exam integrity rules above (single activation, immutable responses, server-side deadline, locked question set) and adds:
+
+- **Code-gated entry.** Sessions can only start via `start_internal_exam_session(p_code)`. The RPC validates `code_not_yours`, `code_voided`, `code_already_used`, `code_expired`, and consumes the code with a race-safe `WHERE consumed_at IS NULL` clause. There is no client-side path that bypasses code validation.
+- **Single-use codes.** `internal_exam_codes` has no INSERT or DELETE RLS policy — writes happen only via SECURITY DEFINER RPCs (`issue_internal_exam_code`, `start_internal_exam_session`, `void_internal_exam_code`). FORCE ROW LEVEL SECURITY (migration `20260429000009`) prevents the table-owner role from bypassing RLS even on direct PostgREST writes.
+- **Plaintext code storage.** Codes are stored unhashed because the active-code window is short (24h, single-use) and admins must be able to re-display a code they just issued. Codes are never returned to students through any read-path query — the student "Available" tab lists active codes by subject + expiry only, never the code value. This is enforced in `apps/web/app/app/internal-exam/queries.ts`.
+- **Admin void = forced fail.** Voiding a consumed code with an active session forces `passed = false` and computes the score from existing answers (unanswered = wrong). The RPC refuses to retroactively change a session whose `ended_at` is already set (`cannot_void_finished_attempt`).
+- **No discard.** Server Action `discardSession` rejects `mode = 'internal_exam'`. The student-side discard button is hidden by mode in the session header. Internal-exam attempts are auditable artefacts and cannot be removed by the student.
+- **Admin-only issue/void.** `issue_internal_exam_code` and `void_internal_exam_code` both gate via `is_admin()` AND org-scope. `start_internal_exam_session` requires `code.student_id = auth.uid()` — students cannot redeem another student's code.
+
+### `is_admin()` soft-delete fix (migration `20260429000001`)
+
+`public.is_admin()` was missing `AND deleted_at IS NULL` on the `users` lookup. A soft-deleted admin previously satisfied `is_admin()` for every admin RLS policy and admin-gated RPC. Migration `20260429000001` adds the filter. _Pattern hit count = 1 for `is_admin()` specifically; not promoted to a new rule yet — flag and watch for a second occurrence in any other admin-gated function._
 
 ---
 

--- a/packages/db/migrations/057_internal_exam_codes.sql
+++ b/packages/db/migrations/057_internal_exam_codes.sql
@@ -1,0 +1,92 @@
+-- Internal Exam Mode — issuance code table.
+-- Admin issues a one-time short code; student redeems it to start an
+-- internal_exam quiz_session. Code is the audit-trail anchor between admin
+-- issuance and student attempt.
+--
+-- Writes go through SECURITY DEFINER RPCs (issue_internal_exam_code,
+-- start_internal_exam_session, void_internal_exam_code). RLS allows reads
+-- for the owning student (active codes only) and the admin org. UPDATE policy
+-- supports any future admin tooling that touches rows directly. No INSERT or
+-- DELETE policies — issuance and consumption are RPC-only.
+
+CREATE TABLE public.internal_exam_codes (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code                 text NOT NULL UNIQUE,
+  subject_id           uuid NOT NULL REFERENCES public.easa_subjects(id),
+  student_id           uuid NOT NULL REFERENCES public.users(id),
+  issued_by            uuid NOT NULL REFERENCES public.users(id),
+  issued_at            timestamptz NOT NULL DEFAULT now(),
+  expires_at           timestamptz NOT NULL,
+  consumed_at          timestamptz,
+  consumed_session_id  uuid REFERENCES public.quiz_sessions(id),
+  voided_at            timestamptz,
+  voided_by            uuid REFERENCES public.users(id),
+  void_reason          text,
+  organization_id      uuid NOT NULL REFERENCES public.organizations(id),
+  deleted_at           timestamptz,
+  CONSTRAINT consumed_pair_consistency
+    CHECK ((consumed_at IS NULL) = (consumed_session_id IS NULL)),
+  CONSTRAINT voided_pair_consistency
+    CHECK ((voided_at IS NULL) = (voided_by IS NULL))
+);
+
+CREATE INDEX idx_internal_exam_codes_active
+  ON public.internal_exam_codes (student_id, expires_at)
+  WHERE consumed_at IS NULL
+    AND voided_at IS NULL
+    AND deleted_at IS NULL;
+
+CREATE INDEX idx_internal_exam_codes_org
+  ON public.internal_exam_codes (organization_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.internal_exam_codes ENABLE ROW LEVEL SECURITY;
+
+-- Student reads their own active (un-consumed, un-voided, un-expired) codes.
+CREATE POLICY student_read_active_codes
+  ON public.internal_exam_codes
+  FOR SELECT
+  TO authenticated
+  USING (
+    student_id = auth.uid()
+    AND consumed_at IS NULL
+    AND voided_at IS NULL
+    AND expires_at > now()
+    AND deleted_at IS NULL
+  );
+
+-- Admin reads codes for their org.
+CREATE POLICY admin_read_org_codes
+  ON public.internal_exam_codes
+  FOR SELECT
+  TO authenticated
+  USING (
+    public.is_admin()
+    AND organization_id IN (
+      SELECT u.organization_id FROM public.users u
+      WHERE u.id = auth.uid() AND u.deleted_at IS NULL
+    )
+  );
+
+-- Admin direct UPDATE — supports tooling that may touch rows outside the
+-- canonical RPCs. Production writes go via SECURITY DEFINER RPCs.
+CREATE POLICY admin_update_org_codes
+  ON public.internal_exam_codes
+  FOR UPDATE
+  TO authenticated
+  USING (
+    public.is_admin()
+    AND organization_id IN (
+      SELECT u.organization_id FROM public.users u
+      WHERE u.id = auth.uid() AND u.deleted_at IS NULL
+    )
+  )
+  WITH CHECK (
+    public.is_admin()
+    AND organization_id IN (
+      SELECT u.organization_id FROM public.users u
+      WHERE u.id = auth.uid() AND u.deleted_at IS NULL
+    )
+  );
+
+GRANT SELECT, UPDATE ON public.internal_exam_codes TO authenticated;

--- a/packages/db/migrations/057a_is_admin_softdelete_filter.sql
+++ b/packages/db/migrations/057a_is_admin_softdelete_filter.sql
@@ -1,0 +1,20 @@
+-- Add `AND deleted_at IS NULL` to is_admin() helper.
+-- Originally defined in 031_admin_rls_easa_tables.sql lines 7-18 without the
+-- soft-delete filter, allowing soft-deleted admin rows to still pass admin
+-- gates. Body identical to mig 031 apart from the added filter.
+-- security.md rule 7 + rule 9 (SECURITY DEFINER must filter deleted_at).
+
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = auth.uid()
+      AND role = 'admin'
+      AND deleted_at IS NULL
+  );
+$$;

--- a/packages/db/migrations/058_extend_quiz_sessions_mode_check.sql
+++ b/packages/db/migrations/058_extend_quiz_sessions_mode_check.sql
@@ -1,0 +1,23 @@
+-- Extend quiz_sessions.mode CHECK constraint to allow 'internal_exam'.
+-- The constraint name varies across environments (it was renamed at least
+-- once historically). Look it up by predicate text, drop it, and re-add a
+-- canonical-named replacement covering all four modes.
+
+DO $$
+DECLARE
+  v_constraint_name text;
+BEGIN
+  SELECT conname INTO v_constraint_name
+  FROM pg_constraint
+  WHERE conrelid = 'public.quiz_sessions'::regclass
+    AND contype = 'c'
+    AND pg_get_constraintdef(oid) ILIKE '%mode%mock_exam%';
+  IF v_constraint_name IS NULL THEN
+    RAISE EXCEPTION 'Could not locate mode CHECK constraint on quiz_sessions';
+  END IF;
+  EXECUTE format('ALTER TABLE public.quiz_sessions DROP CONSTRAINT %I', v_constraint_name);
+END $$;
+
+ALTER TABLE public.quiz_sessions
+  ADD CONSTRAINT quiz_sessions_mode_check
+  CHECK (mode IN ('smart_review', 'quick_quiz', 'mock_exam', 'internal_exam'));

--- a/packages/db/migrations/059_issue_internal_exam_code_rpc.sql
+++ b/packages/db/migrations/059_issue_internal_exam_code_rpc.sql
@@ -1,0 +1,127 @@
+-- issue_internal_exam_code(p_subject_id, p_student_id)
+-- Admin-only. Generates a single-use 8-char code, stores the row, audits the
+-- issuance, returns (code_id, code, expires_at).
+-- Charset excludes 0/O/I/1 to avoid mis-reads. Default expiry: 24h.
+-- security.md rules 7, 9, 10 — auth.uid() check, deleted_at filters on every
+-- SELECT (including the audit-row subqueries), generic error codes only.
+
+CREATE OR REPLACE FUNCTION public.issue_internal_exam_code(
+  p_subject_id uuid,
+  p_student_id uuid
+)
+RETURNS TABLE(code_id uuid, code text, expires_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id   uuid := auth.uid();
+  v_admin_org  uuid;
+  v_student_org uuid;
+  v_charset    text := 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  v_charset_len int  := length('ABCDEFGHJKLMNPQRSTUVWXYZ23456789');
+  v_code       text;
+  v_new_id     uuid;
+  v_new_expiry timestamptz;
+  v_attempt    int := 0;
+  v_inserted   boolean := false;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  -- Resolve admin's organization.
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id
+    AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  -- Verify student exists in same org with role='student'.
+  SELECT u.organization_id INTO v_student_org
+  FROM public.users u
+  WHERE u.id = p_student_id
+    AND u.role = 'student'
+    AND u.deleted_at IS NULL;
+  IF v_student_org IS NULL OR v_student_org <> v_admin_org THEN
+    RAISE EXCEPTION 'student_not_found';
+  END IF;
+
+  -- Verify subject exists and is not soft-deleted.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.easa_subjects s
+    WHERE s.id = p_subject_id
+      AND s.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'subject_not_found';
+  END IF;
+
+  -- Verify an enabled exam_config exists for (admin_org, subject).
+  IF NOT EXISTS (
+    SELECT 1 FROM public.exam_configs ec
+    WHERE ec.organization_id = v_admin_org
+      AND ec.subject_id = p_subject_id
+      AND ec.enabled = true
+      AND ec.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  v_new_expiry := now() + interval '24 hours';
+
+  -- Generate + insert with up-to-5 retry on unique-violation.
+  WHILE v_attempt < 5 AND NOT v_inserted LOOP
+    v_attempt := v_attempt + 1;
+    v_code := array_to_string(
+      ARRAY(
+        SELECT substr(v_charset, 1 + floor(random() * v_charset_len)::int, 1)
+        FROM generate_series(1, 8)
+      ),
+      ''
+    );
+    BEGIN
+      INSERT INTO public.internal_exam_codes
+        (code, subject_id, student_id, issued_by, expires_at, organization_id)
+      VALUES
+        (v_code, p_subject_id, p_student_id, v_admin_id, v_new_expiry, v_admin_org)
+      RETURNING id INTO v_new_id;
+      v_inserted := true;
+    EXCEPTION WHEN unique_violation THEN
+      -- Retry with a fresh code.
+      v_inserted := false;
+    END;
+  END LOOP;
+
+  IF NOT v_inserted THEN
+    RAISE EXCEPTION 'code_generation_failed';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_issued',
+    'internal_exam_code',
+    v_new_id,
+    jsonb_build_object(
+      'student_id', p_student_id,
+      'subject_id', p_subject_id,
+      'expires_at', v_new_expiry
+    )
+  );
+
+  RETURN QUERY SELECT v_new_id, v_code, v_new_expiry;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.issue_internal_exam_code(uuid, uuid) TO authenticated;

--- a/packages/db/migrations/060_start_internal_exam_session_rpc.sql
+++ b/packages/db/migrations/060_start_internal_exam_session_rpc.sql
@@ -1,0 +1,197 @@
+-- start_internal_exam_session(p_code)
+-- Student-facing. Redeems a single-use code, atomically creates an
+-- internal_exam quiz_session, marks the code consumed.
+-- Mirrors the question-sampling and overdue-cleanup algorithm of
+-- start_exam_session (mig 054). q.status = 'active' (codebase convention).
+-- security.md rules 7, 9, 10.
+
+CREATE OR REPLACE FUNCTION public.start_internal_exam_session(p_code text)
+RETURNS TABLE(
+  session_id uuid,
+  question_ids uuid[],
+  time_limit_seconds int,
+  total_questions int,
+  pass_mark int,
+  started_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_code_id         uuid;
+  v_code_subject    uuid;
+  v_code_student    uuid;
+  v_code_expires    timestamptz;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_old_session_id  uuid;
+  v_config_id       uuid;
+  v_total_questions int;
+  v_time_limit      int;
+  v_pass_mark       int;
+  v_dist            record;
+  v_selected_ids    uuid[] := '{}';
+  v_topic_ids       uuid[];
+  v_session_id      uuid;
+  v_started_at      timestamptz;
+  v_consumed_rows   int;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  -- Lock + validate the code.
+  SELECT iec.id, iec.subject_id, iec.student_id,
+         iec.expires_at, iec.consumed_at, iec.voided_at
+  INTO v_code_id, v_code_subject, v_code_student,
+       v_code_expires, v_code_consumed, v_code_voided
+  FROM public.internal_exam_codes iec
+  WHERE iec.code = p_code
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_student <> v_student_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+  IF v_code_consumed IS NOT NULL THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+  IF v_code_expires <= now() THEN
+    RAISE EXCEPTION 'code_expired';
+  END IF;
+
+  -- Resolve student's org.
+  SELECT u.organization_id INTO v_org_id
+  FROM public.users u
+  WHERE u.id = v_student_id AND u.deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  -- Auto-complete any same-subject internal_exam past +30s grace
+  -- (mirrors start_exam_session in mig 054).
+  SELECT id INTO v_old_session_id
+  FROM public.quiz_sessions
+  WHERE student_id = v_student_id
+    AND organization_id = v_org_id
+    AND subject_id = v_code_subject
+    AND mode = 'internal_exam'
+    AND ended_at IS NULL
+    AND deleted_at IS NULL
+    AND time_limit_seconds IS NOT NULL
+    AND started_at IS NOT NULL
+    AND now() > started_at + ((time_limit_seconds + 30) || ' seconds')::interval
+  LIMIT 1;
+  IF v_old_session_id IS NOT NULL THEN
+    PERFORM public.complete_overdue_exam_session(v_old_session_id);
+  END IF;
+
+  -- Fetch the exam config for this subject in the student's org.
+  SELECT ec.id, ec.total_questions, ec.time_limit_seconds, ec.pass_mark
+  INTO v_config_id, v_total_questions, v_time_limit, v_pass_mark
+  FROM public.exam_configs ec
+  WHERE ec.organization_id = v_org_id
+    AND ec.subject_id = v_code_subject
+    AND ec.enabled = true
+    AND ec.deleted_at IS NULL;
+  IF v_config_id IS NULL THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  -- Sample questions per distribution (matches mig 054 algorithm).
+  FOR v_dist IN
+    SELECT ecd.topic_id, ecd.subtopic_id, ecd.question_count
+    FROM public.exam_config_distributions ecd
+    WHERE ecd.exam_config_id = v_config_id
+    ORDER BY ecd.topic_id, ecd.subtopic_id NULLS LAST
+  LOOP
+    v_topic_ids := ARRAY(
+      SELECT q.id
+      FROM public.questions q
+      WHERE q.subject_id = v_code_subject
+        AND q.topic_id = v_dist.topic_id
+        AND (v_dist.subtopic_id IS NULL OR q.subtopic_id = v_dist.subtopic_id)
+        AND q.status = 'active'
+        AND q.deleted_at IS NULL
+        AND q.organization_id = v_org_id
+        AND q.id != ALL(v_selected_ids)
+      ORDER BY random()
+      LIMIT v_dist.question_count
+    );
+    IF array_length(v_topic_ids, 1) IS NULL OR array_length(v_topic_ids, 1) < v_dist.question_count THEN
+      RAISE EXCEPTION 'insufficient_questions_for_exam';
+    END IF;
+    v_selected_ids := v_selected_ids || v_topic_ids;
+  END LOOP;
+
+  IF array_length(v_selected_ids, 1) IS NULL
+     OR array_length(v_selected_ids, 1) <> v_total_questions THEN
+    RAISE EXCEPTION 'insufficient_questions_for_exam';
+  END IF;
+
+  -- Insert session.
+  INSERT INTO public.quiz_sessions
+    (organization_id, student_id, mode, subject_id,
+     config, total_questions, time_limit_seconds)
+  VALUES (
+    v_org_id, v_student_id, 'internal_exam', v_code_subject,
+    jsonb_build_object(
+      'question_ids',   to_jsonb(v_selected_ids),
+      'exam_config_id', v_config_id,
+      'pass_mark',      v_pass_mark
+    ),
+    v_total_questions, v_time_limit
+  )
+  RETURNING id, quiz_sessions.started_at
+  INTO v_session_id, v_started_at;
+
+  -- Mark code consumed (race-safe: requires consumed_at IS NULL).
+  UPDATE public.internal_exam_codes
+  SET consumed_at = now(),
+      consumed_session_id = v_session_id
+  WHERE id = v_code_id
+    AND consumed_at IS NULL;
+  GET DIAGNOSTICS v_consumed_rows = ROW_COUNT;
+  IF v_consumed_rows = 0 THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_student_id AND u.deleted_at IS NULL),
+    'internal_exam.started',
+    'quiz_session',
+    v_session_id,
+    jsonb_build_object(
+      'code_id',         v_code_id,
+      'subject_id',      v_code_subject,
+      'total_questions', v_total_questions,
+      'pass_mark',       v_pass_mark
+    )
+  );
+
+  RETURN QUERY SELECT
+    v_session_id,
+    v_selected_ids,
+    v_time_limit,
+    v_total_questions,
+    v_pass_mark,
+    v_started_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.start_internal_exam_session(text) TO authenticated;

--- a/packages/db/migrations/061_void_internal_exam_code_rpc.sql
+++ b/packages/db/migrations/061_void_internal_exam_code_rpc.sql
@@ -1,0 +1,160 @@
+-- void_internal_exam_code(p_code_id, p_reason)
+-- Admin-only. Voids an internal exam code. If the code was consumed and the
+-- linked session is still active, terminate the session with passed=false and
+-- a computed score (unanswered = wrong). Refuses if the linked session has
+-- already ended (do not retroactively change a finished attempt).
+-- security.md rules 7, 9, 10.
+
+CREATE OR REPLACE FUNCTION public.void_internal_exam_code(
+  p_code_id uuid,
+  p_reason  text
+)
+RETURNS TABLE(code_id uuid, session_id uuid, session_ended boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id        uuid := auth.uid();
+  v_admin_org       uuid;
+  v_code_org        uuid;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_code_session_id uuid;
+  v_session_ended   timestamptz;
+  v_session_total   int;
+  v_session_config  jsonb;
+  v_pass_mark       int;
+  v_answered        int;
+  v_correct_count   int;
+  v_score           numeric(5,2);
+  v_session_done    boolean := false;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  -- Resolve admin's org (deleted_at filter).
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  -- Lock the code row.
+  SELECT iec.organization_id, iec.consumed_at, iec.voided_at, iec.consumed_session_id
+  INTO v_code_org, v_code_consumed, v_code_voided, v_code_session_id
+  FROM public.internal_exam_codes iec
+  WHERE iec.id = p_code_id
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  -- Org-scope check: admin can only void codes in their own org.
+  IF v_code_org <> v_admin_org THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_voided IS NOT NULL THEN
+    -- Already voided — idempotent no-op for the void itself, but still surface.
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+
+  -- If the code was consumed, look at the linked session.
+  IF v_code_consumed IS NOT NULL AND v_code_session_id IS NOT NULL THEN
+    SELECT qs.ended_at, qs.total_questions, qs.config
+    INTO v_session_ended, v_session_total, v_session_config
+    FROM public.quiz_sessions qs
+    WHERE qs.id = v_code_session_id
+      AND qs.deleted_at IS NULL
+    FOR UPDATE;
+
+    IF FOUND AND v_session_ended IS NOT NULL THEN
+      -- Refuse to retroactively change a finished attempt.
+      RAISE EXCEPTION 'cannot_void_finished_attempt';
+    END IF;
+
+    IF FOUND AND v_session_ended IS NULL THEN
+      -- Compute the score from existing answers; unanswered = wrong.
+      SELECT
+        count(*)::int,
+        count(*) FILTER (WHERE qsa.is_correct)::int
+      INTO v_answered, v_correct_count
+      FROM public.quiz_session_answers qsa
+      WHERE qsa.session_id = v_code_session_id;
+
+      v_score := CASE WHEN v_session_total > 0
+                      THEN round((v_correct_count::numeric / v_session_total) * 100, 2)
+                      ELSE 0 END;
+
+      v_pass_mark := (v_session_config->>'pass_mark')::int;
+
+      UPDATE public.quiz_sessions
+      SET ended_at         = now(),
+          correct_count    = v_correct_count,
+          score_percentage = v_score,
+          passed           = false
+      WHERE id = v_code_session_id;
+
+      v_session_done := true;
+
+      -- Audit the session expiry (subquery filters deleted_at).
+      INSERT INTO public.audit_events
+        (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+      VALUES (
+        v_admin_org,
+        v_admin_id,
+        (SELECT u.role FROM public.users u
+         WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+        'internal_exam.expired',
+        'quiz_session',
+        v_code_session_id,
+        jsonb_build_object(
+          'reason',           'admin_voided',
+          'score_percentage', v_score,
+          'answered_count',   v_answered,
+          'correct_count',    v_correct_count,
+          'total_questions',  v_session_total,
+          'pass_mark',        v_pass_mark,
+          'passed',           false
+        )
+      );
+    END IF;
+  END IF;
+
+  -- Mark the code voided.
+  UPDATE public.internal_exam_codes
+  SET voided_at   = now(),
+      voided_by   = v_admin_id,
+      void_reason = p_reason
+  WHERE id = p_code_id;
+
+  -- Audit the void event.
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_voided',
+    'internal_exam_code',
+    p_code_id,
+    jsonb_build_object(
+      'reason',       p_reason,
+      'was_consumed', (v_code_consumed IS NOT NULL),
+      'session_ended', v_session_done
+    )
+  );
+
+  RETURN QUERY SELECT p_code_id, v_code_session_id, v_session_done;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.void_internal_exam_code(uuid, text) TO authenticated;

--- a/packages/db/migrations/062_extend_batch_submit_for_internal_exam.sql
+++ b/packages/db/migrations/062_extend_batch_submit_for_internal_exam.sql
@@ -1,0 +1,300 @@
+-- Extend batch_submit_quiz to handle 'internal_exam' alongside 'mock_exam'.
+-- Body forked from mig 056. Mode-branch widenings:
+--  - Score: correct/total for both exam modes; correct/answered for others.
+--  - Pass: pass-mark gates both; mock_exam also requires all answered.
+--  - Audit: mock_exam→'exam.completed', internal_exam→'internal_exam.completed',
+--    else 'quiz_session.batch_submitted'. Expiry mirrors with '.expired'.
+-- security.md rule 10: audit-row subqueries on users filter deleted_at.
+
+CREATE OR REPLACE FUNCTION batch_submit_quiz(
+  p_session_id uuid,
+  p_answers    jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_config          jsonb;
+  v_mode            text;
+  v_answer          jsonb;
+  v_correct_option  text;
+  v_is_correct      boolean;
+  v_expl_text       text;
+  v_expl_image_url  text;
+  v_question_id     uuid;
+  v_selected_option text;
+  v_response_time   int;
+  v_results         jsonb := '[]'::jsonb;
+  v_total           int;
+  v_answered        int;
+  v_correct_count   int;
+  v_score           numeric(5,2);
+  v_session_question_ids uuid[];
+  v_qid_text        text;
+  v_rt_text         text;
+  v_ended_at        timestamptz;
+  v_options         jsonb;
+  v_passed          boolean;
+  v_pass_mark       int;
+  v_time_limit      int;
+  v_started_at      timestamptz;
+  v_expired_event   text;
+  v_completed_event text;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT qs.organization_id, qs.total_questions, qs.config, qs.ended_at,
+         qs.correct_count, qs.score_percentage, qs.mode,
+         qs.time_limit_seconds, qs.started_at, qs.passed
+  INTO v_org_id, v_total, v_config, v_ended_at, v_correct_count, v_score, v_mode,
+       v_time_limit, v_started_at, v_passed
+  FROM quiz_sessions qs
+  WHERE qs.id = p_session_id
+    AND qs.student_id = v_student_id
+    AND qs.deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session not found or not accessible';
+  END IF;
+
+  IF v_ended_at IS NOT NULL THEN
+    SELECT count(*)::int INTO v_answered
+    FROM quiz_session_answers WHERE session_id = p_session_id;
+    SELECT jsonb_agg(jsonb_build_object(
+      'question_id', qsa.question_id,
+      'is_correct', qsa.is_correct,
+      'correct_option_id', (
+        SELECT opt->>'id' FROM jsonb_array_elements(q.options) opt
+        WHERE (opt->>'correct')::boolean LIMIT 1
+      ),
+      'explanation_text', q.explanation_text,
+      'explanation_image_url', q.explanation_image_url
+    ))
+    INTO v_results
+    FROM quiz_session_answers qsa
+    JOIN questions q ON q.id = qsa.question_id
+    WHERE qsa.session_id = p_session_id;
+
+    RETURN jsonb_build_object(
+      'results', COALESCE(v_results, '[]'::jsonb),
+      'total_questions', v_total,
+      'answered_count', v_answered,
+      'correct_count', v_correct_count,
+      'score_percentage', v_score,
+      'passed', v_passed
+    );
+  END IF;
+
+  -- Time-limit enforcement (30s grace, mirrors mig 056).
+  IF v_time_limit IS NOT NULL AND v_started_at IS NOT NULL THEN
+    IF now() > v_started_at + (v_time_limit + 30) * interval '1 second' THEN
+      UPDATE quiz_sessions
+      SET ended_at = now(), correct_count = 0, score_percentage = 0, passed = false
+      WHERE id = p_session_id;
+      v_expired_event := CASE v_mode
+                           WHEN 'internal_exam' THEN 'internal_exam.expired'
+                           ELSE 'exam.expired'
+                         END;
+      INSERT INTO audit_events
+        (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+      VALUES (
+        v_org_id, v_student_id,
+        (SELECT role FROM users WHERE id = v_student_id AND deleted_at IS NULL),
+        v_expired_event, 'quiz_session', p_session_id,
+        jsonb_build_object('total_questions', v_total, 'reason', 'submission past grace period')
+      );
+      RETURN jsonb_build_object(
+        'results', '[]'::jsonb,
+        'total_questions', v_total,
+        'answered_count', 0,
+        'correct_count', 0,
+        'score_percentage', 0,
+        'passed', false,
+        'expired', true
+      );
+    END IF;
+  END IF;
+
+  IF v_config IS NULL OR v_config->'question_ids' IS NULL OR jsonb_typeof(v_config->'question_ids') <> 'array' THEN
+    RAISE EXCEPTION 'session config is malformed — question_ids not set';
+  END IF;
+  v_session_question_ids := ARRAY(SELECT jsonb_array_elements_text(v_config->'question_ids'))::uuid[];
+
+  IF p_answers IS NULL
+     OR jsonb_typeof(p_answers) <> 'array'
+     OR jsonb_array_length(p_answers) = 0 THEN
+    RAISE EXCEPTION 'answers must be a non-empty JSON array';
+  END IF;
+
+  IF (
+    SELECT count(*) <> count(DISTINCT lower(e->>'question_id'))
+    FROM jsonb_array_elements(p_answers) AS e
+  ) THEN
+    RAISE EXCEPTION 'duplicate question_id in answers payload';
+  END IF;
+
+  -- See docs/database.md §3 "Scoring Soft-Deleted Questions".
+  DROP TABLE IF EXISTS _batch_questions;
+  CREATE TEMP TABLE _batch_questions ON COMMIT DROP AS
+  SELECT
+    q.id,
+    (SELECT opt->>'id' FROM jsonb_array_elements(q.options) opt
+     WHERE (opt->>'correct')::boolean LIMIT 1) AS correct_option,
+    q.explanation_text,
+    q.explanation_image_url,
+    q.options
+  FROM questions q
+  WHERE q.id = ANY(v_session_question_ids);
+
+  FOR v_answer IN SELECT * FROM jsonb_array_elements(p_answers)
+  LOOP
+    v_qid_text        := v_answer->>'question_id';
+    v_selected_option := v_answer->>'selected_option';
+    v_rt_text         := v_answer->>'response_time_ms';
+
+    IF v_qid_text IS NULL OR v_qid_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+      RAISE EXCEPTION 'invalid question_id format: %', coalesce(v_qid_text, 'NULL');
+    END IF;
+    IF v_selected_option IS NULL OR v_selected_option = '' THEN
+      RAISE EXCEPTION 'answer for question % has empty selected_option', v_qid_text;
+    END IF;
+    IF v_rt_text IS NULL OR v_rt_text !~ '^\d{1,9}$' THEN
+      RAISE EXCEPTION 'answer for question % has invalid response_time_ms', v_qid_text;
+    END IF;
+
+    v_question_id   := v_qid_text::uuid;
+    v_response_time := v_rt_text::int;
+
+    IF NOT (v_question_id = ANY(v_session_question_ids)) THEN
+      RAISE EXCEPTION 'question % does not belong to session %', v_question_id, p_session_id;
+    END IF;
+
+    SELECT bq.correct_option, bq.explanation_text, bq.explanation_image_url, bq.options
+    INTO v_correct_option, v_expl_text, v_expl_image_url, v_options
+    FROM _batch_questions bq
+    WHERE bq.id = v_question_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'question not found: %', v_question_id;
+    END IF;
+    IF v_correct_option IS NULL THEN
+      RAISE EXCEPTION 'question % has no correct option', v_question_id;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM jsonb_array_elements(v_options) opt
+      WHERE opt->>'id' = v_selected_option
+    ) THEN
+      RAISE EXCEPTION 'selected option % does not belong to question %', v_selected_option, v_question_id;
+    END IF;
+
+    v_is_correct := (v_selected_option = v_correct_option);
+
+    INSERT INTO quiz_session_answers
+      (session_id, question_id, selected_option_id, is_correct, response_time_ms)
+    VALUES
+      (p_session_id, v_question_id, v_selected_option, v_is_correct, v_response_time)
+    ON CONFLICT (session_id, question_id) DO NOTHING;
+
+    INSERT INTO student_responses
+      (organization_id, student_id, question_id, session_id,
+       selected_option_id, is_correct, response_time_ms)
+    VALUES
+      (v_org_id, v_student_id, v_question_id, p_session_id,
+       v_selected_option, v_is_correct, v_response_time)
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO fsrs_cards (student_id, question_id, last_was_correct, updated_at)
+    VALUES (v_student_id, v_question_id, v_is_correct, now())
+    ON CONFLICT (student_id, question_id)
+    DO UPDATE SET
+      last_was_correct = EXCLUDED.last_was_correct,
+      updated_at = now();
+
+    v_results := v_results || jsonb_build_object(
+      'question_id', v_question_id,
+      'is_correct', v_is_correct,
+      'correct_option_id', v_correct_option,
+      'explanation_text', v_expl_text,
+      'explanation_image_url', v_expl_image_url
+    );
+  END LOOP;
+
+  SELECT
+    count(*)::int,
+    count(*) FILTER (WHERE qsa.is_correct)::int
+  INTO v_answered, v_correct_count
+  FROM quiz_session_answers qsa
+  WHERE qsa.session_id = p_session_id;
+
+  -- Score: correct/total for both exam modes (unanswered = wrong);
+  -- correct/answered for non-exam modes.
+  IF v_mode IN ('mock_exam', 'internal_exam') THEN
+    v_score := CASE WHEN v_total > 0 THEN round((v_correct_count::numeric / v_total) * 100, 2) ELSE 0 END;
+  ELSE
+    v_score := CASE WHEN v_answered > 0 THEN round((v_correct_count::numeric / v_answered) * 100, 2) ELSE 0 END;
+  END IF;
+
+  -- Pass-mark gating for both exam modes. mock_exam additionally requires
+  -- all questions answered; internal_exam allows partial submissions.
+  IF v_mode IN ('mock_exam', 'internal_exam') THEN
+    v_pass_mark := (v_config->>'pass_mark')::int;
+    IF v_pass_mark IS NOT NULL THEN
+      v_passed := (v_score >= v_pass_mark);
+    ELSE
+      v_passed := false;
+    END IF;
+    IF v_mode = 'mock_exam' AND v_answered < v_total THEN
+      v_passed := false;
+    END IF;
+  END IF;
+
+  UPDATE quiz_sessions
+  SET
+    ended_at         = now(),
+    correct_count    = v_correct_count,
+    score_percentage = v_score,
+    passed           = v_passed
+  WHERE id = p_session_id;
+
+  v_completed_event := CASE v_mode
+                         WHEN 'mock_exam'     THEN 'exam.completed'
+                         WHEN 'internal_exam' THEN 'internal_exam.completed'
+                         ELSE 'quiz_session.batch_submitted'
+                       END;
+  INSERT INTO audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT role FROM users WHERE id = v_student_id AND deleted_at IS NULL),
+    v_completed_event,
+    'quiz_session',
+    p_session_id,
+    jsonb_build_object(
+      'total_questions', v_total,
+      'answered', v_answered,
+      'correct', v_correct_count,
+      'score', v_score,
+      'passed', v_passed
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'results', v_results,
+    'total_questions', v_total,
+    'answered_count', v_answered,
+    'correct_count', v_correct_count,
+    'score_percentage', v_score,
+    'passed', v_passed
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION batch_submit_quiz(uuid, jsonb) TO authenticated;

--- a/packages/db/migrations/063_extend_overdue_for_internal_exam.sql
+++ b/packages/db/migrations/063_extend_overdue_for_internal_exam.sql
@@ -1,0 +1,270 @@
+-- Extend Layer 1 overdue helpers to recognise 'internal_exam' alongside
+-- 'mock_exam'. Bodies forked from migs 052 (complete_overdue_exam_session)
+-- and 055 (complete_empty_exam_session). Mode guard widens to IN (...);
+-- audit event_type maps via CASE so internal_exam emits 'internal_exam.expired'
+-- / 'internal_exam.completed' while mock_exam keeps 'exam.expired' / 'exam.completed'.
+
+CREATE OR REPLACE FUNCTION complete_overdue_exam_session(p_session_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id     uuid := auth.uid();
+  v_org_id         uuid;
+  v_ended_at       timestamptz;
+  v_total          int;
+  v_mode           text;
+  v_started_at     timestamptz;
+  v_time_limit     int;
+  v_config         jsonb;
+  v_pass_mark      int;
+  v_answered       int;
+  v_correct_count  int;
+  v_score          numeric(5,2);
+  v_passed         boolean;
+  v_reason         text;
+  v_event_type     text;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT organization_id INTO v_org_id
+  FROM users
+  WHERE id = v_student_id AND deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  SELECT qs.ended_at, qs.total_questions, qs.mode,
+         qs.started_at, qs.time_limit_seconds, qs.config
+  INTO v_ended_at, v_total, v_mode, v_started_at, v_time_limit, v_config
+  FROM quiz_sessions qs
+  WHERE qs.id = p_session_id
+    AND qs.student_id = v_student_id
+    AND qs.organization_id = v_org_id
+    AND qs.deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session not found or not accessible';
+  END IF;
+  IF v_mode NOT IN ('mock_exam', 'internal_exam') THEN
+    RAISE EXCEPTION 'session is not an exam';
+  END IF;
+
+  IF v_ended_at IS NOT NULL THEN
+    SELECT qs.correct_count, qs.score_percentage, qs.passed,
+           (SELECT count(*)::int FROM quiz_session_answers WHERE session_id = p_session_id)
+    INTO v_correct_count, v_score, v_passed, v_answered
+    FROM quiz_sessions qs
+    WHERE qs.id = p_session_id
+      AND qs.student_id = v_student_id
+      AND qs.organization_id = v_org_id
+      AND qs.deleted_at IS NULL;
+    RETURN jsonb_build_object(
+      'session_id',       p_session_id,
+      'score_percentage', COALESCE(v_score, 0),
+      'passed',           COALESCE(v_passed, false),
+      'total_questions',  v_total,
+      'answered_count',   COALESCE(v_answered, 0)
+    );
+  END IF;
+
+  IF v_time_limit IS NULL OR v_started_at IS NULL THEN
+    RAISE EXCEPTION 'session has no deadline to enforce';
+  END IF;
+  IF now() <= v_started_at + ((v_time_limit + 30) || ' seconds')::interval THEN
+    RAISE EXCEPTION 'session is not overdue';
+  END IF;
+
+  SELECT
+    count(*)::int,
+    count(*) FILTER (WHERE qsa.is_correct)::int
+  INTO v_answered, v_correct_count
+  FROM quiz_session_answers qsa
+  WHERE qsa.session_id = p_session_id;
+
+  v_score := CASE WHEN v_total > 0
+                  THEN round((v_correct_count::numeric / v_total) * 100, 2)
+                  ELSE 0 END;
+
+  v_pass_mark := (v_config->>'pass_mark')::int;
+  v_passed := COALESCE(v_pass_mark IS NOT NULL AND v_score >= v_pass_mark, false);
+  -- mock_exam requires all answered; internal_exam allows partial submits.
+  IF v_mode = 'mock_exam' AND v_answered < v_total THEN
+    v_passed := false;
+  END IF;
+
+  UPDATE quiz_sessions
+  SET ended_at = now(),
+      correct_count = v_correct_count,
+      score_percentage = v_score,
+      passed = v_passed
+  WHERE id = p_session_id;
+
+  v_reason := CASE WHEN v_answered > 0
+                   THEN 'overdue_with_answers'
+                   ELSE 'overdue_zero_answers' END;
+
+  v_event_type := CASE v_mode
+                    WHEN 'internal_exam' THEN 'internal_exam.expired'
+                    ELSE 'exam.expired'
+                  END;
+
+  INSERT INTO audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id, v_student_id,
+    (SELECT role FROM users WHERE id = v_student_id AND deleted_at IS NULL),
+    v_event_type, 'quiz_session', p_session_id,
+    jsonb_build_object(
+      'total_questions', v_total,
+      'answered_count',  v_answered,
+      'correct_count',   v_correct_count,
+      'score',           v_score,
+      'passed',          v_passed,
+      'reason',          v_reason
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'session_id',       p_session_id,
+    'score_percentage', v_score,
+    'passed',           v_passed,
+    'total_questions',  v_total,
+    'answered_count',   v_answered
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION complete_overdue_exam_session(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION complete_empty_exam_session(p_session_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_ended_at        timestamptz;
+  v_total           int;
+  v_mode            text;
+  v_started_at      timestamptz;
+  v_time_limit      int;
+  v_correct_count   int;
+  v_score           numeric;
+  v_passed          boolean;
+  v_answered        int;
+  v_overdue         boolean;
+  v_event_type      text;
+  v_reason          text;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT organization_id INTO v_org_id
+  FROM users
+  WHERE id = v_student_id AND deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  SELECT qs.ended_at, qs.total_questions, qs.mode,
+         qs.started_at, qs.time_limit_seconds
+  INTO v_ended_at, v_total, v_mode, v_started_at, v_time_limit
+  FROM quiz_sessions qs
+  WHERE qs.id = p_session_id
+    AND qs.student_id = v_student_id
+    AND qs.organization_id = v_org_id
+    AND qs.deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session not found or not accessible';
+  END IF;
+  IF v_mode NOT IN ('mock_exam', 'internal_exam') THEN
+    RAISE EXCEPTION 'session is not an exam';
+  END IF;
+
+  IF v_ended_at IS NOT NULL THEN
+    SELECT qs.correct_count, qs.score_percentage, qs.passed,
+           (SELECT count(*)::int FROM quiz_session_answers WHERE session_id = p_session_id)
+    INTO v_correct_count, v_score, v_passed, v_answered
+    FROM quiz_sessions qs
+    WHERE qs.id = p_session_id
+      AND qs.student_id = v_student_id
+      AND qs.organization_id = v_org_id
+      AND qs.deleted_at IS NULL;
+    RETURN jsonb_build_object(
+      'session_id',       p_session_id,
+      'score_percentage', COALESCE(v_score, 0),
+      'passed',           COALESCE(v_passed, false),
+      'total_questions',  v_total,
+      'answered_count',   COALESCE(v_answered, 0)
+    );
+  END IF;
+
+  UPDATE quiz_sessions
+  SET
+    ended_at         = now(),
+    correct_count    = 0,
+    score_percentage = 0,
+    passed           = false
+  WHERE id = p_session_id;
+
+  -- 30s grace mirrors batch_submit_quiz / mig 052: a session within grace was
+  -- not "timed out" — the student was just early.
+  v_overdue := v_time_limit IS NOT NULL
+               AND v_started_at IS NOT NULL
+               AND now() > v_started_at + ((v_time_limit + 30) || ' seconds')::interval;
+
+  IF v_overdue THEN
+    v_event_type := CASE v_mode
+                      WHEN 'internal_exam' THEN 'internal_exam.expired'
+                      ELSE 'exam.expired'
+                    END;
+    v_reason := 'timed out with no answers';
+  ELSE
+    v_event_type := CASE v_mode
+                      WHEN 'internal_exam' THEN 'internal_exam.completed'
+                      ELSE 'exam.completed'
+                    END;
+    v_reason := 'completed with no answers';
+  END IF;
+
+  INSERT INTO audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT role FROM users WHERE id = v_student_id AND deleted_at IS NULL),
+    v_event_type,
+    'quiz_session',
+    p_session_id,
+    jsonb_build_object(
+      'total_questions', v_total,
+      'answered_count', 0,
+      'correct_count', 0,
+      'score', 0,
+      'passed', false,
+      'reason', v_reason
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'session_id',       p_session_id,
+    'score_percentage', 0,
+    'passed',           false,
+    'total_questions',  v_total,
+    'answered_count',   0
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION complete_empty_exam_session(uuid) TO authenticated;

--- a/packages/db/migrations/064_internal_exam_codes_force_rls.sql
+++ b/packages/db/migrations/064_internal_exam_codes_force_rls.sql
@@ -1,0 +1,6 @@
+-- Migration 064: Force RLS on internal_exam_codes
+-- Closes a defense-in-depth gap caught in semantic review of commit 10b27cc.
+-- Without FORCE, the table owner role bypasses policies during admin tooling,
+-- migration scripts, or service-role queries (see docs/security.md §3).
+
+ALTER TABLE public.internal_exam_codes FORCE ROW LEVEL SECURITY;

--- a/packages/db/migrations/065_start_internal_exam_session_active_guard.sql
+++ b/packages/db/migrations/065_start_internal_exam_session_active_guard.sql
@@ -1,0 +1,215 @@
+-- Migration 065: Add duplicate-active-session guard to start_internal_exam_session
+-- Closes an ISSUE caught in semantic review of commit 10b27cc.
+-- Mirrors the guard added to start_exam_session in mig 054. Without it, a
+-- student holding two valid codes for the same subject within their 24h
+-- windows could redeem both and run two concurrent internal_exam sessions.
+-- The guard runs AFTER the overdue auto-complete (so a stale overdue session
+-- is cleaned up first and won't trigger the guard) but BEFORE the INSERT into
+-- quiz_sessions or the UPDATE of internal_exam_codes.
+-- security.md rules 7, 9, 10 (audit subquery keeps deleted_at IS NULL).
+
+CREATE OR REPLACE FUNCTION public.start_internal_exam_session(p_code text)
+RETURNS TABLE(
+  session_id uuid,
+  question_ids uuid[],
+  time_limit_seconds int,
+  total_questions int,
+  pass_mark int,
+  started_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_code_id         uuid;
+  v_code_subject    uuid;
+  v_code_student    uuid;
+  v_code_expires    timestamptz;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_old_session_id  uuid;
+  v_config_id       uuid;
+  v_total_questions int;
+  v_time_limit      int;
+  v_pass_mark       int;
+  v_dist            record;
+  v_selected_ids    uuid[] := '{}';
+  v_topic_ids       uuid[];
+  v_session_id      uuid;
+  v_started_at      timestamptz;
+  v_consumed_rows   int;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  -- Lock + validate the code.
+  SELECT iec.id, iec.subject_id, iec.student_id,
+         iec.expires_at, iec.consumed_at, iec.voided_at
+  INTO v_code_id, v_code_subject, v_code_student,
+       v_code_expires, v_code_consumed, v_code_voided
+  FROM public.internal_exam_codes iec
+  WHERE iec.code = p_code
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_student <> v_student_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+  IF v_code_consumed IS NOT NULL THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+  IF v_code_expires <= now() THEN
+    RAISE EXCEPTION 'code_expired';
+  END IF;
+
+  -- Resolve student's org.
+  SELECT u.organization_id INTO v_org_id
+  FROM public.users u
+  WHERE u.id = v_student_id AND u.deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  -- Auto-complete any same-subject internal_exam past +30s grace
+  -- (mirrors start_exam_session in mig 054).
+  SELECT id INTO v_old_session_id
+  FROM public.quiz_sessions
+  WHERE student_id = v_student_id
+    AND organization_id = v_org_id
+    AND subject_id = v_code_subject
+    AND mode = 'internal_exam'
+    AND ended_at IS NULL
+    AND deleted_at IS NULL
+    AND time_limit_seconds IS NOT NULL
+    AND started_at IS NOT NULL
+    AND now() > started_at + ((time_limit_seconds + 30) || ' seconds')::interval
+  LIMIT 1;
+  IF v_old_session_id IS NOT NULL THEN
+    PERFORM public.complete_overdue_exam_session(v_old_session_id);
+  END IF;
+
+  -- Guard against starting a second active session for the same subject (parity
+  -- with start_exam_session, mig 054). This protects against a student
+  -- redeeming two valid codes for the same subject within their 24h windows.
+  IF EXISTS (
+    SELECT 1 FROM public.quiz_sessions
+    WHERE student_id = v_student_id
+      AND organization_id = v_org_id
+      AND subject_id = v_code_subject
+      AND mode = 'internal_exam'
+      AND ended_at IS NULL
+      AND deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END IF;
+
+  -- Fetch the exam config for this subject in the student's org.
+  SELECT ec.id, ec.total_questions, ec.time_limit_seconds, ec.pass_mark
+  INTO v_config_id, v_total_questions, v_time_limit, v_pass_mark
+  FROM public.exam_configs ec
+  WHERE ec.organization_id = v_org_id
+    AND ec.subject_id = v_code_subject
+    AND ec.enabled = true
+    AND ec.deleted_at IS NULL;
+  IF v_config_id IS NULL THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  -- Sample questions per distribution (matches mig 054 algorithm).
+  FOR v_dist IN
+    SELECT ecd.topic_id, ecd.subtopic_id, ecd.question_count
+    FROM public.exam_config_distributions ecd
+    WHERE ecd.exam_config_id = v_config_id
+    ORDER BY ecd.topic_id, ecd.subtopic_id NULLS LAST
+  LOOP
+    v_topic_ids := ARRAY(
+      SELECT q.id
+      FROM public.questions q
+      WHERE q.subject_id = v_code_subject
+        AND q.topic_id = v_dist.topic_id
+        AND (v_dist.subtopic_id IS NULL OR q.subtopic_id = v_dist.subtopic_id)
+        AND q.status = 'active'
+        AND q.deleted_at IS NULL
+        AND q.organization_id = v_org_id
+        AND q.id != ALL(v_selected_ids)
+      ORDER BY random()
+      LIMIT v_dist.question_count
+    );
+    IF array_length(v_topic_ids, 1) IS NULL OR array_length(v_topic_ids, 1) < v_dist.question_count THEN
+      RAISE EXCEPTION 'insufficient_questions_for_exam';
+    END IF;
+    v_selected_ids := v_selected_ids || v_topic_ids;
+  END LOOP;
+
+  IF array_length(v_selected_ids, 1) IS NULL
+     OR array_length(v_selected_ids, 1) <> v_total_questions THEN
+    RAISE EXCEPTION 'insufficient_questions_for_exam';
+  END IF;
+
+  -- Insert session.
+  INSERT INTO public.quiz_sessions
+    (organization_id, student_id, mode, subject_id,
+     config, total_questions, time_limit_seconds)
+  VALUES (
+    v_org_id, v_student_id, 'internal_exam', v_code_subject,
+    jsonb_build_object(
+      'question_ids',   to_jsonb(v_selected_ids),
+      'exam_config_id', v_config_id,
+      'pass_mark',      v_pass_mark
+    ),
+    v_total_questions, v_time_limit
+  )
+  RETURNING id, quiz_sessions.started_at
+  INTO v_session_id, v_started_at;
+
+  -- Mark code consumed (race-safe: requires consumed_at IS NULL).
+  UPDATE public.internal_exam_codes
+  SET consumed_at = now(),
+      consumed_session_id = v_session_id
+  WHERE id = v_code_id
+    AND consumed_at IS NULL;
+  GET DIAGNOSTICS v_consumed_rows = ROW_COUNT;
+  IF v_consumed_rows = 0 THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_student_id AND u.deleted_at IS NULL),
+    'internal_exam.started',
+    'quiz_session',
+    v_session_id,
+    jsonb_build_object(
+      'code_id',         v_code_id,
+      'subject_id',      v_code_subject,
+      'total_questions', v_total_questions,
+      'pass_mark',       v_pass_mark
+    )
+  );
+
+  RETURN QUERY SELECT
+    v_session_id,
+    v_selected_ids,
+    v_time_limit,
+    v_total_questions,
+    v_pass_mark,
+    v_started_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.start_internal_exam_session(text) TO authenticated;

--- a/packages/db/migrations/066_get_session_reports_exclude_internal_exam.sql
+++ b/packages/db/migrations/066_get_session_reports_exclude_internal_exam.sql
@@ -1,0 +1,79 @@
+-- Migration 066: get_session_reports excludes internal_exam at the SQL level.
+-- Without this, count(*) OVER() includes internal_exam rows in total_count even
+-- though the TypeScript filter in lib/queries/reports.ts excludes them from the
+-- returned rows, causing pagination drift on mixed-mode student histories.
+
+CREATE OR REPLACE FUNCTION public.get_session_reports(
+  p_sort  TEXT DEFAULT 'started_at',
+  p_dir   TEXT DEFAULT 'desc',
+  p_limit INT DEFAULT 10,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id               UUID,
+  mode             TEXT,
+  total_questions  INT,
+  correct_count    INT,
+  score_percentage NUMERIC,
+  started_at       TIMESTAMPTZ,
+  ended_at         TIMESTAMPTZ,
+  subject_id       UUID,
+  subject_name     TEXT,
+  answered_count   BIGINT,
+  total_count      BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid UUID;
+  v_sort TEXT;
+  v_dir  TEXT;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  CASE p_sort
+    WHEN 'started_at'       THEN v_sort := 'qs.started_at';
+    WHEN 'score_percentage'  THEN v_sort := 'qs.score_percentage';
+    WHEN 'subject_name'      THEN v_sort := 'es.name';
+    ELSE v_sort := 'qs.started_at';
+  END CASE;
+
+  IF lower(p_dir) = 'asc' THEN
+    v_dir := 'ASC';
+  ELSE
+    v_dir := 'DESC';
+  END IF;
+
+  RETURN QUERY EXECUTE format(
+    'SELECT
+       qs.id,
+       qs.mode::TEXT,
+       qs.total_questions,
+       qs.correct_count,
+       qs.score_percentage,
+       qs.started_at,
+       qs.ended_at,
+       qs.subject_id,
+       es.name AS subject_name,
+       (SELECT count(*) FROM quiz_session_answers qsa WHERE qsa.session_id = qs.id) AS answered_count,
+       count(*) OVER() AS total_count
+     FROM quiz_sessions qs
+     LEFT JOIN easa_subjects es ON es.id = qs.subject_id
+     WHERE qs.student_id = $1
+       AND qs.ended_at IS NOT NULL
+       AND qs.deleted_at IS NULL
+       AND qs.mode <> ''internal_exam''
+     ORDER BY %s %s NULLS LAST, qs.id ASC
+     LIMIT $2 OFFSET $3',
+    v_sort, v_dir
+  )
+  USING v_uid, p_limit, p_offset;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_session_reports(TEXT, TEXT, INT, INT) TO authenticated;

--- a/packages/db/migrations/067_issue_internal_exam_code_drop_subject_softdelete.sql
+++ b/packages/db/migrations/067_issue_internal_exam_code_drop_subject_softdelete.sql
@@ -1,0 +1,130 @@
+-- Migration 067: Drop non-existent easa_subjects.deleted_at filter
+-- CodeRabbit PR #576 finding #30 (CRITICAL).
+-- mig 059 line 60 references `s.deleted_at IS NULL` on `public.easa_subjects`,
+-- but that table has no `deleted_at` column. The RPC throws
+-- `column "deleted_at" does not exist` at runtime, breaking every code-issuance
+-- attempt. Forward fix: re-CREATE OR REPLACE with the predicate removed.
+-- All other filters (org match, role check on student, exam_config check,
+-- code-generation loop, audit insert) preserved verbatim.
+-- security.md rules 7, 9, 10 — auth.uid() check, deleted_at filters on every
+-- SELECT (including the audit-row subqueries), generic error codes only.
+
+CREATE OR REPLACE FUNCTION public.issue_internal_exam_code(
+  p_subject_id uuid,
+  p_student_id uuid
+)
+RETURNS TABLE(code_id uuid, code text, expires_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id   uuid := auth.uid();
+  v_admin_org  uuid;
+  v_student_org uuid;
+  v_charset    text := 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  v_charset_len int  := length('ABCDEFGHJKLMNPQRSTUVWXYZ23456789');
+  v_code       text;
+  v_new_id     uuid;
+  v_new_expiry timestamptz;
+  v_attempt    int := 0;
+  v_inserted   boolean := false;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  -- Resolve admin's organization.
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id
+    AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  -- Verify student exists in same org with role='student'.
+  SELECT u.organization_id INTO v_student_org
+  FROM public.users u
+  WHERE u.id = p_student_id
+    AND u.role = 'student'
+    AND u.deleted_at IS NULL;
+  IF v_student_org IS NULL OR v_student_org <> v_admin_org THEN
+    RAISE EXCEPTION 'student_not_found';
+  END IF;
+
+  -- Verify subject exists. easa_subjects has no deleted_at column.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.easa_subjects s
+    WHERE s.id = p_subject_id
+  ) THEN
+    RAISE EXCEPTION 'subject_not_found';
+  END IF;
+
+  -- Verify an enabled exam_config exists for (admin_org, subject).
+  IF NOT EXISTS (
+    SELECT 1 FROM public.exam_configs ec
+    WHERE ec.organization_id = v_admin_org
+      AND ec.subject_id = p_subject_id
+      AND ec.enabled = true
+      AND ec.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  v_new_expiry := now() + interval '24 hours';
+
+  -- Generate + insert with up-to-5 retry on unique-violation.
+  WHILE v_attempt < 5 AND NOT v_inserted LOOP
+    v_attempt := v_attempt + 1;
+    v_code := array_to_string(
+      ARRAY(
+        SELECT substr(v_charset, 1 + floor(random() * v_charset_len)::int, 1)
+        FROM generate_series(1, 8)
+      ),
+      ''
+    );
+    BEGIN
+      INSERT INTO public.internal_exam_codes
+        (code, subject_id, student_id, issued_by, expires_at, organization_id)
+      VALUES
+        (v_code, p_subject_id, p_student_id, v_admin_id, v_new_expiry, v_admin_org)
+      RETURNING id INTO v_new_id;
+      v_inserted := true;
+    EXCEPTION WHEN unique_violation THEN
+      -- Retry with a fresh code.
+      v_inserted := false;
+    END;
+  END LOOP;
+
+  IF NOT v_inserted THEN
+    RAISE EXCEPTION 'code_generation_failed';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_issued',
+    'internal_exam_code',
+    v_new_id,
+    jsonb_build_object(
+      'student_id', p_student_id,
+      'subject_id', p_subject_id,
+      'expires_at', v_new_expiry
+    )
+  );
+
+  RETURN QUERY SELECT v_new_id, v_code, v_new_expiry;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.issue_internal_exam_code(uuid, uuid) TO authenticated;

--- a/packages/db/migrations/068_void_internal_exam_code_validate_reason.sql
+++ b/packages/db/migrations/068_void_internal_exam_code_validate_reason.sql
@@ -1,0 +1,173 @@
+-- Migration 068: Validate p_reason in DB + align audit metadata key
+-- CodeRabbit PR #576 findings #31 (validation) + #32 (audit-key naming).
+-- Issue #31: Reason length/non-empty validation lives only in the JS Zod
+-- schema, so direct RPC callers (red-team specs, future tooling, psql) bypass
+-- it and can store empty/oversized reasons. Add server-side validation:
+-- non-null, non-blank after btrim, length <= 500.
+-- Issue #32: The 'internal_exam.expired' audit row uses jsonb key
+-- `score_percentage`, but the canonical key across other audit events is
+-- `score`. Rename for consistency. Other audit events untouched.
+-- security.md rules 7, 9, 10.
+
+CREATE OR REPLACE FUNCTION public.void_internal_exam_code(
+  p_code_id uuid,
+  p_reason  text
+)
+RETURNS TABLE(code_id uuid, session_id uuid, session_ended boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id        uuid := auth.uid();
+  v_admin_org       uuid;
+  v_code_org        uuid;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_code_session_id uuid;
+  v_session_ended   timestamptz;
+  v_session_total   int;
+  v_session_config  jsonb;
+  v_pass_mark       int;
+  v_answered        int;
+  v_correct_count   int;
+  v_score           numeric(5,2);
+  v_session_done    boolean := false;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  -- Server-side reason validation (parity with Zod schema in JS layer).
+  IF p_reason IS NULL OR btrim(p_reason) = '' THEN
+    RAISE EXCEPTION 'invalid_reason';
+  END IF;
+  IF length(p_reason) > 500 THEN
+    RAISE EXCEPTION 'invalid_reason';
+  END IF;
+
+  -- Resolve admin's org (deleted_at filter).
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  -- Lock the code row.
+  SELECT iec.organization_id, iec.consumed_at, iec.voided_at, iec.consumed_session_id
+  INTO v_code_org, v_code_consumed, v_code_voided, v_code_session_id
+  FROM public.internal_exam_codes iec
+  WHERE iec.id = p_code_id
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  -- Org-scope check: admin can only void codes in their own org.
+  IF v_code_org <> v_admin_org THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_voided IS NOT NULL THEN
+    -- Already voided — idempotent no-op for the void itself, but still surface.
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+
+  -- If the code was consumed, look at the linked session.
+  IF v_code_consumed IS NOT NULL AND v_code_session_id IS NOT NULL THEN
+    SELECT qs.ended_at, qs.total_questions, qs.config
+    INTO v_session_ended, v_session_total, v_session_config
+    FROM public.quiz_sessions qs
+    WHERE qs.id = v_code_session_id
+      AND qs.deleted_at IS NULL
+    FOR UPDATE;
+
+    IF FOUND AND v_session_ended IS NOT NULL THEN
+      -- Refuse to retroactively change a finished attempt.
+      RAISE EXCEPTION 'cannot_void_finished_attempt';
+    END IF;
+
+    IF FOUND AND v_session_ended IS NULL THEN
+      -- Compute the score from existing answers; unanswered = wrong.
+      SELECT
+        count(*)::int,
+        count(*) FILTER (WHERE qsa.is_correct)::int
+      INTO v_answered, v_correct_count
+      FROM public.quiz_session_answers qsa
+      WHERE qsa.session_id = v_code_session_id;
+
+      v_score := CASE WHEN v_session_total > 0
+                      THEN round((v_correct_count::numeric / v_session_total) * 100, 2)
+                      ELSE 0 END;
+
+      v_pass_mark := (v_session_config->>'pass_mark')::int;
+
+      UPDATE public.quiz_sessions
+      SET ended_at         = now(),
+          correct_count    = v_correct_count,
+          score_percentage = v_score,
+          passed           = false
+      WHERE id = v_code_session_id;
+
+      v_session_done := true;
+
+      -- Audit the session expiry (subquery filters deleted_at).
+      -- Canonical audit key is `score` (matches other audit events).
+      INSERT INTO public.audit_events
+        (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+      VALUES (
+        v_admin_org,
+        v_admin_id,
+        (SELECT u.role FROM public.users u
+         WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+        'internal_exam.expired',
+        'quiz_session',
+        v_code_session_id,
+        jsonb_build_object(
+          'reason',           'admin_voided',
+          'score',            v_score,
+          'answered_count',   v_answered,
+          'correct_count',    v_correct_count,
+          'total_questions',  v_session_total,
+          'pass_mark',        v_pass_mark,
+          'passed',           false
+        )
+      );
+    END IF;
+  END IF;
+
+  -- Mark the code voided.
+  UPDATE public.internal_exam_codes
+  SET voided_at   = now(),
+      voided_by   = v_admin_id,
+      void_reason = p_reason
+  WHERE id = p_code_id;
+
+  -- Audit the void event.
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_voided',
+    'internal_exam_code',
+    p_code_id,
+    jsonb_build_object(
+      'reason',       p_reason,
+      'was_consumed', (v_code_consumed IS NOT NULL),
+      'session_ended', v_session_done
+    )
+  );
+
+  RETURN QUERY SELECT p_code_id, v_code_session_id, v_session_done;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.void_internal_exam_code(uuid, text) TO authenticated;

--- a/packages/db/migrations/069_internal_exam_session_active_unique.sql
+++ b/packages/db/migrations/069_internal_exam_session_active_unique.sql
@@ -1,0 +1,16 @@
+-- Migration 069: Schema-level guard against concurrent active internal_exam sessions
+-- CodeRabbit PR #576 finding #33 (CRITICAL — race condition).
+-- The EXISTS guard in start_internal_exam_session (mig 065 lines 104-114) is
+-- racy: two concurrent transactions with two different codes for the same
+-- (student, subject) can both observe no active session, both INSERT into
+-- quiz_sessions, and both succeed — producing two simultaneous active
+-- internal_exam sessions for one student.
+-- Fix: a partial unique index that enforces the invariant at the schema level.
+-- This is concurrency-safe because PG serialises unique-index check + insert.
+-- The companion function-body update (with EXCEPTION WHEN unique_violation)
+-- ships in migration 070, which also fixes the missing org check (#36).
+-- This migration ships only the index — it does NOT modify the function.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_internal_exam_session_active
+ON public.quiz_sessions (student_id, organization_id, subject_id)
+WHERE mode = 'internal_exam' AND ended_at IS NULL AND deleted_at IS NULL;

--- a/packages/db/migrations/070_start_internal_exam_session_org_check.sql
+++ b/packages/db/migrations/070_start_internal_exam_session_org_check.sql
@@ -1,0 +1,240 @@
+-- Migration 070: Org-scope check + race-safe INSERT on start_internal_exam_session
+-- CodeRabbit PR #576 finding #36 (CRITICAL — missing org check) +
+-- function-body half of finding #33 (race condition; the index ships in 069).
+--
+-- Issue #36: The SELECT from internal_exam_codes (mig 065 lines 50-57) loaded
+--   id, subject_id, student_id, expires_at, consumed_at, voided_at
+-- but NOT organization_id. The code's org is never compared to the resolving
+-- student's org, so a code for a student moved cross-org (or any future
+-- corruption that drifts iec.organization_id from u.organization_id) would
+-- silently start a session in the wrong org.
+-- Fix: SELECT iec.organization_id INTO v_code_org and verify v_code_org = v_org_id
+-- after the student's org is resolved. Use the unified `code_not_yours` error
+-- to avoid leaking cross-org existence.
+--
+-- Issue #33 (function-body): wrap the INSERT INTO quiz_sessions in
+-- EXCEPTION WHEN unique_violation -> 'active_session_exists'. The pre-INSERT
+-- EXISTS guard is kept (cheap, gives clean error in normal flow), but the
+-- catch-handler is now the source of truth for the invariant — it is the only
+-- one that is concurrency-safe (relies on the partial unique index from 069).
+-- security.md rules 7, 9, 10 (audit subquery keeps deleted_at IS NULL).
+
+CREATE OR REPLACE FUNCTION public.start_internal_exam_session(p_code text)
+RETURNS TABLE(
+  session_id uuid,
+  question_ids uuid[],
+  time_limit_seconds int,
+  total_questions int,
+  pass_mark int,
+  started_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_code_id         uuid;
+  v_code_subject    uuid;
+  v_code_student    uuid;
+  v_code_org        uuid;
+  v_code_expires    timestamptz;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_old_session_id  uuid;
+  v_config_id       uuid;
+  v_total_questions int;
+  v_time_limit      int;
+  v_pass_mark       int;
+  v_dist            record;
+  v_selected_ids    uuid[] := '{}';
+  v_topic_ids       uuid[];
+  v_session_id      uuid;
+  v_started_at      timestamptz;
+  v_consumed_rows   int;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  -- Lock + validate the code (now also reads organization_id for cross-org check).
+  SELECT iec.id, iec.subject_id, iec.student_id, iec.organization_id,
+         iec.expires_at, iec.consumed_at, iec.voided_at
+  INTO v_code_id, v_code_subject, v_code_student, v_code_org,
+       v_code_expires, v_code_consumed, v_code_voided
+  FROM public.internal_exam_codes iec
+  WHERE iec.code = p_code
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_student <> v_student_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+  IF v_code_consumed IS NOT NULL THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+  IF v_code_expires <= now() THEN
+    RAISE EXCEPTION 'code_expired';
+  END IF;
+
+  -- Resolve student's org.
+  SELECT u.organization_id INTO v_org_id
+  FROM public.users u
+  WHERE u.id = v_student_id AND u.deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  -- Cross-org check: the code's org must match the resolving student's org.
+  -- Unified error message — never reveal cross-org existence.
+  IF v_code_org IS NULL OR v_code_org <> v_org_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+
+  -- Auto-complete any same-subject internal_exam past +30s grace
+  -- (mirrors start_exam_session in mig 054).
+  SELECT id INTO v_old_session_id
+  FROM public.quiz_sessions
+  WHERE student_id = v_student_id
+    AND organization_id = v_org_id
+    AND subject_id = v_code_subject
+    AND mode = 'internal_exam'
+    AND ended_at IS NULL
+    AND deleted_at IS NULL
+    AND time_limit_seconds IS NOT NULL
+    AND started_at IS NOT NULL
+    AND now() > started_at + ((time_limit_seconds + 30) || ' seconds')::interval
+  LIMIT 1;
+  IF v_old_session_id IS NOT NULL THEN
+    PERFORM public.complete_overdue_exam_session(v_old_session_id);
+  END IF;
+
+  -- Pre-INSERT guard: cheap fast path that yields a clean error in normal flow.
+  -- The schema-level partial unique index (mig 069) is the concurrency-safe
+  -- source of truth — see the EXCEPTION handler around the INSERT below.
+  IF EXISTS (
+    SELECT 1 FROM public.quiz_sessions
+    WHERE student_id = v_student_id
+      AND organization_id = v_org_id
+      AND subject_id = v_code_subject
+      AND mode = 'internal_exam'
+      AND ended_at IS NULL
+      AND deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END IF;
+
+  -- Fetch the exam config for this subject in the student's org.
+  SELECT ec.id, ec.total_questions, ec.time_limit_seconds, ec.pass_mark
+  INTO v_config_id, v_total_questions, v_time_limit, v_pass_mark
+  FROM public.exam_configs ec
+  WHERE ec.organization_id = v_org_id
+    AND ec.subject_id = v_code_subject
+    AND ec.enabled = true
+    AND ec.deleted_at IS NULL;
+  IF v_config_id IS NULL THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  -- Sample questions per distribution (matches mig 054 algorithm).
+  FOR v_dist IN
+    SELECT ecd.topic_id, ecd.subtopic_id, ecd.question_count
+    FROM public.exam_config_distributions ecd
+    WHERE ecd.exam_config_id = v_config_id
+    ORDER BY ecd.topic_id, ecd.subtopic_id NULLS LAST
+  LOOP
+    v_topic_ids := ARRAY(
+      SELECT q.id
+      FROM public.questions q
+      WHERE q.subject_id = v_code_subject
+        AND q.topic_id = v_dist.topic_id
+        AND (v_dist.subtopic_id IS NULL OR q.subtopic_id = v_dist.subtopic_id)
+        AND q.status = 'active'
+        AND q.deleted_at IS NULL
+        AND q.organization_id = v_org_id
+        AND q.id != ALL(v_selected_ids)
+      ORDER BY random()
+      LIMIT v_dist.question_count
+    );
+    IF array_length(v_topic_ids, 1) IS NULL OR array_length(v_topic_ids, 1) < v_dist.question_count THEN
+      RAISE EXCEPTION 'insufficient_questions_for_exam';
+    END IF;
+    v_selected_ids := v_selected_ids || v_topic_ids;
+  END LOOP;
+
+  IF array_length(v_selected_ids, 1) IS NULL
+     OR array_length(v_selected_ids, 1) <> v_total_questions THEN
+    RAISE EXCEPTION 'insufficient_questions_for_exam';
+  END IF;
+
+  -- Insert session. Race-safe: the partial unique index on
+  -- (student_id, organization_id, subject_id) WHERE mode='internal_exam'
+  -- AND ended_at IS NULL AND deleted_at IS NULL (mig 069) catches concurrent
+  -- INSERTs that both passed the EXISTS guard above.
+  BEGIN
+    INSERT INTO public.quiz_sessions
+      (organization_id, student_id, mode, subject_id,
+       config, total_questions, time_limit_seconds)
+    VALUES (
+      v_org_id, v_student_id, 'internal_exam', v_code_subject,
+      jsonb_build_object(
+        'question_ids',   to_jsonb(v_selected_ids),
+        'exam_config_id', v_config_id,
+        'pass_mark',      v_pass_mark
+      ),
+      v_total_questions, v_time_limit
+    )
+    RETURNING id, quiz_sessions.started_at
+    INTO v_session_id, v_started_at;
+  EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END;
+
+  -- Mark code consumed (race-safe: requires consumed_at IS NULL).
+  UPDATE public.internal_exam_codes
+  SET consumed_at = now(),
+      consumed_session_id = v_session_id
+  WHERE id = v_code_id
+    AND consumed_at IS NULL;
+  GET DIAGNOSTICS v_consumed_rows = ROW_COUNT;
+  IF v_consumed_rows = 0 THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_student_id AND u.deleted_at IS NULL),
+    'internal_exam.started',
+    'quiz_session',
+    v_session_id,
+    jsonb_build_object(
+      'code_id',         v_code_id,
+      'subject_id',      v_code_subject,
+      'total_questions', v_total_questions,
+      'pass_mark',       v_pass_mark
+    )
+  );
+
+  RETURN QUERY SELECT
+    v_session_id,
+    v_selected_ids,
+    v_time_limit,
+    v_total_questions,
+    v_pass_mark,
+    v_started_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.start_internal_exam_session(text) TO authenticated;

--- a/packages/db/migrations/071_start_internal_exam_session_qualify_columns.sql
+++ b/packages/db/migrations/071_start_internal_exam_session_qualify_columns.sql
@@ -1,0 +1,229 @@
+-- Migration 071: Qualify quiz_sessions columns in start_internal_exam_session
+-- CodeRabbit PR #576 round-2 + CI red-team failure.
+--
+-- Bug (PG 42702 "column reference \"time_limit_seconds\" is ambiguous"):
+-- The function RETURNS TABLE(... time_limit_seconds int, ..., started_at timestamptz)
+-- exposes those names as variables in the function body. The auto-complete SELECT
+-- in mig 070 lines 103-114 referenced them unqualified:
+--
+--   AND time_limit_seconds IS NOT NULL
+--   AND started_at IS NOT NULL
+--   AND now() > started_at + ((time_limit_seconds + 30) || ' seconds')::interval
+--
+-- Postgres cannot distinguish the RETURNS column from the quiz_sessions column
+-- and raises 42702. The bug was latent until the red-team spec exercised the
+-- "active session past its grace window" code path.
+--
+-- Fix: alias public.quiz_sessions AS qs and qualify every reference. Function
+-- body otherwise unchanged from mig 070.
+
+CREATE OR REPLACE FUNCTION public.start_internal_exam_session(p_code text)
+RETURNS TABLE(
+  session_id uuid,
+  question_ids uuid[],
+  time_limit_seconds int,
+  total_questions int,
+  pass_mark int,
+  started_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_code_id         uuid;
+  v_code_subject    uuid;
+  v_code_student    uuid;
+  v_code_org        uuid;
+  v_code_expires    timestamptz;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_old_session_id  uuid;
+  v_config_id       uuid;
+  v_total_questions int;
+  v_time_limit      int;
+  v_pass_mark       int;
+  v_dist            record;
+  v_selected_ids    uuid[] := '{}';
+  v_topic_ids       uuid[];
+  v_session_id      uuid;
+  v_started_at      timestamptz;
+  v_consumed_rows   int;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  SELECT iec.id, iec.subject_id, iec.student_id, iec.organization_id,
+         iec.expires_at, iec.consumed_at, iec.voided_at
+  INTO v_code_id, v_code_subject, v_code_student, v_code_org,
+       v_code_expires, v_code_consumed, v_code_voided
+  FROM public.internal_exam_codes iec
+  WHERE iec.code = p_code
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_student <> v_student_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+  IF v_code_consumed IS NOT NULL THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+  IF v_code_expires <= now() THEN
+    RAISE EXCEPTION 'code_expired';
+  END IF;
+
+  SELECT u.organization_id INTO v_org_id
+  FROM public.users u
+  WHERE u.id = v_student_id AND u.deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  IF v_code_org IS NULL OR v_code_org <> v_org_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+
+  -- Auto-complete any same-subject internal_exam past +30s grace.
+  -- All quiz_sessions columns aliased as qs.* — the function's RETURNS TABLE
+  -- exposes time_limit_seconds and started_at as bare names too, so any
+  -- unqualified reference here is ambiguous (PG 42702).
+  SELECT qs.id INTO v_old_session_id
+  FROM public.quiz_sessions qs
+  WHERE qs.student_id = v_student_id
+    AND qs.organization_id = v_org_id
+    AND qs.subject_id = v_code_subject
+    AND qs.mode = 'internal_exam'
+    AND qs.ended_at IS NULL
+    AND qs.deleted_at IS NULL
+    AND qs.time_limit_seconds IS NOT NULL
+    AND qs.started_at IS NOT NULL
+    AND now() > qs.started_at + ((qs.time_limit_seconds + 30) || ' seconds')::interval
+  LIMIT 1;
+  IF v_old_session_id IS NOT NULL THEN
+    PERFORM public.complete_overdue_exam_session(v_old_session_id);
+  END IF;
+
+  -- Pre-INSERT guard. Concurrency-safe source of truth is the partial unique
+  -- index on (student_id, organization_id, subject_id) WHERE mode='internal_exam'
+  -- AND ended_at IS NULL AND deleted_at IS NULL (mig 069) caught by the
+  -- EXCEPTION handler around the INSERT below.
+  IF EXISTS (
+    SELECT 1 FROM public.quiz_sessions qs
+    WHERE qs.student_id = v_student_id
+      AND qs.organization_id = v_org_id
+      AND qs.subject_id = v_code_subject
+      AND qs.mode = 'internal_exam'
+      AND qs.ended_at IS NULL
+      AND qs.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END IF;
+
+  SELECT ec.id, ec.total_questions, ec.time_limit_seconds, ec.pass_mark
+  INTO v_config_id, v_total_questions, v_time_limit, v_pass_mark
+  FROM public.exam_configs ec
+  WHERE ec.organization_id = v_org_id
+    AND ec.subject_id = v_code_subject
+    AND ec.enabled = true
+    AND ec.deleted_at IS NULL;
+  IF v_config_id IS NULL THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  FOR v_dist IN
+    SELECT ecd.topic_id, ecd.subtopic_id, ecd.question_count
+    FROM public.exam_config_distributions ecd
+    WHERE ecd.exam_config_id = v_config_id
+    ORDER BY ecd.topic_id, ecd.subtopic_id NULLS LAST
+  LOOP
+    v_topic_ids := ARRAY(
+      SELECT q.id
+      FROM public.questions q
+      WHERE q.subject_id = v_code_subject
+        AND q.topic_id = v_dist.topic_id
+        AND (v_dist.subtopic_id IS NULL OR q.subtopic_id = v_dist.subtopic_id)
+        AND q.status = 'active'
+        AND q.deleted_at IS NULL
+        AND q.organization_id = v_org_id
+        AND q.id != ALL(v_selected_ids)
+      ORDER BY random()
+      LIMIT v_dist.question_count
+    );
+    IF array_length(v_topic_ids, 1) IS NULL OR array_length(v_topic_ids, 1) < v_dist.question_count THEN
+      RAISE EXCEPTION 'insufficient_questions_for_exam';
+    END IF;
+    v_selected_ids := v_selected_ids || v_topic_ids;
+  END LOOP;
+
+  IF array_length(v_selected_ids, 1) IS NULL
+     OR array_length(v_selected_ids, 1) <> v_total_questions THEN
+    RAISE EXCEPTION 'insufficient_questions_for_exam';
+  END IF;
+
+  BEGIN
+    INSERT INTO public.quiz_sessions
+      (organization_id, student_id, mode, subject_id,
+       config, total_questions, time_limit_seconds)
+    VALUES (
+      v_org_id, v_student_id, 'internal_exam', v_code_subject,
+      jsonb_build_object(
+        'question_ids',   to_jsonb(v_selected_ids),
+        'exam_config_id', v_config_id,
+        'pass_mark',      v_pass_mark
+      ),
+      v_total_questions, v_time_limit
+    )
+    RETURNING id, quiz_sessions.started_at
+    INTO v_session_id, v_started_at;
+  EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END;
+
+  UPDATE public.internal_exam_codes
+  SET consumed_at = now(),
+      consumed_session_id = v_session_id
+  WHERE id = v_code_id
+    AND consumed_at IS NULL;
+  GET DIAGNOSTICS v_consumed_rows = ROW_COUNT;
+  IF v_consumed_rows = 0 THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_student_id AND u.deleted_at IS NULL),
+    'internal_exam.started',
+    'quiz_session',
+    v_session_id,
+    jsonb_build_object(
+      'code_id',         v_code_id,
+      'subject_id',      v_code_subject,
+      'total_questions', v_total_questions,
+      'pass_mark',       v_pass_mark
+    )
+  );
+
+  RETURN QUERY SELECT
+    v_session_id,
+    v_selected_ids,
+    v_time_limit,
+    v_total_questions,
+    v_pass_mark,
+    v_started_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.start_internal_exam_session(text) TO authenticated;

--- a/packages/db/migrations/072_void_internal_exam_code_org_scope_session.sql
+++ b/packages/db/migrations/072_void_internal_exam_code_org_scope_session.sql
@@ -1,0 +1,190 @@
+-- Migration 072: Org-scope the linked-session SELECT/UPDATE in
+-- void_internal_exam_code (defense-in-depth)
+-- CodeRabbit PR #576 round-2 finding (Major).
+--
+-- Background: mig 068 verifies the code's organization_id matches the admin's,
+-- then trusts the code row's consumed_session_id and locks/updates
+-- public.quiz_sessions BY id ONLY:
+--
+--   SELECT qs.ended_at, qs.total_questions, qs.config ...
+--   FROM public.quiz_sessions qs
+--   WHERE qs.id = v_code_session_id AND qs.deleted_at IS NULL FOR UPDATE;
+--   ...
+--   UPDATE public.quiz_sessions
+--   SET ended_at = now(), ...
+--   WHERE id = v_code_session_id;
+--
+-- This is a SECURITY DEFINER function bypassing RLS. If a future bug or
+-- admin-tooling regression ever stored a cross-org consumed_session_id on a
+-- code, this RPC would expire a foreign-org session. The code-org check
+-- (mig 068 lines 71-74) makes that path unreachable today, but session-row
+-- writes that depend on a single guarantee are exactly the kind of pattern that
+-- breaks silently when invariants drift. Add the explicit org filter.
+--
+-- Function body otherwise unchanged from mig 068.
+
+CREATE OR REPLACE FUNCTION public.void_internal_exam_code(
+  p_code_id uuid,
+  p_reason  text
+)
+RETURNS TABLE(code_id uuid, session_id uuid, session_ended boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id        uuid := auth.uid();
+  v_admin_org       uuid;
+  v_code_org        uuid;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_code_session_id uuid;
+  v_session_ended   timestamptz;
+  v_session_total   int;
+  v_session_config  jsonb;
+  v_pass_mark       int;
+  v_answered        int;
+  v_correct_count   int;
+  v_score           numeric(5,2);
+  v_session_done    boolean := false;
+  v_session_updated int;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  IF p_reason IS NULL OR btrim(p_reason) = '' THEN
+    RAISE EXCEPTION 'invalid_reason';
+  END IF;
+  IF length(p_reason) > 500 THEN
+    RAISE EXCEPTION 'invalid_reason';
+  END IF;
+
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  SELECT iec.organization_id, iec.consumed_at, iec.voided_at, iec.consumed_session_id
+  INTO v_code_org, v_code_consumed, v_code_voided, v_code_session_id
+  FROM public.internal_exam_codes iec
+  WHERE iec.id = p_code_id
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_org <> v_admin_org THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+
+  IF v_code_consumed IS NOT NULL AND v_code_session_id IS NOT NULL THEN
+    -- Defense-in-depth: scope both the SELECT and the UPDATE to the admin's
+    -- org. The code-org guard above (v_code_org = v_admin_org) makes a foreign
+    -- session unreachable today, but a SECURITY DEFINER write that depends on
+    -- a single upstream invariant is the wrong shape for cross-org safety.
+    SELECT qs.ended_at, qs.total_questions, qs.config
+    INTO v_session_ended, v_session_total, v_session_config
+    FROM public.quiz_sessions qs
+    WHERE qs.id = v_code_session_id
+      AND qs.organization_id = v_admin_org
+      AND qs.deleted_at IS NULL
+    FOR UPDATE;
+
+    IF FOUND AND v_session_ended IS NOT NULL THEN
+      RAISE EXCEPTION 'cannot_void_finished_attempt';
+    END IF;
+
+    IF FOUND AND v_session_ended IS NULL THEN
+      SELECT
+        count(*)::int,
+        count(*) FILTER (WHERE qsa.is_correct)::int
+      INTO v_answered, v_correct_count
+      FROM public.quiz_session_answers qsa
+      WHERE qsa.session_id = v_code_session_id;
+
+      v_score := CASE WHEN v_session_total > 0
+                      THEN round((v_correct_count::numeric / v_session_total) * 100, 2)
+                      ELSE 0 END;
+
+      v_pass_mark := (v_session_config->>'pass_mark')::int;
+
+      UPDATE public.quiz_sessions
+      SET ended_at         = now(),
+          correct_count    = v_correct_count,
+          score_percentage = v_score,
+          passed           = false
+      WHERE id = v_code_session_id
+        AND organization_id = v_admin_org
+        AND deleted_at IS NULL;
+      GET DIAGNOSTICS v_session_updated = ROW_COUNT;
+      IF v_session_updated = 0 THEN
+        -- A concurrent writer ended/deleted the session between SELECT and
+        -- UPDATE, or org guard rejected it. Fail loudly rather than silently
+        -- proceed to audit a write that didn't happen.
+        RAISE EXCEPTION 'session_state_changed';
+      END IF;
+
+      v_session_done := true;
+
+      INSERT INTO public.audit_events
+        (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+      VALUES (
+        v_admin_org,
+        v_admin_id,
+        (SELECT u.role FROM public.users u
+         WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+        'internal_exam.expired',
+        'quiz_session',
+        v_code_session_id,
+        jsonb_build_object(
+          'reason',           'admin_voided',
+          'score',            v_score,
+          'answered_count',   v_answered,
+          'correct_count',    v_correct_count,
+          'total_questions',  v_session_total,
+          'pass_mark',        v_pass_mark,
+          'passed',           false
+        )
+      );
+    END IF;
+  END IF;
+
+  UPDATE public.internal_exam_codes
+  SET voided_at   = now(),
+      voided_by   = v_admin_id,
+      void_reason = p_reason
+  WHERE id = p_code_id;
+
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_voided',
+    'internal_exam_code',
+    p_code_id,
+    jsonb_build_object(
+      'reason',       p_reason,
+      'was_consumed', (v_code_consumed IS NOT NULL),
+      'session_ended', v_session_done
+    )
+  );
+
+  RETURN QUERY SELECT p_code_id, v_code_session_id, v_session_done;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.void_internal_exam_code(uuid, text) TO authenticated;

--- a/supabase/migrations/20260429000001_is_admin_softdelete_filter.sql
+++ b/supabase/migrations/20260429000001_is_admin_softdelete_filter.sql
@@ -1,0 +1,20 @@
+-- Add `AND deleted_at IS NULL` to is_admin() helper.
+-- Originally defined in 031_admin_rls_easa_tables.sql lines 7-18 without the
+-- soft-delete filter, allowing soft-deleted admin rows to still pass admin
+-- gates. Body identical to mig 031 apart from the added filter.
+-- security.md rule 7 + rule 9 (SECURITY DEFINER must filter deleted_at).
+
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = auth.uid()
+      AND role = 'admin'
+      AND deleted_at IS NULL
+  );
+$$;

--- a/supabase/migrations/20260429000002_internal_exam_codes.sql
+++ b/supabase/migrations/20260429000002_internal_exam_codes.sql
@@ -1,0 +1,92 @@
+-- Internal Exam Mode — issuance code table.
+-- Admin issues a one-time short code; student redeems it to start an
+-- internal_exam quiz_session. Code is the audit-trail anchor between admin
+-- issuance and student attempt.
+--
+-- Writes go through SECURITY DEFINER RPCs (issue_internal_exam_code,
+-- start_internal_exam_session, void_internal_exam_code). RLS allows reads
+-- for the owning student (active codes only) and the admin org. UPDATE policy
+-- supports any future admin tooling that touches rows directly. No INSERT or
+-- DELETE policies — issuance and consumption are RPC-only.
+
+CREATE TABLE public.internal_exam_codes (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code                 text NOT NULL UNIQUE,
+  subject_id           uuid NOT NULL REFERENCES public.easa_subjects(id),
+  student_id           uuid NOT NULL REFERENCES public.users(id),
+  issued_by            uuid NOT NULL REFERENCES public.users(id),
+  issued_at            timestamptz NOT NULL DEFAULT now(),
+  expires_at           timestamptz NOT NULL,
+  consumed_at          timestamptz,
+  consumed_session_id  uuid REFERENCES public.quiz_sessions(id),
+  voided_at            timestamptz,
+  voided_by            uuid REFERENCES public.users(id),
+  void_reason          text,
+  organization_id      uuid NOT NULL REFERENCES public.organizations(id),
+  deleted_at           timestamptz,
+  CONSTRAINT consumed_pair_consistency
+    CHECK ((consumed_at IS NULL) = (consumed_session_id IS NULL)),
+  CONSTRAINT voided_pair_consistency
+    CHECK ((voided_at IS NULL) = (voided_by IS NULL))
+);
+
+CREATE INDEX idx_internal_exam_codes_active
+  ON public.internal_exam_codes (student_id, expires_at)
+  WHERE consumed_at IS NULL
+    AND voided_at IS NULL
+    AND deleted_at IS NULL;
+
+CREATE INDEX idx_internal_exam_codes_org
+  ON public.internal_exam_codes (organization_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.internal_exam_codes ENABLE ROW LEVEL SECURITY;
+
+-- Student reads their own active (un-consumed, un-voided, un-expired) codes.
+CREATE POLICY student_read_active_codes
+  ON public.internal_exam_codes
+  FOR SELECT
+  TO authenticated
+  USING (
+    student_id = auth.uid()
+    AND consumed_at IS NULL
+    AND voided_at IS NULL
+    AND expires_at > now()
+    AND deleted_at IS NULL
+  );
+
+-- Admin reads codes for their org.
+CREATE POLICY admin_read_org_codes
+  ON public.internal_exam_codes
+  FOR SELECT
+  TO authenticated
+  USING (
+    public.is_admin()
+    AND organization_id IN (
+      SELECT u.organization_id FROM public.users u
+      WHERE u.id = auth.uid() AND u.deleted_at IS NULL
+    )
+  );
+
+-- Admin direct UPDATE — supports tooling that may touch rows outside the
+-- canonical RPCs. Production writes go via SECURITY DEFINER RPCs.
+CREATE POLICY admin_update_org_codes
+  ON public.internal_exam_codes
+  FOR UPDATE
+  TO authenticated
+  USING (
+    public.is_admin()
+    AND organization_id IN (
+      SELECT u.organization_id FROM public.users u
+      WHERE u.id = auth.uid() AND u.deleted_at IS NULL
+    )
+  )
+  WITH CHECK (
+    public.is_admin()
+    AND organization_id IN (
+      SELECT u.organization_id FROM public.users u
+      WHERE u.id = auth.uid() AND u.deleted_at IS NULL
+    )
+  );
+
+GRANT SELECT, UPDATE ON public.internal_exam_codes TO authenticated;

--- a/supabase/migrations/20260429000003_extend_quiz_sessions_mode_check.sql
+++ b/supabase/migrations/20260429000003_extend_quiz_sessions_mode_check.sql
@@ -1,0 +1,23 @@
+-- Extend quiz_sessions.mode CHECK constraint to allow 'internal_exam'.
+-- The constraint name varies across environments (it was renamed at least
+-- once historically). Look it up by predicate text, drop it, and re-add a
+-- canonical-named replacement covering all four modes.
+
+DO $$
+DECLARE
+  v_constraint_name text;
+BEGIN
+  SELECT conname INTO v_constraint_name
+  FROM pg_constraint
+  WHERE conrelid = 'public.quiz_sessions'::regclass
+    AND contype = 'c'
+    AND pg_get_constraintdef(oid) ILIKE '%mode%mock_exam%';
+  IF v_constraint_name IS NULL THEN
+    RAISE EXCEPTION 'Could not locate mode CHECK constraint on quiz_sessions';
+  END IF;
+  EXECUTE format('ALTER TABLE public.quiz_sessions DROP CONSTRAINT %I', v_constraint_name);
+END $$;
+
+ALTER TABLE public.quiz_sessions
+  ADD CONSTRAINT quiz_sessions_mode_check
+  CHECK (mode IN ('smart_review', 'quick_quiz', 'mock_exam', 'internal_exam'));

--- a/supabase/migrations/20260429000004_issue_internal_exam_code_rpc.sql
+++ b/supabase/migrations/20260429000004_issue_internal_exam_code_rpc.sql
@@ -1,0 +1,127 @@
+-- issue_internal_exam_code(p_subject_id, p_student_id)
+-- Admin-only. Generates a single-use 8-char code, stores the row, audits the
+-- issuance, returns (code_id, code, expires_at).
+-- Charset excludes 0/O/I/1 to avoid mis-reads. Default expiry: 24h.
+-- security.md rules 7, 9, 10 — auth.uid() check, deleted_at filters on every
+-- SELECT (including the audit-row subqueries), generic error codes only.
+
+CREATE OR REPLACE FUNCTION public.issue_internal_exam_code(
+  p_subject_id uuid,
+  p_student_id uuid
+)
+RETURNS TABLE(code_id uuid, code text, expires_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id   uuid := auth.uid();
+  v_admin_org  uuid;
+  v_student_org uuid;
+  v_charset    text := 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  v_charset_len int  := length('ABCDEFGHJKLMNPQRSTUVWXYZ23456789');
+  v_code       text;
+  v_new_id     uuid;
+  v_new_expiry timestamptz;
+  v_attempt    int := 0;
+  v_inserted   boolean := false;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  -- Resolve admin's organization.
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id
+    AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  -- Verify student exists in same org with role='student'.
+  SELECT u.organization_id INTO v_student_org
+  FROM public.users u
+  WHERE u.id = p_student_id
+    AND u.role = 'student'
+    AND u.deleted_at IS NULL;
+  IF v_student_org IS NULL OR v_student_org <> v_admin_org THEN
+    RAISE EXCEPTION 'student_not_found';
+  END IF;
+
+  -- Verify subject exists and is not soft-deleted.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.easa_subjects s
+    WHERE s.id = p_subject_id
+      AND s.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'subject_not_found';
+  END IF;
+
+  -- Verify an enabled exam_config exists for (admin_org, subject).
+  IF NOT EXISTS (
+    SELECT 1 FROM public.exam_configs ec
+    WHERE ec.organization_id = v_admin_org
+      AND ec.subject_id = p_subject_id
+      AND ec.enabled = true
+      AND ec.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  v_new_expiry := now() + interval '24 hours';
+
+  -- Generate + insert with up-to-5 retry on unique-violation.
+  WHILE v_attempt < 5 AND NOT v_inserted LOOP
+    v_attempt := v_attempt + 1;
+    v_code := array_to_string(
+      ARRAY(
+        SELECT substr(v_charset, 1 + floor(random() * v_charset_len)::int, 1)
+        FROM generate_series(1, 8)
+      ),
+      ''
+    );
+    BEGIN
+      INSERT INTO public.internal_exam_codes
+        (code, subject_id, student_id, issued_by, expires_at, organization_id)
+      VALUES
+        (v_code, p_subject_id, p_student_id, v_admin_id, v_new_expiry, v_admin_org)
+      RETURNING id INTO v_new_id;
+      v_inserted := true;
+    EXCEPTION WHEN unique_violation THEN
+      -- Retry with a fresh code.
+      v_inserted := false;
+    END;
+  END LOOP;
+
+  IF NOT v_inserted THEN
+    RAISE EXCEPTION 'code_generation_failed';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_issued',
+    'internal_exam_code',
+    v_new_id,
+    jsonb_build_object(
+      'student_id', p_student_id,
+      'subject_id', p_subject_id,
+      'expires_at', v_new_expiry
+    )
+  );
+
+  RETURN QUERY SELECT v_new_id, v_code, v_new_expiry;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.issue_internal_exam_code(uuid, uuid) TO authenticated;

--- a/supabase/migrations/20260429000005_start_internal_exam_session_rpc.sql
+++ b/supabase/migrations/20260429000005_start_internal_exam_session_rpc.sql
@@ -1,0 +1,197 @@
+-- start_internal_exam_session(p_code)
+-- Student-facing. Redeems a single-use code, atomically creates an
+-- internal_exam quiz_session, marks the code consumed.
+-- Mirrors the question-sampling and overdue-cleanup algorithm of
+-- start_exam_session (mig 054). q.status = 'active' (codebase convention).
+-- security.md rules 7, 9, 10.
+
+CREATE OR REPLACE FUNCTION public.start_internal_exam_session(p_code text)
+RETURNS TABLE(
+  session_id uuid,
+  question_ids uuid[],
+  time_limit_seconds int,
+  total_questions int,
+  pass_mark int,
+  started_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_code_id         uuid;
+  v_code_subject    uuid;
+  v_code_student    uuid;
+  v_code_expires    timestamptz;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_old_session_id  uuid;
+  v_config_id       uuid;
+  v_total_questions int;
+  v_time_limit      int;
+  v_pass_mark       int;
+  v_dist            record;
+  v_selected_ids    uuid[] := '{}';
+  v_topic_ids       uuid[];
+  v_session_id      uuid;
+  v_started_at      timestamptz;
+  v_consumed_rows   int;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  -- Lock + validate the code.
+  SELECT iec.id, iec.subject_id, iec.student_id,
+         iec.expires_at, iec.consumed_at, iec.voided_at
+  INTO v_code_id, v_code_subject, v_code_student,
+       v_code_expires, v_code_consumed, v_code_voided
+  FROM public.internal_exam_codes iec
+  WHERE iec.code = p_code
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_student <> v_student_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+  IF v_code_consumed IS NOT NULL THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+  IF v_code_expires <= now() THEN
+    RAISE EXCEPTION 'code_expired';
+  END IF;
+
+  -- Resolve student's org.
+  SELECT u.organization_id INTO v_org_id
+  FROM public.users u
+  WHERE u.id = v_student_id AND u.deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  -- Auto-complete any same-subject internal_exam past +30s grace
+  -- (mirrors start_exam_session in mig 054).
+  SELECT id INTO v_old_session_id
+  FROM public.quiz_sessions
+  WHERE student_id = v_student_id
+    AND organization_id = v_org_id
+    AND subject_id = v_code_subject
+    AND mode = 'internal_exam'
+    AND ended_at IS NULL
+    AND deleted_at IS NULL
+    AND time_limit_seconds IS NOT NULL
+    AND started_at IS NOT NULL
+    AND now() > started_at + ((time_limit_seconds + 30) || ' seconds')::interval
+  LIMIT 1;
+  IF v_old_session_id IS NOT NULL THEN
+    PERFORM public.complete_overdue_exam_session(v_old_session_id);
+  END IF;
+
+  -- Fetch the exam config for this subject in the student's org.
+  SELECT ec.id, ec.total_questions, ec.time_limit_seconds, ec.pass_mark
+  INTO v_config_id, v_total_questions, v_time_limit, v_pass_mark
+  FROM public.exam_configs ec
+  WHERE ec.organization_id = v_org_id
+    AND ec.subject_id = v_code_subject
+    AND ec.enabled = true
+    AND ec.deleted_at IS NULL;
+  IF v_config_id IS NULL THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  -- Sample questions per distribution (matches mig 054 algorithm).
+  FOR v_dist IN
+    SELECT ecd.topic_id, ecd.subtopic_id, ecd.question_count
+    FROM public.exam_config_distributions ecd
+    WHERE ecd.exam_config_id = v_config_id
+    ORDER BY ecd.topic_id, ecd.subtopic_id NULLS LAST
+  LOOP
+    v_topic_ids := ARRAY(
+      SELECT q.id
+      FROM public.questions q
+      WHERE q.subject_id = v_code_subject
+        AND q.topic_id = v_dist.topic_id
+        AND (v_dist.subtopic_id IS NULL OR q.subtopic_id = v_dist.subtopic_id)
+        AND q.status = 'active'
+        AND q.deleted_at IS NULL
+        AND q.organization_id = v_org_id
+        AND q.id != ALL(v_selected_ids)
+      ORDER BY random()
+      LIMIT v_dist.question_count
+    );
+    IF array_length(v_topic_ids, 1) IS NULL OR array_length(v_topic_ids, 1) < v_dist.question_count THEN
+      RAISE EXCEPTION 'insufficient_questions_for_exam';
+    END IF;
+    v_selected_ids := v_selected_ids || v_topic_ids;
+  END LOOP;
+
+  IF array_length(v_selected_ids, 1) IS NULL
+     OR array_length(v_selected_ids, 1) <> v_total_questions THEN
+    RAISE EXCEPTION 'insufficient_questions_for_exam';
+  END IF;
+
+  -- Insert session.
+  INSERT INTO public.quiz_sessions
+    (organization_id, student_id, mode, subject_id,
+     config, total_questions, time_limit_seconds)
+  VALUES (
+    v_org_id, v_student_id, 'internal_exam', v_code_subject,
+    jsonb_build_object(
+      'question_ids',   to_jsonb(v_selected_ids),
+      'exam_config_id', v_config_id,
+      'pass_mark',      v_pass_mark
+    ),
+    v_total_questions, v_time_limit
+  )
+  RETURNING id, quiz_sessions.started_at
+  INTO v_session_id, v_started_at;
+
+  -- Mark code consumed (race-safe: requires consumed_at IS NULL).
+  UPDATE public.internal_exam_codes
+  SET consumed_at = now(),
+      consumed_session_id = v_session_id
+  WHERE id = v_code_id
+    AND consumed_at IS NULL;
+  GET DIAGNOSTICS v_consumed_rows = ROW_COUNT;
+  IF v_consumed_rows = 0 THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_student_id AND u.deleted_at IS NULL),
+    'internal_exam.started',
+    'quiz_session',
+    v_session_id,
+    jsonb_build_object(
+      'code_id',         v_code_id,
+      'subject_id',      v_code_subject,
+      'total_questions', v_total_questions,
+      'pass_mark',       v_pass_mark
+    )
+  );
+
+  RETURN QUERY SELECT
+    v_session_id,
+    v_selected_ids,
+    v_time_limit,
+    v_total_questions,
+    v_pass_mark,
+    v_started_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.start_internal_exam_session(text) TO authenticated;

--- a/supabase/migrations/20260429000006_void_internal_exam_code_rpc.sql
+++ b/supabase/migrations/20260429000006_void_internal_exam_code_rpc.sql
@@ -1,0 +1,160 @@
+-- void_internal_exam_code(p_code_id, p_reason)
+-- Admin-only. Voids an internal exam code. If the code was consumed and the
+-- linked session is still active, terminate the session with passed=false and
+-- a computed score (unanswered = wrong). Refuses if the linked session has
+-- already ended (do not retroactively change a finished attempt).
+-- security.md rules 7, 9, 10.
+
+CREATE OR REPLACE FUNCTION public.void_internal_exam_code(
+  p_code_id uuid,
+  p_reason  text
+)
+RETURNS TABLE(code_id uuid, session_id uuid, session_ended boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id        uuid := auth.uid();
+  v_admin_org       uuid;
+  v_code_org        uuid;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_code_session_id uuid;
+  v_session_ended   timestamptz;
+  v_session_total   int;
+  v_session_config  jsonb;
+  v_pass_mark       int;
+  v_answered        int;
+  v_correct_count   int;
+  v_score           numeric(5,2);
+  v_session_done    boolean := false;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  -- Resolve admin's org (deleted_at filter).
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  -- Lock the code row.
+  SELECT iec.organization_id, iec.consumed_at, iec.voided_at, iec.consumed_session_id
+  INTO v_code_org, v_code_consumed, v_code_voided, v_code_session_id
+  FROM public.internal_exam_codes iec
+  WHERE iec.id = p_code_id
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  -- Org-scope check: admin can only void codes in their own org.
+  IF v_code_org <> v_admin_org THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_voided IS NOT NULL THEN
+    -- Already voided — idempotent no-op for the void itself, but still surface.
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+
+  -- If the code was consumed, look at the linked session.
+  IF v_code_consumed IS NOT NULL AND v_code_session_id IS NOT NULL THEN
+    SELECT qs.ended_at, qs.total_questions, qs.config
+    INTO v_session_ended, v_session_total, v_session_config
+    FROM public.quiz_sessions qs
+    WHERE qs.id = v_code_session_id
+      AND qs.deleted_at IS NULL
+    FOR UPDATE;
+
+    IF FOUND AND v_session_ended IS NOT NULL THEN
+      -- Refuse to retroactively change a finished attempt.
+      RAISE EXCEPTION 'cannot_void_finished_attempt';
+    END IF;
+
+    IF FOUND AND v_session_ended IS NULL THEN
+      -- Compute the score from existing answers; unanswered = wrong.
+      SELECT
+        count(*)::int,
+        count(*) FILTER (WHERE qsa.is_correct)::int
+      INTO v_answered, v_correct_count
+      FROM public.quiz_session_answers qsa
+      WHERE qsa.session_id = v_code_session_id;
+
+      v_score := CASE WHEN v_session_total > 0
+                      THEN round((v_correct_count::numeric / v_session_total) * 100, 2)
+                      ELSE 0 END;
+
+      v_pass_mark := (v_session_config->>'pass_mark')::int;
+
+      UPDATE public.quiz_sessions
+      SET ended_at         = now(),
+          correct_count    = v_correct_count,
+          score_percentage = v_score,
+          passed           = false
+      WHERE id = v_code_session_id;
+
+      v_session_done := true;
+
+      -- Audit the session expiry (subquery filters deleted_at).
+      INSERT INTO public.audit_events
+        (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+      VALUES (
+        v_admin_org,
+        v_admin_id,
+        (SELECT u.role FROM public.users u
+         WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+        'internal_exam.expired',
+        'quiz_session',
+        v_code_session_id,
+        jsonb_build_object(
+          'reason',           'admin_voided',
+          'score_percentage', v_score,
+          'answered_count',   v_answered,
+          'correct_count',    v_correct_count,
+          'total_questions',  v_session_total,
+          'pass_mark',        v_pass_mark,
+          'passed',           false
+        )
+      );
+    END IF;
+  END IF;
+
+  -- Mark the code voided.
+  UPDATE public.internal_exam_codes
+  SET voided_at   = now(),
+      voided_by   = v_admin_id,
+      void_reason = p_reason
+  WHERE id = p_code_id;
+
+  -- Audit the void event.
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_voided',
+    'internal_exam_code',
+    p_code_id,
+    jsonb_build_object(
+      'reason',       p_reason,
+      'was_consumed', (v_code_consumed IS NOT NULL),
+      'session_ended', v_session_done
+    )
+  );
+
+  RETURN QUERY SELECT p_code_id, v_code_session_id, v_session_done;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.void_internal_exam_code(uuid, text) TO authenticated;

--- a/supabase/migrations/20260429000007_extend_batch_submit_for_internal_exam.sql
+++ b/supabase/migrations/20260429000007_extend_batch_submit_for_internal_exam.sql
@@ -1,0 +1,300 @@
+-- Extend batch_submit_quiz to handle 'internal_exam' alongside 'mock_exam'.
+-- Body forked from mig 056. Mode-branch widenings:
+--  - Score: correct/total for both exam modes; correct/answered for others.
+--  - Pass: pass-mark gates both; mock_exam also requires all answered.
+--  - Audit: mock_exam→'exam.completed', internal_exam→'internal_exam.completed',
+--    else 'quiz_session.batch_submitted'. Expiry mirrors with '.expired'.
+-- security.md rule 10: audit-row subqueries on users filter deleted_at.
+
+CREATE OR REPLACE FUNCTION batch_submit_quiz(
+  p_session_id uuid,
+  p_answers    jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_config          jsonb;
+  v_mode            text;
+  v_answer          jsonb;
+  v_correct_option  text;
+  v_is_correct      boolean;
+  v_expl_text       text;
+  v_expl_image_url  text;
+  v_question_id     uuid;
+  v_selected_option text;
+  v_response_time   int;
+  v_results         jsonb := '[]'::jsonb;
+  v_total           int;
+  v_answered        int;
+  v_correct_count   int;
+  v_score           numeric(5,2);
+  v_session_question_ids uuid[];
+  v_qid_text        text;
+  v_rt_text         text;
+  v_ended_at        timestamptz;
+  v_options         jsonb;
+  v_passed          boolean;
+  v_pass_mark       int;
+  v_time_limit      int;
+  v_started_at      timestamptz;
+  v_expired_event   text;
+  v_completed_event text;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT qs.organization_id, qs.total_questions, qs.config, qs.ended_at,
+         qs.correct_count, qs.score_percentage, qs.mode,
+         qs.time_limit_seconds, qs.started_at, qs.passed
+  INTO v_org_id, v_total, v_config, v_ended_at, v_correct_count, v_score, v_mode,
+       v_time_limit, v_started_at, v_passed
+  FROM quiz_sessions qs
+  WHERE qs.id = p_session_id
+    AND qs.student_id = v_student_id
+    AND qs.deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session not found or not accessible';
+  END IF;
+
+  IF v_ended_at IS NOT NULL THEN
+    SELECT count(*)::int INTO v_answered
+    FROM quiz_session_answers WHERE session_id = p_session_id;
+    SELECT jsonb_agg(jsonb_build_object(
+      'question_id', qsa.question_id,
+      'is_correct', qsa.is_correct,
+      'correct_option_id', (
+        SELECT opt->>'id' FROM jsonb_array_elements(q.options) opt
+        WHERE (opt->>'correct')::boolean LIMIT 1
+      ),
+      'explanation_text', q.explanation_text,
+      'explanation_image_url', q.explanation_image_url
+    ))
+    INTO v_results
+    FROM quiz_session_answers qsa
+    JOIN questions q ON q.id = qsa.question_id
+    WHERE qsa.session_id = p_session_id;
+
+    RETURN jsonb_build_object(
+      'results', COALESCE(v_results, '[]'::jsonb),
+      'total_questions', v_total,
+      'answered_count', v_answered,
+      'correct_count', v_correct_count,
+      'score_percentage', v_score,
+      'passed', v_passed
+    );
+  END IF;
+
+  -- Time-limit enforcement (30s grace, mirrors mig 056).
+  IF v_time_limit IS NOT NULL AND v_started_at IS NOT NULL THEN
+    IF now() > v_started_at + (v_time_limit + 30) * interval '1 second' THEN
+      UPDATE quiz_sessions
+      SET ended_at = now(), correct_count = 0, score_percentage = 0, passed = false
+      WHERE id = p_session_id;
+      v_expired_event := CASE v_mode
+                           WHEN 'internal_exam' THEN 'internal_exam.expired'
+                           ELSE 'exam.expired'
+                         END;
+      INSERT INTO audit_events
+        (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+      VALUES (
+        v_org_id, v_student_id,
+        (SELECT role FROM users WHERE id = v_student_id AND deleted_at IS NULL),
+        v_expired_event, 'quiz_session', p_session_id,
+        jsonb_build_object('total_questions', v_total, 'reason', 'submission past grace period')
+      );
+      RETURN jsonb_build_object(
+        'results', '[]'::jsonb,
+        'total_questions', v_total,
+        'answered_count', 0,
+        'correct_count', 0,
+        'score_percentage', 0,
+        'passed', false,
+        'expired', true
+      );
+    END IF;
+  END IF;
+
+  IF v_config IS NULL OR v_config->'question_ids' IS NULL OR jsonb_typeof(v_config->'question_ids') <> 'array' THEN
+    RAISE EXCEPTION 'session config is malformed — question_ids not set';
+  END IF;
+  v_session_question_ids := ARRAY(SELECT jsonb_array_elements_text(v_config->'question_ids'))::uuid[];
+
+  IF p_answers IS NULL
+     OR jsonb_typeof(p_answers) <> 'array'
+     OR jsonb_array_length(p_answers) = 0 THEN
+    RAISE EXCEPTION 'answers must be a non-empty JSON array';
+  END IF;
+
+  IF (
+    SELECT count(*) <> count(DISTINCT lower(e->>'question_id'))
+    FROM jsonb_array_elements(p_answers) AS e
+  ) THEN
+    RAISE EXCEPTION 'duplicate question_id in answers payload';
+  END IF;
+
+  -- See docs/database.md §3 "Scoring Soft-Deleted Questions".
+  DROP TABLE IF EXISTS _batch_questions;
+  CREATE TEMP TABLE _batch_questions ON COMMIT DROP AS
+  SELECT
+    q.id,
+    (SELECT opt->>'id' FROM jsonb_array_elements(q.options) opt
+     WHERE (opt->>'correct')::boolean LIMIT 1) AS correct_option,
+    q.explanation_text,
+    q.explanation_image_url,
+    q.options
+  FROM questions q
+  WHERE q.id = ANY(v_session_question_ids);
+
+  FOR v_answer IN SELECT * FROM jsonb_array_elements(p_answers)
+  LOOP
+    v_qid_text        := v_answer->>'question_id';
+    v_selected_option := v_answer->>'selected_option';
+    v_rt_text         := v_answer->>'response_time_ms';
+
+    IF v_qid_text IS NULL OR v_qid_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+      RAISE EXCEPTION 'invalid question_id format: %', coalesce(v_qid_text, 'NULL');
+    END IF;
+    IF v_selected_option IS NULL OR v_selected_option = '' THEN
+      RAISE EXCEPTION 'answer for question % has empty selected_option', v_qid_text;
+    END IF;
+    IF v_rt_text IS NULL OR v_rt_text !~ '^\d{1,9}$' THEN
+      RAISE EXCEPTION 'answer for question % has invalid response_time_ms', v_qid_text;
+    END IF;
+
+    v_question_id   := v_qid_text::uuid;
+    v_response_time := v_rt_text::int;
+
+    IF NOT (v_question_id = ANY(v_session_question_ids)) THEN
+      RAISE EXCEPTION 'question % does not belong to session %', v_question_id, p_session_id;
+    END IF;
+
+    SELECT bq.correct_option, bq.explanation_text, bq.explanation_image_url, bq.options
+    INTO v_correct_option, v_expl_text, v_expl_image_url, v_options
+    FROM _batch_questions bq
+    WHERE bq.id = v_question_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'question not found: %', v_question_id;
+    END IF;
+    IF v_correct_option IS NULL THEN
+      RAISE EXCEPTION 'question % has no correct option', v_question_id;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM jsonb_array_elements(v_options) opt
+      WHERE opt->>'id' = v_selected_option
+    ) THEN
+      RAISE EXCEPTION 'selected option % does not belong to question %', v_selected_option, v_question_id;
+    END IF;
+
+    v_is_correct := (v_selected_option = v_correct_option);
+
+    INSERT INTO quiz_session_answers
+      (session_id, question_id, selected_option_id, is_correct, response_time_ms)
+    VALUES
+      (p_session_id, v_question_id, v_selected_option, v_is_correct, v_response_time)
+    ON CONFLICT (session_id, question_id) DO NOTHING;
+
+    INSERT INTO student_responses
+      (organization_id, student_id, question_id, session_id,
+       selected_option_id, is_correct, response_time_ms)
+    VALUES
+      (v_org_id, v_student_id, v_question_id, p_session_id,
+       v_selected_option, v_is_correct, v_response_time)
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO fsrs_cards (student_id, question_id, last_was_correct, updated_at)
+    VALUES (v_student_id, v_question_id, v_is_correct, now())
+    ON CONFLICT (student_id, question_id)
+    DO UPDATE SET
+      last_was_correct = EXCLUDED.last_was_correct,
+      updated_at = now();
+
+    v_results := v_results || jsonb_build_object(
+      'question_id', v_question_id,
+      'is_correct', v_is_correct,
+      'correct_option_id', v_correct_option,
+      'explanation_text', v_expl_text,
+      'explanation_image_url', v_expl_image_url
+    );
+  END LOOP;
+
+  SELECT
+    count(*)::int,
+    count(*) FILTER (WHERE qsa.is_correct)::int
+  INTO v_answered, v_correct_count
+  FROM quiz_session_answers qsa
+  WHERE qsa.session_id = p_session_id;
+
+  -- Score: correct/total for both exam modes (unanswered = wrong);
+  -- correct/answered for non-exam modes.
+  IF v_mode IN ('mock_exam', 'internal_exam') THEN
+    v_score := CASE WHEN v_total > 0 THEN round((v_correct_count::numeric / v_total) * 100, 2) ELSE 0 END;
+  ELSE
+    v_score := CASE WHEN v_answered > 0 THEN round((v_correct_count::numeric / v_answered) * 100, 2) ELSE 0 END;
+  END IF;
+
+  -- Pass-mark gating for both exam modes. mock_exam additionally requires
+  -- all questions answered; internal_exam allows partial submissions.
+  IF v_mode IN ('mock_exam', 'internal_exam') THEN
+    v_pass_mark := (v_config->>'pass_mark')::int;
+    IF v_pass_mark IS NOT NULL THEN
+      v_passed := (v_score >= v_pass_mark);
+    ELSE
+      v_passed := false;
+    END IF;
+    IF v_mode = 'mock_exam' AND v_answered < v_total THEN
+      v_passed := false;
+    END IF;
+  END IF;
+
+  UPDATE quiz_sessions
+  SET
+    ended_at         = now(),
+    correct_count    = v_correct_count,
+    score_percentage = v_score,
+    passed           = v_passed
+  WHERE id = p_session_id;
+
+  v_completed_event := CASE v_mode
+                         WHEN 'mock_exam'     THEN 'exam.completed'
+                         WHEN 'internal_exam' THEN 'internal_exam.completed'
+                         ELSE 'quiz_session.batch_submitted'
+                       END;
+  INSERT INTO audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT role FROM users WHERE id = v_student_id AND deleted_at IS NULL),
+    v_completed_event,
+    'quiz_session',
+    p_session_id,
+    jsonb_build_object(
+      'total_questions', v_total,
+      'answered', v_answered,
+      'correct', v_correct_count,
+      'score', v_score,
+      'passed', v_passed
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'results', v_results,
+    'total_questions', v_total,
+    'answered_count', v_answered,
+    'correct_count', v_correct_count,
+    'score_percentage', v_score,
+    'passed', v_passed
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION batch_submit_quiz(uuid, jsonb) TO authenticated;

--- a/supabase/migrations/20260429000008_extend_overdue_for_internal_exam.sql
+++ b/supabase/migrations/20260429000008_extend_overdue_for_internal_exam.sql
@@ -1,0 +1,270 @@
+-- Extend Layer 1 overdue helpers to recognise 'internal_exam' alongside
+-- 'mock_exam'. Bodies forked from migs 052 (complete_overdue_exam_session)
+-- and 055 (complete_empty_exam_session). Mode guard widens to IN (...);
+-- audit event_type maps via CASE so internal_exam emits 'internal_exam.expired'
+-- / 'internal_exam.completed' while mock_exam keeps 'exam.expired' / 'exam.completed'.
+
+CREATE OR REPLACE FUNCTION complete_overdue_exam_session(p_session_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id     uuid := auth.uid();
+  v_org_id         uuid;
+  v_ended_at       timestamptz;
+  v_total          int;
+  v_mode           text;
+  v_started_at     timestamptz;
+  v_time_limit     int;
+  v_config         jsonb;
+  v_pass_mark      int;
+  v_answered       int;
+  v_correct_count  int;
+  v_score          numeric(5,2);
+  v_passed         boolean;
+  v_reason         text;
+  v_event_type     text;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT organization_id INTO v_org_id
+  FROM users
+  WHERE id = v_student_id AND deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  SELECT qs.ended_at, qs.total_questions, qs.mode,
+         qs.started_at, qs.time_limit_seconds, qs.config
+  INTO v_ended_at, v_total, v_mode, v_started_at, v_time_limit, v_config
+  FROM quiz_sessions qs
+  WHERE qs.id = p_session_id
+    AND qs.student_id = v_student_id
+    AND qs.organization_id = v_org_id
+    AND qs.deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session not found or not accessible';
+  END IF;
+  IF v_mode NOT IN ('mock_exam', 'internal_exam') THEN
+    RAISE EXCEPTION 'session is not an exam';
+  END IF;
+
+  IF v_ended_at IS NOT NULL THEN
+    SELECT qs.correct_count, qs.score_percentage, qs.passed,
+           (SELECT count(*)::int FROM quiz_session_answers WHERE session_id = p_session_id)
+    INTO v_correct_count, v_score, v_passed, v_answered
+    FROM quiz_sessions qs
+    WHERE qs.id = p_session_id
+      AND qs.student_id = v_student_id
+      AND qs.organization_id = v_org_id
+      AND qs.deleted_at IS NULL;
+    RETURN jsonb_build_object(
+      'session_id',       p_session_id,
+      'score_percentage', COALESCE(v_score, 0),
+      'passed',           COALESCE(v_passed, false),
+      'total_questions',  v_total,
+      'answered_count',   COALESCE(v_answered, 0)
+    );
+  END IF;
+
+  IF v_time_limit IS NULL OR v_started_at IS NULL THEN
+    RAISE EXCEPTION 'session has no deadline to enforce';
+  END IF;
+  IF now() <= v_started_at + ((v_time_limit + 30) || ' seconds')::interval THEN
+    RAISE EXCEPTION 'session is not overdue';
+  END IF;
+
+  SELECT
+    count(*)::int,
+    count(*) FILTER (WHERE qsa.is_correct)::int
+  INTO v_answered, v_correct_count
+  FROM quiz_session_answers qsa
+  WHERE qsa.session_id = p_session_id;
+
+  v_score := CASE WHEN v_total > 0
+                  THEN round((v_correct_count::numeric / v_total) * 100, 2)
+                  ELSE 0 END;
+
+  v_pass_mark := (v_config->>'pass_mark')::int;
+  v_passed := COALESCE(v_pass_mark IS NOT NULL AND v_score >= v_pass_mark, false);
+  -- mock_exam requires all answered; internal_exam allows partial submits.
+  IF v_mode = 'mock_exam' AND v_answered < v_total THEN
+    v_passed := false;
+  END IF;
+
+  UPDATE quiz_sessions
+  SET ended_at = now(),
+      correct_count = v_correct_count,
+      score_percentage = v_score,
+      passed = v_passed
+  WHERE id = p_session_id;
+
+  v_reason := CASE WHEN v_answered > 0
+                   THEN 'overdue_with_answers'
+                   ELSE 'overdue_zero_answers' END;
+
+  v_event_type := CASE v_mode
+                    WHEN 'internal_exam' THEN 'internal_exam.expired'
+                    ELSE 'exam.expired'
+                  END;
+
+  INSERT INTO audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id, v_student_id,
+    (SELECT role FROM users WHERE id = v_student_id AND deleted_at IS NULL),
+    v_event_type, 'quiz_session', p_session_id,
+    jsonb_build_object(
+      'total_questions', v_total,
+      'answered_count',  v_answered,
+      'correct_count',   v_correct_count,
+      'score',           v_score,
+      'passed',          v_passed,
+      'reason',          v_reason
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'session_id',       p_session_id,
+    'score_percentage', v_score,
+    'passed',           v_passed,
+    'total_questions',  v_total,
+    'answered_count',   v_answered
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION complete_overdue_exam_session(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION complete_empty_exam_session(p_session_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_ended_at        timestamptz;
+  v_total           int;
+  v_mode            text;
+  v_started_at      timestamptz;
+  v_time_limit      int;
+  v_correct_count   int;
+  v_score           numeric;
+  v_passed          boolean;
+  v_answered        int;
+  v_overdue         boolean;
+  v_event_type      text;
+  v_reason          text;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT organization_id INTO v_org_id
+  FROM users
+  WHERE id = v_student_id AND deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  SELECT qs.ended_at, qs.total_questions, qs.mode,
+         qs.started_at, qs.time_limit_seconds
+  INTO v_ended_at, v_total, v_mode, v_started_at, v_time_limit
+  FROM quiz_sessions qs
+  WHERE qs.id = p_session_id
+    AND qs.student_id = v_student_id
+    AND qs.organization_id = v_org_id
+    AND qs.deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session not found or not accessible';
+  END IF;
+  IF v_mode NOT IN ('mock_exam', 'internal_exam') THEN
+    RAISE EXCEPTION 'session is not an exam';
+  END IF;
+
+  IF v_ended_at IS NOT NULL THEN
+    SELECT qs.correct_count, qs.score_percentage, qs.passed,
+           (SELECT count(*)::int FROM quiz_session_answers WHERE session_id = p_session_id)
+    INTO v_correct_count, v_score, v_passed, v_answered
+    FROM quiz_sessions qs
+    WHERE qs.id = p_session_id
+      AND qs.student_id = v_student_id
+      AND qs.organization_id = v_org_id
+      AND qs.deleted_at IS NULL;
+    RETURN jsonb_build_object(
+      'session_id',       p_session_id,
+      'score_percentage', COALESCE(v_score, 0),
+      'passed',           COALESCE(v_passed, false),
+      'total_questions',  v_total,
+      'answered_count',   COALESCE(v_answered, 0)
+    );
+  END IF;
+
+  UPDATE quiz_sessions
+  SET
+    ended_at         = now(),
+    correct_count    = 0,
+    score_percentage = 0,
+    passed           = false
+  WHERE id = p_session_id;
+
+  -- 30s grace mirrors batch_submit_quiz / mig 052: a session within grace was
+  -- not "timed out" — the student was just early.
+  v_overdue := v_time_limit IS NOT NULL
+               AND v_started_at IS NOT NULL
+               AND now() > v_started_at + ((v_time_limit + 30) || ' seconds')::interval;
+
+  IF v_overdue THEN
+    v_event_type := CASE v_mode
+                      WHEN 'internal_exam' THEN 'internal_exam.expired'
+                      ELSE 'exam.expired'
+                    END;
+    v_reason := 'timed out with no answers';
+  ELSE
+    v_event_type := CASE v_mode
+                      WHEN 'internal_exam' THEN 'internal_exam.completed'
+                      ELSE 'exam.completed'
+                    END;
+    v_reason := 'completed with no answers';
+  END IF;
+
+  INSERT INTO audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT role FROM users WHERE id = v_student_id AND deleted_at IS NULL),
+    v_event_type,
+    'quiz_session',
+    p_session_id,
+    jsonb_build_object(
+      'total_questions', v_total,
+      'answered_count', 0,
+      'correct_count', 0,
+      'score', 0,
+      'passed', false,
+      'reason', v_reason
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'session_id',       p_session_id,
+    'score_percentage', 0,
+    'passed',           false,
+    'total_questions',  v_total,
+    'answered_count',   0
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION complete_empty_exam_session(uuid) TO authenticated;

--- a/supabase/migrations/20260429000009_internal_exam_codes_force_rls.sql
+++ b/supabase/migrations/20260429000009_internal_exam_codes_force_rls.sql
@@ -1,0 +1,6 @@
+-- Migration 064: Force RLS on internal_exam_codes
+-- Closes a defense-in-depth gap caught in semantic review of commit 10b27cc.
+-- Without FORCE, the table owner role bypasses policies during admin tooling,
+-- migration scripts, or service-role queries (see docs/security.md §3).
+
+ALTER TABLE public.internal_exam_codes FORCE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260429000010_start_internal_exam_session_active_guard.sql
+++ b/supabase/migrations/20260429000010_start_internal_exam_session_active_guard.sql
@@ -1,0 +1,215 @@
+-- Migration 065: Add duplicate-active-session guard to start_internal_exam_session
+-- Closes an ISSUE caught in semantic review of commit 10b27cc.
+-- Mirrors the guard added to start_exam_session in mig 054. Without it, a
+-- student holding two valid codes for the same subject within their 24h
+-- windows could redeem both and run two concurrent internal_exam sessions.
+-- The guard runs AFTER the overdue auto-complete (so a stale overdue session
+-- is cleaned up first and won't trigger the guard) but BEFORE the INSERT into
+-- quiz_sessions or the UPDATE of internal_exam_codes.
+-- security.md rules 7, 9, 10 (audit subquery keeps deleted_at IS NULL).
+
+CREATE OR REPLACE FUNCTION public.start_internal_exam_session(p_code text)
+RETURNS TABLE(
+  session_id uuid,
+  question_ids uuid[],
+  time_limit_seconds int,
+  total_questions int,
+  pass_mark int,
+  started_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_code_id         uuid;
+  v_code_subject    uuid;
+  v_code_student    uuid;
+  v_code_expires    timestamptz;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_old_session_id  uuid;
+  v_config_id       uuid;
+  v_total_questions int;
+  v_time_limit      int;
+  v_pass_mark       int;
+  v_dist            record;
+  v_selected_ids    uuid[] := '{}';
+  v_topic_ids       uuid[];
+  v_session_id      uuid;
+  v_started_at      timestamptz;
+  v_consumed_rows   int;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  -- Lock + validate the code.
+  SELECT iec.id, iec.subject_id, iec.student_id,
+         iec.expires_at, iec.consumed_at, iec.voided_at
+  INTO v_code_id, v_code_subject, v_code_student,
+       v_code_expires, v_code_consumed, v_code_voided
+  FROM public.internal_exam_codes iec
+  WHERE iec.code = p_code
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_student <> v_student_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+  IF v_code_consumed IS NOT NULL THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+  IF v_code_expires <= now() THEN
+    RAISE EXCEPTION 'code_expired';
+  END IF;
+
+  -- Resolve student's org.
+  SELECT u.organization_id INTO v_org_id
+  FROM public.users u
+  WHERE u.id = v_student_id AND u.deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  -- Auto-complete any same-subject internal_exam past +30s grace
+  -- (mirrors start_exam_session in mig 054).
+  SELECT id INTO v_old_session_id
+  FROM public.quiz_sessions
+  WHERE student_id = v_student_id
+    AND organization_id = v_org_id
+    AND subject_id = v_code_subject
+    AND mode = 'internal_exam'
+    AND ended_at IS NULL
+    AND deleted_at IS NULL
+    AND time_limit_seconds IS NOT NULL
+    AND started_at IS NOT NULL
+    AND now() > started_at + ((time_limit_seconds + 30) || ' seconds')::interval
+  LIMIT 1;
+  IF v_old_session_id IS NOT NULL THEN
+    PERFORM public.complete_overdue_exam_session(v_old_session_id);
+  END IF;
+
+  -- Guard against starting a second active session for the same subject (parity
+  -- with start_exam_session, mig 054). This protects against a student
+  -- redeeming two valid codes for the same subject within their 24h windows.
+  IF EXISTS (
+    SELECT 1 FROM public.quiz_sessions
+    WHERE student_id = v_student_id
+      AND organization_id = v_org_id
+      AND subject_id = v_code_subject
+      AND mode = 'internal_exam'
+      AND ended_at IS NULL
+      AND deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END IF;
+
+  -- Fetch the exam config for this subject in the student's org.
+  SELECT ec.id, ec.total_questions, ec.time_limit_seconds, ec.pass_mark
+  INTO v_config_id, v_total_questions, v_time_limit, v_pass_mark
+  FROM public.exam_configs ec
+  WHERE ec.organization_id = v_org_id
+    AND ec.subject_id = v_code_subject
+    AND ec.enabled = true
+    AND ec.deleted_at IS NULL;
+  IF v_config_id IS NULL THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  -- Sample questions per distribution (matches mig 054 algorithm).
+  FOR v_dist IN
+    SELECT ecd.topic_id, ecd.subtopic_id, ecd.question_count
+    FROM public.exam_config_distributions ecd
+    WHERE ecd.exam_config_id = v_config_id
+    ORDER BY ecd.topic_id, ecd.subtopic_id NULLS LAST
+  LOOP
+    v_topic_ids := ARRAY(
+      SELECT q.id
+      FROM public.questions q
+      WHERE q.subject_id = v_code_subject
+        AND q.topic_id = v_dist.topic_id
+        AND (v_dist.subtopic_id IS NULL OR q.subtopic_id = v_dist.subtopic_id)
+        AND q.status = 'active'
+        AND q.deleted_at IS NULL
+        AND q.organization_id = v_org_id
+        AND q.id != ALL(v_selected_ids)
+      ORDER BY random()
+      LIMIT v_dist.question_count
+    );
+    IF array_length(v_topic_ids, 1) IS NULL OR array_length(v_topic_ids, 1) < v_dist.question_count THEN
+      RAISE EXCEPTION 'insufficient_questions_for_exam';
+    END IF;
+    v_selected_ids := v_selected_ids || v_topic_ids;
+  END LOOP;
+
+  IF array_length(v_selected_ids, 1) IS NULL
+     OR array_length(v_selected_ids, 1) <> v_total_questions THEN
+    RAISE EXCEPTION 'insufficient_questions_for_exam';
+  END IF;
+
+  -- Insert session.
+  INSERT INTO public.quiz_sessions
+    (organization_id, student_id, mode, subject_id,
+     config, total_questions, time_limit_seconds)
+  VALUES (
+    v_org_id, v_student_id, 'internal_exam', v_code_subject,
+    jsonb_build_object(
+      'question_ids',   to_jsonb(v_selected_ids),
+      'exam_config_id', v_config_id,
+      'pass_mark',      v_pass_mark
+    ),
+    v_total_questions, v_time_limit
+  )
+  RETURNING id, quiz_sessions.started_at
+  INTO v_session_id, v_started_at;
+
+  -- Mark code consumed (race-safe: requires consumed_at IS NULL).
+  UPDATE public.internal_exam_codes
+  SET consumed_at = now(),
+      consumed_session_id = v_session_id
+  WHERE id = v_code_id
+    AND consumed_at IS NULL;
+  GET DIAGNOSTICS v_consumed_rows = ROW_COUNT;
+  IF v_consumed_rows = 0 THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_student_id AND u.deleted_at IS NULL),
+    'internal_exam.started',
+    'quiz_session',
+    v_session_id,
+    jsonb_build_object(
+      'code_id',         v_code_id,
+      'subject_id',      v_code_subject,
+      'total_questions', v_total_questions,
+      'pass_mark',       v_pass_mark
+    )
+  );
+
+  RETURN QUERY SELECT
+    v_session_id,
+    v_selected_ids,
+    v_time_limit,
+    v_total_questions,
+    v_pass_mark,
+    v_started_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.start_internal_exam_session(text) TO authenticated;

--- a/supabase/migrations/20260429000011_get_session_reports_exclude_internal_exam.sql
+++ b/supabase/migrations/20260429000011_get_session_reports_exclude_internal_exam.sql
@@ -1,0 +1,79 @@
+-- Migration 066: get_session_reports excludes internal_exam at the SQL level.
+-- Without this, count(*) OVER() includes internal_exam rows in total_count even
+-- though the TypeScript filter in lib/queries/reports.ts excludes them from the
+-- returned rows, causing pagination drift on mixed-mode student histories.
+
+CREATE OR REPLACE FUNCTION public.get_session_reports(
+  p_sort  TEXT DEFAULT 'started_at',
+  p_dir   TEXT DEFAULT 'desc',
+  p_limit INT DEFAULT 10,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id               UUID,
+  mode             TEXT,
+  total_questions  INT,
+  correct_count    INT,
+  score_percentage NUMERIC,
+  started_at       TIMESTAMPTZ,
+  ended_at         TIMESTAMPTZ,
+  subject_id       UUID,
+  subject_name     TEXT,
+  answered_count   BIGINT,
+  total_count      BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid UUID;
+  v_sort TEXT;
+  v_dir  TEXT;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  CASE p_sort
+    WHEN 'started_at'       THEN v_sort := 'qs.started_at';
+    WHEN 'score_percentage'  THEN v_sort := 'qs.score_percentage';
+    WHEN 'subject_name'      THEN v_sort := 'es.name';
+    ELSE v_sort := 'qs.started_at';
+  END CASE;
+
+  IF lower(p_dir) = 'asc' THEN
+    v_dir := 'ASC';
+  ELSE
+    v_dir := 'DESC';
+  END IF;
+
+  RETURN QUERY EXECUTE format(
+    'SELECT
+       qs.id,
+       qs.mode::TEXT,
+       qs.total_questions,
+       qs.correct_count,
+       qs.score_percentage,
+       qs.started_at,
+       qs.ended_at,
+       qs.subject_id,
+       es.name AS subject_name,
+       (SELECT count(*) FROM quiz_session_answers qsa WHERE qsa.session_id = qs.id) AS answered_count,
+       count(*) OVER() AS total_count
+     FROM quiz_sessions qs
+     LEFT JOIN easa_subjects es ON es.id = qs.subject_id
+     WHERE qs.student_id = $1
+       AND qs.ended_at IS NOT NULL
+       AND qs.deleted_at IS NULL
+       AND qs.mode <> ''internal_exam''
+     ORDER BY %s %s NULLS LAST, qs.id ASC
+     LIMIT $2 OFFSET $3',
+    v_sort, v_dir
+  )
+  USING v_uid, p_limit, p_offset;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_session_reports(TEXT, TEXT, INT, INT) TO authenticated;

--- a/supabase/migrations/20260430000001_issue_internal_exam_code_drop_subject_softdelete.sql
+++ b/supabase/migrations/20260430000001_issue_internal_exam_code_drop_subject_softdelete.sql
@@ -1,0 +1,130 @@
+-- Migration 067: Drop non-existent easa_subjects.deleted_at filter
+-- CodeRabbit PR #576 finding #30 (CRITICAL).
+-- mig 059 line 60 references `s.deleted_at IS NULL` on `public.easa_subjects`,
+-- but that table has no `deleted_at` column. The RPC throws
+-- `column "deleted_at" does not exist` at runtime, breaking every code-issuance
+-- attempt. Forward fix: re-CREATE OR REPLACE with the predicate removed.
+-- All other filters (org match, role check on student, exam_config check,
+-- code-generation loop, audit insert) preserved verbatim.
+-- security.md rules 7, 9, 10 — auth.uid() check, deleted_at filters on every
+-- SELECT (including the audit-row subqueries), generic error codes only.
+
+CREATE OR REPLACE FUNCTION public.issue_internal_exam_code(
+  p_subject_id uuid,
+  p_student_id uuid
+)
+RETURNS TABLE(code_id uuid, code text, expires_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id   uuid := auth.uid();
+  v_admin_org  uuid;
+  v_student_org uuid;
+  v_charset    text := 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  v_charset_len int  := length('ABCDEFGHJKLMNPQRSTUVWXYZ23456789');
+  v_code       text;
+  v_new_id     uuid;
+  v_new_expiry timestamptz;
+  v_attempt    int := 0;
+  v_inserted   boolean := false;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  -- Resolve admin's organization.
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id
+    AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  -- Verify student exists in same org with role='student'.
+  SELECT u.organization_id INTO v_student_org
+  FROM public.users u
+  WHERE u.id = p_student_id
+    AND u.role = 'student'
+    AND u.deleted_at IS NULL;
+  IF v_student_org IS NULL OR v_student_org <> v_admin_org THEN
+    RAISE EXCEPTION 'student_not_found';
+  END IF;
+
+  -- Verify subject exists. easa_subjects has no deleted_at column.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.easa_subjects s
+    WHERE s.id = p_subject_id
+  ) THEN
+    RAISE EXCEPTION 'subject_not_found';
+  END IF;
+
+  -- Verify an enabled exam_config exists for (admin_org, subject).
+  IF NOT EXISTS (
+    SELECT 1 FROM public.exam_configs ec
+    WHERE ec.organization_id = v_admin_org
+      AND ec.subject_id = p_subject_id
+      AND ec.enabled = true
+      AND ec.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  v_new_expiry := now() + interval '24 hours';
+
+  -- Generate + insert with up-to-5 retry on unique-violation.
+  WHILE v_attempt < 5 AND NOT v_inserted LOOP
+    v_attempt := v_attempt + 1;
+    v_code := array_to_string(
+      ARRAY(
+        SELECT substr(v_charset, 1 + floor(random() * v_charset_len)::int, 1)
+        FROM generate_series(1, 8)
+      ),
+      ''
+    );
+    BEGIN
+      INSERT INTO public.internal_exam_codes
+        (code, subject_id, student_id, issued_by, expires_at, organization_id)
+      VALUES
+        (v_code, p_subject_id, p_student_id, v_admin_id, v_new_expiry, v_admin_org)
+      RETURNING id INTO v_new_id;
+      v_inserted := true;
+    EXCEPTION WHEN unique_violation THEN
+      -- Retry with a fresh code.
+      v_inserted := false;
+    END;
+  END LOOP;
+
+  IF NOT v_inserted THEN
+    RAISE EXCEPTION 'code_generation_failed';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_issued',
+    'internal_exam_code',
+    v_new_id,
+    jsonb_build_object(
+      'student_id', p_student_id,
+      'subject_id', p_subject_id,
+      'expires_at', v_new_expiry
+    )
+  );
+
+  RETURN QUERY SELECT v_new_id, v_code, v_new_expiry;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.issue_internal_exam_code(uuid, uuid) TO authenticated;

--- a/supabase/migrations/20260430000002_void_internal_exam_code_validate_reason.sql
+++ b/supabase/migrations/20260430000002_void_internal_exam_code_validate_reason.sql
@@ -1,0 +1,173 @@
+-- Migration 068: Validate p_reason in DB + align audit metadata key
+-- CodeRabbit PR #576 findings #31 (validation) + #32 (audit-key naming).
+-- Issue #31: Reason length/non-empty validation lives only in the JS Zod
+-- schema, so direct RPC callers (red-team specs, future tooling, psql) bypass
+-- it and can store empty/oversized reasons. Add server-side validation:
+-- non-null, non-blank after btrim, length <= 500.
+-- Issue #32: The 'internal_exam.expired' audit row uses jsonb key
+-- `score_percentage`, but the canonical key across other audit events is
+-- `score`. Rename for consistency. Other audit events untouched.
+-- security.md rules 7, 9, 10.
+
+CREATE OR REPLACE FUNCTION public.void_internal_exam_code(
+  p_code_id uuid,
+  p_reason  text
+)
+RETURNS TABLE(code_id uuid, session_id uuid, session_ended boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id        uuid := auth.uid();
+  v_admin_org       uuid;
+  v_code_org        uuid;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_code_session_id uuid;
+  v_session_ended   timestamptz;
+  v_session_total   int;
+  v_session_config  jsonb;
+  v_pass_mark       int;
+  v_answered        int;
+  v_correct_count   int;
+  v_score           numeric(5,2);
+  v_session_done    boolean := false;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  -- Server-side reason validation (parity with Zod schema in JS layer).
+  IF p_reason IS NULL OR btrim(p_reason) = '' THEN
+    RAISE EXCEPTION 'invalid_reason';
+  END IF;
+  IF length(p_reason) > 500 THEN
+    RAISE EXCEPTION 'invalid_reason';
+  END IF;
+
+  -- Resolve admin's org (deleted_at filter).
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  -- Lock the code row.
+  SELECT iec.organization_id, iec.consumed_at, iec.voided_at, iec.consumed_session_id
+  INTO v_code_org, v_code_consumed, v_code_voided, v_code_session_id
+  FROM public.internal_exam_codes iec
+  WHERE iec.id = p_code_id
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  -- Org-scope check: admin can only void codes in their own org.
+  IF v_code_org <> v_admin_org THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_voided IS NOT NULL THEN
+    -- Already voided — idempotent no-op for the void itself, but still surface.
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+
+  -- If the code was consumed, look at the linked session.
+  IF v_code_consumed IS NOT NULL AND v_code_session_id IS NOT NULL THEN
+    SELECT qs.ended_at, qs.total_questions, qs.config
+    INTO v_session_ended, v_session_total, v_session_config
+    FROM public.quiz_sessions qs
+    WHERE qs.id = v_code_session_id
+      AND qs.deleted_at IS NULL
+    FOR UPDATE;
+
+    IF FOUND AND v_session_ended IS NOT NULL THEN
+      -- Refuse to retroactively change a finished attempt.
+      RAISE EXCEPTION 'cannot_void_finished_attempt';
+    END IF;
+
+    IF FOUND AND v_session_ended IS NULL THEN
+      -- Compute the score from existing answers; unanswered = wrong.
+      SELECT
+        count(*)::int,
+        count(*) FILTER (WHERE qsa.is_correct)::int
+      INTO v_answered, v_correct_count
+      FROM public.quiz_session_answers qsa
+      WHERE qsa.session_id = v_code_session_id;
+
+      v_score := CASE WHEN v_session_total > 0
+                      THEN round((v_correct_count::numeric / v_session_total) * 100, 2)
+                      ELSE 0 END;
+
+      v_pass_mark := (v_session_config->>'pass_mark')::int;
+
+      UPDATE public.quiz_sessions
+      SET ended_at         = now(),
+          correct_count    = v_correct_count,
+          score_percentage = v_score,
+          passed           = false
+      WHERE id = v_code_session_id;
+
+      v_session_done := true;
+
+      -- Audit the session expiry (subquery filters deleted_at).
+      -- Canonical audit key is `score` (matches other audit events).
+      INSERT INTO public.audit_events
+        (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+      VALUES (
+        v_admin_org,
+        v_admin_id,
+        (SELECT u.role FROM public.users u
+         WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+        'internal_exam.expired',
+        'quiz_session',
+        v_code_session_id,
+        jsonb_build_object(
+          'reason',           'admin_voided',
+          'score',            v_score,
+          'answered_count',   v_answered,
+          'correct_count',    v_correct_count,
+          'total_questions',  v_session_total,
+          'pass_mark',        v_pass_mark,
+          'passed',           false
+        )
+      );
+    END IF;
+  END IF;
+
+  -- Mark the code voided.
+  UPDATE public.internal_exam_codes
+  SET voided_at   = now(),
+      voided_by   = v_admin_id,
+      void_reason = p_reason
+  WHERE id = p_code_id;
+
+  -- Audit the void event.
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_voided',
+    'internal_exam_code',
+    p_code_id,
+    jsonb_build_object(
+      'reason',       p_reason,
+      'was_consumed', (v_code_consumed IS NOT NULL),
+      'session_ended', v_session_done
+    )
+  );
+
+  RETURN QUERY SELECT p_code_id, v_code_session_id, v_session_done;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.void_internal_exam_code(uuid, text) TO authenticated;

--- a/supabase/migrations/20260430000003_internal_exam_session_active_unique.sql
+++ b/supabase/migrations/20260430000003_internal_exam_session_active_unique.sql
@@ -1,0 +1,16 @@
+-- Migration 069: Schema-level guard against concurrent active internal_exam sessions
+-- CodeRabbit PR #576 finding #33 (CRITICAL — race condition).
+-- The EXISTS guard in start_internal_exam_session (mig 065 lines 104-114) is
+-- racy: two concurrent transactions with two different codes for the same
+-- (student, subject) can both observe no active session, both INSERT into
+-- quiz_sessions, and both succeed — producing two simultaneous active
+-- internal_exam sessions for one student.
+-- Fix: a partial unique index that enforces the invariant at the schema level.
+-- This is concurrency-safe because PG serialises unique-index check + insert.
+-- The companion function-body update (with EXCEPTION WHEN unique_violation)
+-- ships in migration 070, which also fixes the missing org check (#36).
+-- This migration ships only the index — it does NOT modify the function.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_internal_exam_session_active
+ON public.quiz_sessions (student_id, organization_id, subject_id)
+WHERE mode = 'internal_exam' AND ended_at IS NULL AND deleted_at IS NULL;

--- a/supabase/migrations/20260430000004_start_internal_exam_session_org_check.sql
+++ b/supabase/migrations/20260430000004_start_internal_exam_session_org_check.sql
@@ -1,0 +1,240 @@
+-- Migration 070: Org-scope check + race-safe INSERT on start_internal_exam_session
+-- CodeRabbit PR #576 finding #36 (CRITICAL — missing org check) +
+-- function-body half of finding #33 (race condition; the index ships in 069).
+--
+-- Issue #36: The SELECT from internal_exam_codes (mig 065 lines 50-57) loaded
+--   id, subject_id, student_id, expires_at, consumed_at, voided_at
+-- but NOT organization_id. The code's org is never compared to the resolving
+-- student's org, so a code for a student moved cross-org (or any future
+-- corruption that drifts iec.organization_id from u.organization_id) would
+-- silently start a session in the wrong org.
+-- Fix: SELECT iec.organization_id INTO v_code_org and verify v_code_org = v_org_id
+-- after the student's org is resolved. Use the unified `code_not_yours` error
+-- to avoid leaking cross-org existence.
+--
+-- Issue #33 (function-body): wrap the INSERT INTO quiz_sessions in
+-- EXCEPTION WHEN unique_violation -> 'active_session_exists'. The pre-INSERT
+-- EXISTS guard is kept (cheap, gives clean error in normal flow), but the
+-- catch-handler is now the source of truth for the invariant — it is the only
+-- one that is concurrency-safe (relies on the partial unique index from 069).
+-- security.md rules 7, 9, 10 (audit subquery keeps deleted_at IS NULL).
+
+CREATE OR REPLACE FUNCTION public.start_internal_exam_session(p_code text)
+RETURNS TABLE(
+  session_id uuid,
+  question_ids uuid[],
+  time_limit_seconds int,
+  total_questions int,
+  pass_mark int,
+  started_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_code_id         uuid;
+  v_code_subject    uuid;
+  v_code_student    uuid;
+  v_code_org        uuid;
+  v_code_expires    timestamptz;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_old_session_id  uuid;
+  v_config_id       uuid;
+  v_total_questions int;
+  v_time_limit      int;
+  v_pass_mark       int;
+  v_dist            record;
+  v_selected_ids    uuid[] := '{}';
+  v_topic_ids       uuid[];
+  v_session_id      uuid;
+  v_started_at      timestamptz;
+  v_consumed_rows   int;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  -- Lock + validate the code (now also reads organization_id for cross-org check).
+  SELECT iec.id, iec.subject_id, iec.student_id, iec.organization_id,
+         iec.expires_at, iec.consumed_at, iec.voided_at
+  INTO v_code_id, v_code_subject, v_code_student, v_code_org,
+       v_code_expires, v_code_consumed, v_code_voided
+  FROM public.internal_exam_codes iec
+  WHERE iec.code = p_code
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_student <> v_student_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+  IF v_code_consumed IS NOT NULL THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+  IF v_code_expires <= now() THEN
+    RAISE EXCEPTION 'code_expired';
+  END IF;
+
+  -- Resolve student's org.
+  SELECT u.organization_id INTO v_org_id
+  FROM public.users u
+  WHERE u.id = v_student_id AND u.deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  -- Cross-org check: the code's org must match the resolving student's org.
+  -- Unified error message — never reveal cross-org existence.
+  IF v_code_org IS NULL OR v_code_org <> v_org_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+
+  -- Auto-complete any same-subject internal_exam past +30s grace
+  -- (mirrors start_exam_session in mig 054).
+  SELECT id INTO v_old_session_id
+  FROM public.quiz_sessions
+  WHERE student_id = v_student_id
+    AND organization_id = v_org_id
+    AND subject_id = v_code_subject
+    AND mode = 'internal_exam'
+    AND ended_at IS NULL
+    AND deleted_at IS NULL
+    AND time_limit_seconds IS NOT NULL
+    AND started_at IS NOT NULL
+    AND now() > started_at + ((time_limit_seconds + 30) || ' seconds')::interval
+  LIMIT 1;
+  IF v_old_session_id IS NOT NULL THEN
+    PERFORM public.complete_overdue_exam_session(v_old_session_id);
+  END IF;
+
+  -- Pre-INSERT guard: cheap fast path that yields a clean error in normal flow.
+  -- The schema-level partial unique index (mig 069) is the concurrency-safe
+  -- source of truth — see the EXCEPTION handler around the INSERT below.
+  IF EXISTS (
+    SELECT 1 FROM public.quiz_sessions
+    WHERE student_id = v_student_id
+      AND organization_id = v_org_id
+      AND subject_id = v_code_subject
+      AND mode = 'internal_exam'
+      AND ended_at IS NULL
+      AND deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END IF;
+
+  -- Fetch the exam config for this subject in the student's org.
+  SELECT ec.id, ec.total_questions, ec.time_limit_seconds, ec.pass_mark
+  INTO v_config_id, v_total_questions, v_time_limit, v_pass_mark
+  FROM public.exam_configs ec
+  WHERE ec.organization_id = v_org_id
+    AND ec.subject_id = v_code_subject
+    AND ec.enabled = true
+    AND ec.deleted_at IS NULL;
+  IF v_config_id IS NULL THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  -- Sample questions per distribution (matches mig 054 algorithm).
+  FOR v_dist IN
+    SELECT ecd.topic_id, ecd.subtopic_id, ecd.question_count
+    FROM public.exam_config_distributions ecd
+    WHERE ecd.exam_config_id = v_config_id
+    ORDER BY ecd.topic_id, ecd.subtopic_id NULLS LAST
+  LOOP
+    v_topic_ids := ARRAY(
+      SELECT q.id
+      FROM public.questions q
+      WHERE q.subject_id = v_code_subject
+        AND q.topic_id = v_dist.topic_id
+        AND (v_dist.subtopic_id IS NULL OR q.subtopic_id = v_dist.subtopic_id)
+        AND q.status = 'active'
+        AND q.deleted_at IS NULL
+        AND q.organization_id = v_org_id
+        AND q.id != ALL(v_selected_ids)
+      ORDER BY random()
+      LIMIT v_dist.question_count
+    );
+    IF array_length(v_topic_ids, 1) IS NULL OR array_length(v_topic_ids, 1) < v_dist.question_count THEN
+      RAISE EXCEPTION 'insufficient_questions_for_exam';
+    END IF;
+    v_selected_ids := v_selected_ids || v_topic_ids;
+  END LOOP;
+
+  IF array_length(v_selected_ids, 1) IS NULL
+     OR array_length(v_selected_ids, 1) <> v_total_questions THEN
+    RAISE EXCEPTION 'insufficient_questions_for_exam';
+  END IF;
+
+  -- Insert session. Race-safe: the partial unique index on
+  -- (student_id, organization_id, subject_id) WHERE mode='internal_exam'
+  -- AND ended_at IS NULL AND deleted_at IS NULL (mig 069) catches concurrent
+  -- INSERTs that both passed the EXISTS guard above.
+  BEGIN
+    INSERT INTO public.quiz_sessions
+      (organization_id, student_id, mode, subject_id,
+       config, total_questions, time_limit_seconds)
+    VALUES (
+      v_org_id, v_student_id, 'internal_exam', v_code_subject,
+      jsonb_build_object(
+        'question_ids',   to_jsonb(v_selected_ids),
+        'exam_config_id', v_config_id,
+        'pass_mark',      v_pass_mark
+      ),
+      v_total_questions, v_time_limit
+    )
+    RETURNING id, quiz_sessions.started_at
+    INTO v_session_id, v_started_at;
+  EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END;
+
+  -- Mark code consumed (race-safe: requires consumed_at IS NULL).
+  UPDATE public.internal_exam_codes
+  SET consumed_at = now(),
+      consumed_session_id = v_session_id
+  WHERE id = v_code_id
+    AND consumed_at IS NULL;
+  GET DIAGNOSTICS v_consumed_rows = ROW_COUNT;
+  IF v_consumed_rows = 0 THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+
+  -- Audit. Subquery on users filters deleted_at (security.md rule 10).
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_student_id AND u.deleted_at IS NULL),
+    'internal_exam.started',
+    'quiz_session',
+    v_session_id,
+    jsonb_build_object(
+      'code_id',         v_code_id,
+      'subject_id',      v_code_subject,
+      'total_questions', v_total_questions,
+      'pass_mark',       v_pass_mark
+    )
+  );
+
+  RETURN QUERY SELECT
+    v_session_id,
+    v_selected_ids,
+    v_time_limit,
+    v_total_questions,
+    v_pass_mark,
+    v_started_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.start_internal_exam_session(text) TO authenticated;

--- a/supabase/migrations/20260430000005_start_internal_exam_session_qualify_columns.sql
+++ b/supabase/migrations/20260430000005_start_internal_exam_session_qualify_columns.sql
@@ -1,0 +1,229 @@
+-- Migration 071: Qualify quiz_sessions columns in start_internal_exam_session
+-- CodeRabbit PR #576 round-2 + CI red-team failure.
+--
+-- Bug (PG 42702 "column reference \"time_limit_seconds\" is ambiguous"):
+-- The function RETURNS TABLE(... time_limit_seconds int, ..., started_at timestamptz)
+-- exposes those names as variables in the function body. The auto-complete SELECT
+-- in mig 070 lines 103-114 referenced them unqualified:
+--
+--   AND time_limit_seconds IS NOT NULL
+--   AND started_at IS NOT NULL
+--   AND now() > started_at + ((time_limit_seconds + 30) || ' seconds')::interval
+--
+-- Postgres cannot distinguish the RETURNS column from the quiz_sessions column
+-- and raises 42702. The bug was latent until the red-team spec exercised the
+-- "active session past its grace window" code path.
+--
+-- Fix: alias public.quiz_sessions AS qs and qualify every reference. Function
+-- body otherwise unchanged from mig 070.
+
+CREATE OR REPLACE FUNCTION public.start_internal_exam_session(p_code text)
+RETURNS TABLE(
+  session_id uuid,
+  question_ids uuid[],
+  time_limit_seconds int,
+  total_questions int,
+  pass_mark int,
+  started_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_student_id      uuid := auth.uid();
+  v_org_id          uuid;
+  v_code_id         uuid;
+  v_code_subject    uuid;
+  v_code_student    uuid;
+  v_code_org        uuid;
+  v_code_expires    timestamptz;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_old_session_id  uuid;
+  v_config_id       uuid;
+  v_total_questions int;
+  v_time_limit      int;
+  v_pass_mark       int;
+  v_dist            record;
+  v_selected_ids    uuid[] := '{}';
+  v_topic_ids       uuid[];
+  v_session_id      uuid;
+  v_started_at      timestamptz;
+  v_consumed_rows   int;
+BEGIN
+  IF v_student_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  SELECT iec.id, iec.subject_id, iec.student_id, iec.organization_id,
+         iec.expires_at, iec.consumed_at, iec.voided_at
+  INTO v_code_id, v_code_subject, v_code_student, v_code_org,
+       v_code_expires, v_code_consumed, v_code_voided
+  FROM public.internal_exam_codes iec
+  WHERE iec.code = p_code
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_student <> v_student_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+  IF v_code_consumed IS NOT NULL THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+  IF v_code_expires <= now() THEN
+    RAISE EXCEPTION 'code_expired';
+  END IF;
+
+  SELECT u.organization_id INTO v_org_id
+  FROM public.users u
+  WHERE u.id = v_student_id AND u.deleted_at IS NULL;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  IF v_code_org IS NULL OR v_code_org <> v_org_id THEN
+    RAISE EXCEPTION 'code_not_yours';
+  END IF;
+
+  -- Auto-complete any same-subject internal_exam past +30s grace.
+  -- All quiz_sessions columns aliased as qs.* — the function's RETURNS TABLE
+  -- exposes time_limit_seconds and started_at as bare names too, so any
+  -- unqualified reference here is ambiguous (PG 42702).
+  SELECT qs.id INTO v_old_session_id
+  FROM public.quiz_sessions qs
+  WHERE qs.student_id = v_student_id
+    AND qs.organization_id = v_org_id
+    AND qs.subject_id = v_code_subject
+    AND qs.mode = 'internal_exam'
+    AND qs.ended_at IS NULL
+    AND qs.deleted_at IS NULL
+    AND qs.time_limit_seconds IS NOT NULL
+    AND qs.started_at IS NOT NULL
+    AND now() > qs.started_at + ((qs.time_limit_seconds + 30) || ' seconds')::interval
+  LIMIT 1;
+  IF v_old_session_id IS NOT NULL THEN
+    PERFORM public.complete_overdue_exam_session(v_old_session_id);
+  END IF;
+
+  -- Pre-INSERT guard. Concurrency-safe source of truth is the partial unique
+  -- index on (student_id, organization_id, subject_id) WHERE mode='internal_exam'
+  -- AND ended_at IS NULL AND deleted_at IS NULL (mig 069) caught by the
+  -- EXCEPTION handler around the INSERT below.
+  IF EXISTS (
+    SELECT 1 FROM public.quiz_sessions qs
+    WHERE qs.student_id = v_student_id
+      AND qs.organization_id = v_org_id
+      AND qs.subject_id = v_code_subject
+      AND qs.mode = 'internal_exam'
+      AND qs.ended_at IS NULL
+      AND qs.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END IF;
+
+  SELECT ec.id, ec.total_questions, ec.time_limit_seconds, ec.pass_mark
+  INTO v_config_id, v_total_questions, v_time_limit, v_pass_mark
+  FROM public.exam_configs ec
+  WHERE ec.organization_id = v_org_id
+    AND ec.subject_id = v_code_subject
+    AND ec.enabled = true
+    AND ec.deleted_at IS NULL;
+  IF v_config_id IS NULL THEN
+    RAISE EXCEPTION 'exam_config_required';
+  END IF;
+
+  FOR v_dist IN
+    SELECT ecd.topic_id, ecd.subtopic_id, ecd.question_count
+    FROM public.exam_config_distributions ecd
+    WHERE ecd.exam_config_id = v_config_id
+    ORDER BY ecd.topic_id, ecd.subtopic_id NULLS LAST
+  LOOP
+    v_topic_ids := ARRAY(
+      SELECT q.id
+      FROM public.questions q
+      WHERE q.subject_id = v_code_subject
+        AND q.topic_id = v_dist.topic_id
+        AND (v_dist.subtopic_id IS NULL OR q.subtopic_id = v_dist.subtopic_id)
+        AND q.status = 'active'
+        AND q.deleted_at IS NULL
+        AND q.organization_id = v_org_id
+        AND q.id != ALL(v_selected_ids)
+      ORDER BY random()
+      LIMIT v_dist.question_count
+    );
+    IF array_length(v_topic_ids, 1) IS NULL OR array_length(v_topic_ids, 1) < v_dist.question_count THEN
+      RAISE EXCEPTION 'insufficient_questions_for_exam';
+    END IF;
+    v_selected_ids := v_selected_ids || v_topic_ids;
+  END LOOP;
+
+  IF array_length(v_selected_ids, 1) IS NULL
+     OR array_length(v_selected_ids, 1) <> v_total_questions THEN
+    RAISE EXCEPTION 'insufficient_questions_for_exam';
+  END IF;
+
+  BEGIN
+    INSERT INTO public.quiz_sessions
+      (organization_id, student_id, mode, subject_id,
+       config, total_questions, time_limit_seconds)
+    VALUES (
+      v_org_id, v_student_id, 'internal_exam', v_code_subject,
+      jsonb_build_object(
+        'question_ids',   to_jsonb(v_selected_ids),
+        'exam_config_id', v_config_id,
+        'pass_mark',      v_pass_mark
+      ),
+      v_total_questions, v_time_limit
+    )
+    RETURNING id, quiz_sessions.started_at
+    INTO v_session_id, v_started_at;
+  EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'active_session_exists';
+  END;
+
+  UPDATE public.internal_exam_codes
+  SET consumed_at = now(),
+      consumed_session_id = v_session_id
+  WHERE id = v_code_id
+    AND consumed_at IS NULL;
+  GET DIAGNOSTICS v_consumed_rows = ROW_COUNT;
+  IF v_consumed_rows = 0 THEN
+    RAISE EXCEPTION 'code_already_used';
+  END IF;
+
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_org_id,
+    v_student_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_student_id AND u.deleted_at IS NULL),
+    'internal_exam.started',
+    'quiz_session',
+    v_session_id,
+    jsonb_build_object(
+      'code_id',         v_code_id,
+      'subject_id',      v_code_subject,
+      'total_questions', v_total_questions,
+      'pass_mark',       v_pass_mark
+    )
+  );
+
+  RETURN QUERY SELECT
+    v_session_id,
+    v_selected_ids,
+    v_time_limit,
+    v_total_questions,
+    v_pass_mark,
+    v_started_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.start_internal_exam_session(text) TO authenticated;

--- a/supabase/migrations/20260430000006_void_internal_exam_code_org_scope_session.sql
+++ b/supabase/migrations/20260430000006_void_internal_exam_code_org_scope_session.sql
@@ -1,0 +1,190 @@
+-- Migration 072: Org-scope the linked-session SELECT/UPDATE in
+-- void_internal_exam_code (defense-in-depth)
+-- CodeRabbit PR #576 round-2 finding (Major).
+--
+-- Background: mig 068 verifies the code's organization_id matches the admin's,
+-- then trusts the code row's consumed_session_id and locks/updates
+-- public.quiz_sessions BY id ONLY:
+--
+--   SELECT qs.ended_at, qs.total_questions, qs.config ...
+--   FROM public.quiz_sessions qs
+--   WHERE qs.id = v_code_session_id AND qs.deleted_at IS NULL FOR UPDATE;
+--   ...
+--   UPDATE public.quiz_sessions
+--   SET ended_at = now(), ...
+--   WHERE id = v_code_session_id;
+--
+-- This is a SECURITY DEFINER function bypassing RLS. If a future bug or
+-- admin-tooling regression ever stored a cross-org consumed_session_id on a
+-- code, this RPC would expire a foreign-org session. The code-org check
+-- (mig 068 lines 71-74) makes that path unreachable today, but session-row
+-- writes that depend on a single guarantee are exactly the kind of pattern that
+-- breaks silently when invariants drift. Add the explicit org filter.
+--
+-- Function body otherwise unchanged from mig 068.
+
+CREATE OR REPLACE FUNCTION public.void_internal_exam_code(
+  p_code_id uuid,
+  p_reason  text
+)
+RETURNS TABLE(code_id uuid, session_id uuid, session_ended boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_id        uuid := auth.uid();
+  v_admin_org       uuid;
+  v_code_org        uuid;
+  v_code_consumed   timestamptz;
+  v_code_voided     timestamptz;
+  v_code_session_id uuid;
+  v_session_ended   timestamptz;
+  v_session_total   int;
+  v_session_config  jsonb;
+  v_pass_mark       int;
+  v_answered        int;
+  v_correct_count   int;
+  v_score           numeric(5,2);
+  v_session_done    boolean := false;
+  v_session_updated int;
+BEGIN
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  IF p_reason IS NULL OR btrim(p_reason) = '' THEN
+    RAISE EXCEPTION 'invalid_reason';
+  END IF;
+  IF length(p_reason) > 500 THEN
+    RAISE EXCEPTION 'invalid_reason';
+  END IF;
+
+  SELECT u.organization_id INTO v_admin_org
+  FROM public.users u
+  WHERE u.id = v_admin_id AND u.deleted_at IS NULL;
+  IF v_admin_org IS NULL THEN
+    RAISE EXCEPTION 'admin_not_found';
+  END IF;
+
+  SELECT iec.organization_id, iec.consumed_at, iec.voided_at, iec.consumed_session_id
+  INTO v_code_org, v_code_consumed, v_code_voided, v_code_session_id
+  FROM public.internal_exam_codes iec
+  WHERE iec.id = p_code_id
+    AND iec.deleted_at IS NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_org <> v_admin_org THEN
+    RAISE EXCEPTION 'code_not_found';
+  END IF;
+
+  IF v_code_voided IS NOT NULL THEN
+    RAISE EXCEPTION 'code_voided';
+  END IF;
+
+  IF v_code_consumed IS NOT NULL AND v_code_session_id IS NOT NULL THEN
+    -- Defense-in-depth: scope both the SELECT and the UPDATE to the admin's
+    -- org. The code-org guard above (v_code_org = v_admin_org) makes a foreign
+    -- session unreachable today, but a SECURITY DEFINER write that depends on
+    -- a single upstream invariant is the wrong shape for cross-org safety.
+    SELECT qs.ended_at, qs.total_questions, qs.config
+    INTO v_session_ended, v_session_total, v_session_config
+    FROM public.quiz_sessions qs
+    WHERE qs.id = v_code_session_id
+      AND qs.organization_id = v_admin_org
+      AND qs.deleted_at IS NULL
+    FOR UPDATE;
+
+    IF FOUND AND v_session_ended IS NOT NULL THEN
+      RAISE EXCEPTION 'cannot_void_finished_attempt';
+    END IF;
+
+    IF FOUND AND v_session_ended IS NULL THEN
+      SELECT
+        count(*)::int,
+        count(*) FILTER (WHERE qsa.is_correct)::int
+      INTO v_answered, v_correct_count
+      FROM public.quiz_session_answers qsa
+      WHERE qsa.session_id = v_code_session_id;
+
+      v_score := CASE WHEN v_session_total > 0
+                      THEN round((v_correct_count::numeric / v_session_total) * 100, 2)
+                      ELSE 0 END;
+
+      v_pass_mark := (v_session_config->>'pass_mark')::int;
+
+      UPDATE public.quiz_sessions
+      SET ended_at         = now(),
+          correct_count    = v_correct_count,
+          score_percentage = v_score,
+          passed           = false
+      WHERE id = v_code_session_id
+        AND organization_id = v_admin_org
+        AND deleted_at IS NULL;
+      GET DIAGNOSTICS v_session_updated = ROW_COUNT;
+      IF v_session_updated = 0 THEN
+        -- A concurrent writer ended/deleted the session between SELECT and
+        -- UPDATE, or org guard rejected it. Fail loudly rather than silently
+        -- proceed to audit a write that didn't happen.
+        RAISE EXCEPTION 'session_state_changed';
+      END IF;
+
+      v_session_done := true;
+
+      INSERT INTO public.audit_events
+        (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+      VALUES (
+        v_admin_org,
+        v_admin_id,
+        (SELECT u.role FROM public.users u
+         WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+        'internal_exam.expired',
+        'quiz_session',
+        v_code_session_id,
+        jsonb_build_object(
+          'reason',           'admin_voided',
+          'score',            v_score,
+          'answered_count',   v_answered,
+          'correct_count',    v_correct_count,
+          'total_questions',  v_session_total,
+          'pass_mark',        v_pass_mark,
+          'passed',           false
+        )
+      );
+    END IF;
+  END IF;
+
+  UPDATE public.internal_exam_codes
+  SET voided_at   = now(),
+      voided_by   = v_admin_id,
+      void_reason = p_reason
+  WHERE id = p_code_id;
+
+  INSERT INTO public.audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id, metadata)
+  VALUES (
+    v_admin_org,
+    v_admin_id,
+    (SELECT u.role FROM public.users u
+     WHERE u.id = v_admin_id AND u.deleted_at IS NULL),
+    'internal_exam.code_voided',
+    'internal_exam_code',
+    p_code_id,
+    jsonb_build_object(
+      'reason',       p_reason,
+      'was_consumed', (v_code_consumed IS NOT NULL),
+      'session_ended', v_session_done
+    )
+  );
+
+  RETURN QUERY SELECT p_code_id, v_code_session_id, v_session_done;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.void_internal_exam_code(uuid, text) TO authenticated;


### PR DESCRIPTION
## Summary
- Adds **Internal Exam Mode** — admin issues a single-use, 24h-valid 8-char code that unlocks one official exam attempt for one student on one subject. Each code is its own attempt; retakes need a new code. Sessions cannot be discarded. Closes #541.
- Centralises mode label strings in a new constants module (`apps/web/lib/constants/exam-modes.ts`). Closes #544.
- Hardens `is_admin()` against soft-deleted admins (defense-in-depth fix surfaced by plan-critic).

## Approach
Reuses ~60% of the practice-exam stack (`exam_configs`, countdown timer, answer buffer, results card, recovery flow). Three new SECURITY DEFINER RPCs (`issue_internal_exam_code`, `start_internal_exam_session`, `void_internal_exam_code`) and minimal mode-aware branches in three existing RPCs (`batch_submit_quiz`, `complete_overdue_exam_session`, `complete_empty_exam_session`).

## Wave structure
1. **Foundation** (`10b27cc`, `f9576ac`) — 8 SQL migrations (`057a`–`063`), constants module, nav extensions.
2. **Force RLS + active-session guard** (`534b352`) — migrations 064 and 065 from semantic review.
3. **Server actions** (`3042851`) — admin issue/void/list, student startInternalExam/getActive/listAvailable/listMyHistory, discard.ts rejection, reports.ts mode filter.
4. **Admin UI** (`4f7a1cc`) — `/app/admin/internal-exams` page + 8 components.
5. **Student UI + mode threading** (`1960766`) — `/app/internal-exam` + threading `examMode` through quiz session UI + Discard hidden for internal_exam.
6. **Docs sync** (`aa179f5`).
7. **E2E + red-team specs** (`873531f`) — 4 lifecycle specs + 4 RPC red-team specs.
8. **Pre-push fix** (`b4eac36`) — `get_session_reports` total_count was inflated by internal_exam rows; SQL fix excludes them at the window function level.
9. **Hook fix** (`c9cd358`) — pre-push security-auditor SIGPIPE'd on truncation; replaced `head` with `awk`.

## Database
- New table `internal_exam_codes` (FORCE RLS, FK to subjects/users/sessions, partial index on active rows, no INSERT/DELETE policies — writes via SECURITY DEFINER RPCs only).
- `quiz_sessions.mode` CHECK widened to include `'internal_exam'`.
- New audit events: `internal_exam.code_issued`, `internal_exam.started`, `internal_exam.completed`, `internal_exam.expired`, `internal_exam.code_voided`.

## Product decisions (locked)
- Code: 8-char Crockford alphabet (no `0/O/I/1`).
- Validity: 24h from issuance.
- One code = one attempt. Retake needs new code.
- Plaintext storage (admin must be able to look up codes).
- Code value never displayed to student in any list (only entered via modal).
- No discard for internal exams (server + UI both block).
- Reports tab is fully separated — practice/quiz reports exclude `internal_exam`.

## Security-auditor pre-push findings (MEDIUM, advisory)
The pre-push auditor approved with three MEDIUM findings — none CRITICAL/HIGH. Calling them out for review:
1. **`is_admin()` lacks explicit `auth.uid() IS NULL` raise** — implicitly safe (the WHERE matches no rows), and every new caller adds its own auth guard. Pre-existing function body, fix would be 1 line if we want it explicit.
2. **Student can read own code via direct PostgREST** — the SELECT policy permits it. We enforce code-secrecy at the application layer (queries.ts selects only `id, subject_id, expires_at, issued_at`). Since a code is addressed to that specific student and they need it anyway, the practical risk is low; do we want to enforce at the DB layer too?
3. **Admin UPDATE policy is column-permissive** — admin could in theory directly un-void a code or reset `consumed_at`, bypassing the SECURITY DEFINER invariants. Trusted-admin pattern; documented as RPC-only writes.

## Test plan
- [ ] Apply migrations 057a–066 against the dev Supabase (`npx supabase db reset` or `migration up`).
- [ ] Regenerate types: `npx supabase gen types typescript --linked > packages/db/src/types.ts`.
- [ ] Run unit suite: `pnpm --filter @repo/web test`.
- [ ] Run E2E: `pnpm --filter @repo/web e2e -- internal-exam-` (after migrations).
- [ ] Run red-team: `pnpm --filter @repo/web e2e:redteam` (after migrations + seed).
- [ ] Manual eval: admin issues code, student receives it OOB, types it in, completes a partial exam, lands on report; reload mid-session resumes; admin voids an active code, student sees cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Internal Exam Mode: admin UI to issue/void single‑use 8‑char codes, manage Codes/Attempts, and dedicated admin page.
  * Student Internal Exam area: Available/My Reports tabs, start‑by‑code modal, issued‑code panel (copy/dismiss), recovery banner to resume sessions.

* **Changes**
  * Internal exams excluded from general reports and surfaced in dedicated internal‑exam reports.
  * Navigation, badges, headers, and finish dialog labels now reflect “Internal Exam”; discard disabled and unanswered questions marked wrong.

* **Tests**
  * New unit, integration and E2E coverage for internal‑exam workflows (admin, student, RLS, RPCs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->