### PR TITLE
test(polish): strengthen expiry assertion and behavior-first test names

### DIFF
--- a/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.test.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.test.tsx
@@ -8,7 +8,7 @@ vi.mock('sonner', () => ({
   toast: { success: mockToastSuccess, error: mockToastError },
 }))
 
-import { IssuedCodePanel } from './issued-code-panel'
+import { formatExpiry, IssuedCodePanel } from './issued-code-panel'
 
 const PROPS = {
   code: 'ABCD2345',
@@ -47,8 +47,7 @@ describe('IssuedCodePanel', () => {
 
   it('shows the expiry timestamp in a human-readable format', () => {
     render(<IssuedCodePanel {...PROPS} />)
-    // The exact format depends on locale, but the year and month should appear.
-    expect(screen.getByText(/Expires/)).toBeInTheDocument()
+    expect(screen.getByText(`Expires ${formatExpiry(PROPS.expiresAt)}`)).toBeInTheDocument()
   })
 
   it('copies the code to the clipboard and shows a confirmation toast on copy', async () => {

--- a/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/issued-code-panel.tsx
@@ -10,7 +10,7 @@ type Props = {
   onDismiss: () => void
 }
 
-function formatExpiry(iso: string): string {
+export function formatExpiry(iso: string): string {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso
   return d.toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' })

--- a/apps/web/app/app/quiz/session/_hooks/use-exam-state.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-exam-state.test.ts
@@ -192,7 +192,7 @@ describe('useExamPipeline — handleSelectAnswer', () => {
 // ---- isExam: true forwarded to useQuizSubmit ----------------------------
 
 describe('useExamPipeline — isExam flag', () => {
-  it('enables exam mode on the submission hook', () => {
+  it('enables exam mode', () => {
     renderHook(() => useExamPipeline(makeOpts()))
     const callArg = mockUseQuizSubmit.mock.calls[0]?.[0] as Record<string, unknown>
     expect(callArg.isExam).toBe(true)

--- a/apps/web/app/app/quiz/session/_hooks/use-exam-state.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-exam-state.test.ts
@@ -192,7 +192,7 @@ describe('useExamPipeline — handleSelectAnswer', () => {
 // ---- isExam: true forwarded to useQuizSubmit ----------------------------
 
 describe('useExamPipeline — isExam flag', () => {
-  it('passes isExam: true to useQuizSubmit', () => {
+  it('enables exam mode on the submission hook', () => {
     renderHook(() => useExamPipeline(makeOpts()))
     const callArg = mockUseQuizSubmit.mock.calls[0]?.[0] as Record<string, unknown>
     expect(callArg.isExam).toBe(true)
@@ -241,45 +241,45 @@ describe('useExamPipeline — navigation forwarding', () => {
 // ---- useQuizSubmit return values surfaced --------------------------------
 
 describe('useExamPipeline — submit state surfacing', () => {
-  it('exposes the submitting flag on its return value', () => {
+  it('returns true while submission is pending', () => {
     mockUseQuizSubmit.mockReturnValue(makeSubmitResult({ submitting: true }))
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.submitting).toBe(true)
   })
 
-  it('exposes the error state on its return value', () => {
+  it('returns the submission error to render', () => {
     mockUseQuizSubmit.mockReturnValue(makeSubmitResult({ error: 'Submission failed' }))
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.error).toBe('Submission failed')
   })
 
-  it('exposes the finish-dialog visibility on its return value', () => {
+  it('returns true while the finish dialog is open', () => {
     mockUseQuizSubmit.mockReturnValue(makeSubmitResult({ showFinishDialog: true }))
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.showFinishDialog).toBe(true)
   })
 
-  it('exposes the submit handler on its return value', () => {
+  it('returns the submit handler to the consumer', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.handleSubmit).toBe(mockHandleSubmit)
   })
 
-  it('exposes the save handler on its return value', () => {
+  it('returns the save handler to the consumer', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.handleSave).toBe(mockHandleSave)
   })
 
-  it('exposes the discard handler on its return value', () => {
+  it('returns the discard handler to the consumer', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.handleDiscard).toBe(mockHandleDiscard)
   })
 
-  it('exposes the finish-dialog setter on its return value', () => {
+  it('returns the finish-dialog setter to the consumer', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.setShowFinishDialog).toBe(mockSetShowFinishDialog)
   })
 
-  it('exposes the submitted ref on its return value', () => {
+  it('returns the submitted ref to the consumer', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.submitted).toBe(mockSubmitted)
   })

--- a/apps/web/app/app/quiz/session/_hooks/use-exam-state.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-exam-state.test.ts
@@ -247,7 +247,7 @@ describe('useExamPipeline — submit state surfacing', () => {
     expect(result.current.submitting).toBe(true)
   })
 
-  it('returns the submission error to render', () => {
+  it('surfaces the submission error string', () => {
     mockUseQuizSubmit.mockReturnValue(makeSubmitResult({ error: 'Submission failed' }))
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.error).toBe('Submission failed')


### PR DESCRIPTION
## Summary

- **#580** — Replace brittle `/Expires/` regex in `issued-code-panel.test.tsx` with assertion derived from `formatExpiry()` itself. Test now follows the formatter rather than hardcoding a locale string. Required exporting `formatExpiry` from the component (logic unchanged).
- **#569** — Rename 9 impl-leakage `it()` titles in `use-exam-state.test.ts` to behavior-first phrasing per `code-style.md` §7. The 5-field forwarding consolidation was already in place — only titles needed rework. `navigateTo` / `navigate` callback titles left untouched (those describe public-contract opts).

Two commits:
- `acd601f` initial test polish
- `5a9c1de` follow-up rename: `'returns the submission error to render'` → `'surfaces the submission error string'` (semantic-reviewer flagged "render" as React-lifecycle vocabulary leakage)

## Closes

Closes #580
Closes #569

## Test plan

- [x] `pnpm --filter @repo/web test -- --run` → **3356/3356** passing
- [x] `pnpm check-types` → clean
- [x] biome lint → clean (pre-commit hook; one pre-existing warning at L33 unrelated to diff)
- [x] security-auditor pre-push → approved
- [x] code-reviewer agent → 0/0
- [x] implementation-critic → approved
- [x] semantic-reviewer → ISSUE 1 fixed in `5a9c1de`; ISSUE 2 + SUGG deferred (see follow-ups)
- [x] doc-updater → clean
- [x] test-writer → no new tests needed
- [x] learner → memory updated, 3 patterns at watch (count=1)

## Out of scope (commented for triage)

- **#555** — `start-exam.test.ts` mock strings already match the action's `.includes()` substring routing. Re-syncing to full RPC text would make tests more brittle, not less. Recommend close as wontfix.
- **#581** — `'maps <ERROR_TOKEN>'` titles describe the public `ERROR_MESSAGES` Server Action contract, not impl detail. Per code-style §7 contract-naming carve-out. Recommend close as wontfix.

## Follow-ups filed

- **#600** — handler-forwarding titles (`'returns X to the consumer'`, lines 262-282) deferred per semantic-reviewer endorsement; also tracks NaN-guard test for `formatExpiry`
- **#601** — design refactor: extract `formatExpiry` to `_utils/format-expiry.ts` instead of widening component-file public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened assertions to validate human-readable expiry timestamps.
  * Clarified and reworded test descriptions for improved readability.

* **Refactor**
  * Made the expiry-formatting utility reusable across modules to reduce duplication and improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->