### PR TITLE
docs: record Internal Exam Mode + #587 fix in plan + decisions

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -641,6 +641,25 @@ Full audit completed — 46 files reviewed. Score: 9.5/10. Full report: `docs/se
 
 **Rationale**: Single-use codes prevent reuse and ensure each student gets unique exam audit records. The code-first approach validates DB design before building Server Actions and UI.
 
+### Decision 38: E2E Spec Hermiticity — every Playwright spec restores shared seed state in afterEach (2026-04-30)
+
+**Date**: 2026-04-30
+
+**Context**: Issue #587 — six `internal-exam-*.spec.ts` files failed deterministically in CI with `page.waitForURL(/\/app\/quiz\/session/)` 15 s timeout. Root cause was *not* the visible symptom: `admin-questions.spec.ts` test "selects rows and performs bulk status change" flipped every visible MET question to `status='draft'` and never restored. Within Playwright's `admin-e2e` project, admin-questions runs alphabetically before `internal-exam-*`, so by the time `start_internal_exam_session` ran, its `q.status='active'` filter returned zero and the RPC raised `insufficient_questions_for_exam`. Three rounds of investigation chased the most-visible signal (stale-session cascade, selector drift, tracing visibility) before round 2 found the cross-spec coupling.
+
+**Decision**: Every Playwright spec that mutates shared seed data must restore state in `test.afterEach` (or `afterAll` for describe-scoped fixtures). Codified as a hard rule in `code-style.md §7` "E2E Spec Hermiticity" and mirrored in `.coderabbit.yaml`. The required shape:
+
+1. **Stable marker constant** for test-created rows, exported from a shared helper module — never inline magic strings.
+2. **Test-created rows carry the marker** in a queryable column (text prefix preferred — PostgREST `.like()` works).
+3. **Single `afterEach` at describe level** invoking the cleanup helper. Runs even on test failure — that is what we want.
+4. **Soft-delete, not hard-delete**, for tables with FK children. `student_responses` / `quiz_session_answers` / `flagged_questions` / `question_comments` reference `questions(id)`; hard DELETE risks 23503 violations and breaks `docs/security.md` rule 6.
+5. **Zero-row no-op chain** (`.select('id')` + log gated on `data.length > 0`) per `code-style.md §5`.
+6. **Cleanup helper has Vitest unit tests** covering org-lookup error, each mutation error path, no-op silence, each log path. Use the `vi.hoisted` + `buildChain` queue/shift pattern when the helper makes multiple sequential calls on the same table.
+
+**Rationale**: Cross-spec test-state leakage produces deterministic failures that present as flakiness — by far the worst class of CI failure to debug, because the symptom and the cause are in different files and the latency between them is the entire prior spec's duration. Promoting the pattern to a rule at count=2 (`admin-students.spec.ts` precedent + `admin-questions.spec.ts` this fix) prevents the next instance from getting through review. Implementation also encodes *why* difficulty is NOT reset in `restoreSeededQuestionsState`: local dev seeds vary difficulty per question (`seed-quiz-setup-eval.ts:184`); resetting would silently mutate dev data while CI is unaffected. That trade-off is documented inline so a future reader doesn't add the reset back without understanding the constraint.
+
+**Implementation**: Round-2 fix commits `e3a7a0b` + `7082d77` + `787b5f0` (PR #590, merged 2026-04-30 → `1eeeda6`). New helper `restoreSeededQuestionsState()` in `apps/web/e2e/helpers/supabase.ts`. Marker constant `E2E_ADMIN_Q_MARKER` exported from same module. 7 unit tests for the helper.
+
 ---
 
-*Last updated: 2026-04-29 — Decision 37: Internal Exam Mode foundation + product decisions*
+*Last updated: 2026-04-30 — Decision 38: E2E Spec Hermiticity rule promotion (count=2)*

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,7 +2,7 @@
 
 > This is the master plan. Start every new session by reading this file.
 > User writes zero code. Claude plans, builds, tests, reviews, documents.
-> Last updated: 2026-03-27
+> Last updated: 2026-04-30 — Internal Exam Mode + CI flake fix landed
 
 ---
 
@@ -1115,3 +1115,48 @@ From setup audit (2026-03-11), updated 2026-03-19:
 - Issue #568 filed for the deferred 0-answer auto-submit bug.
 
 *Round 7 last updated: 2026-04-28 — pushed; round 8 fixes staged; CI e2e unblock pushed.*
+
+---
+
+## Internal Exam Mode — LANDED 2026-04-29 → 2026-04-30
+
+PR #576 (foundation + 4 waves) merged 2026-04-29 (`673d932`). PR #590 (CI flake fix) merged 2026-04-30 (`1eeeda6`) and closed issue #587. **Feature is live on master.**
+
+### What shipped
+
+- **DB foundation** (mig 057a–065 + 067 + 070 + 071 + 072): `internal_exam_codes` table (8-char single-use codes, 24h expiry, FORCE RLS, immutable), three SECURITY DEFINER RPCs (`issue_internal_exam_code`, `start_internal_exam_session`, `void_internal_exam_code`), extended `batch_submit_quiz` for `mode='internal_exam'` partial submissions, extended `complete_overdue_exam_session` to handle internal exams, `is_admin()` `deleted_at` filter (regression close).
+- **Server actions** (`apps/web/app/app/internal-exam/actions/` + `apps/web/app/app/admin/internal-exams/actions/`): issue / start / void / list / report — all admin paths via `adminClient`, all student paths via the user's RLS-scoped client.
+- **Admin UI** at `/app/admin/internal-exams`: issue-code form, code/attempt tables with deep-linked `?tab=` filters, namespaced admin report at `/app/admin/internal-exams/report`.
+- **Student UI** at `/app/internal-exam`: Available + My Reports tabs, code-entry modal, namespaced student report at `/app/internal-exam/report`. Discard hidden mid-session; exam-mode finish dialog.
+- **Tests**: 6 new E2E specs (lifecycle, no-discard-and-void, reports-separation, resume), red-team specs for cross-tenant + question-membership + start-session vectors. Unit-test coverage for every new helper.
+- **Rules promoted at count=2 during PR #576**: PostgREST `!` over `:` for FK expansion; zero-row check scope clarification.
+
+### CI flake fix (PR #590, issue #587)
+
+Six internal-exam Playwright specs deterministically failed in CI after PR #576 with `page.waitForURL(/\/app\/quiz\/session/)` 15 s timeout. Three rounds of investigation:
+
+| Round | Cause | Commits |
+|---|---|---|
+| 1 | Stale-session cascade (active `quiz_sessions` left over from prior tests) → cleanup helper voids leftover via `void_internal_exam_code`. Production-vs-test selector drift after `Submit Quiz`→`Submit Internal Exam` rename. Student `BrowserContext.tracing` was never started. | `e36864d`, `9c4b508`, `c00a2ba`, `4669923`, `db856d5` |
+| 2 | `admin-questions.spec.ts` test "selects rows and performs bulk status change" flips every visible MET question to `status='draft'` and never restores. admin-questions runs alphabetically before internal-exam-* in the `admin-e2e` Playwright project, so `start_internal_exam_session` raised `insufficient_questions_for_exam` and 6 student-side `waitForURL` calls timed out. | `e3a7a0b`, `7082d77`, `787b5f0` |
+
+Round-2 fix shape (mirrors `admin-students.spec.ts` precedent):
+
+- New `restoreSeededQuestionsState()` helper in `apps/web/e2e/helpers/supabase.ts`: soft-deletes `[E2E_ADMIN_Q]`-marker rows + reactivates non-active seeded rows. Both writes chain `.select('id')` + log only when something changed.
+- `test.afterEach` wired into `admin-questions.spec.ts`.
+- Soft-delete (not hard) — `student_responses` / `quiz_session_answers` / `flagged_questions` / `question_comments` carry FK references to `questions(id)`. plan-critic CRITICAL caught this before commit.
+- Difficulty intentionally NOT reset — local dev seeds (`seed-quiz-setup-eval.ts:184`) intentionally vary difficulty; the edit-test's leak doesn't break any downstream spec.
+- 7 unit tests for the helper (org-lookup error, both update error paths, no-op silence, both log paths, org-row-null branch).
+
+### Rule promoted at count=2 — E2E Spec Hermiticity
+
+Pattern hit count=2 (`admin-students.spec.ts` precedent + `admin-questions.spec.ts` this fix). New rule in `code-style.md` §7 + mirrored in `.coderabbit.yaml`. Sweep on rule promotion: zero remaining offenders. See **Decision 38** in `decisions.md`.
+
+### Verification
+
+- 3356 / 3356 unit tests pass.
+- All E2E specs green in CI on the merge commit.
+- Type-check + lint clean.
+- Pre-push security-auditor passed.
+
+*Last updated: 2026-04-30 — Internal Exam Mode + CI flake fix landed.*


### PR DESCRIPTION
## Summary

- Post-merge doc refresh after PR #576 (Internal Exam Mode) and PR #590 (#587 CI flake) landed on master.
- `docs/plan.md`: new section "Internal Exam Mode — LANDED 2026-04-29 → 2026-04-30" summarising what shipped + the three-round CI flake investigation.
- `docs/decisions.md`: Decision 38 — "E2E Spec Hermiticity" — recording the rule promotion at count=2, soft-delete-vs-hard rationale, and the intentional non-reset of difficulty.

## Test plan

- [x] Doc-only diff — no code, no schema, no behavior.
- [x] Biome + type-check clean (cache hit, doc files only).
- [ ] CodeRabbit review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established formal decision for E2E test state cleanup requirements, defining standards for handling shared test data mutation to improve test stability.
  * Updated delivery plan with Internal Exam Mode feature documentation, including database primitives, application flows, and CI flake resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->