### PR TITLE
feat(db): seed EASA subject 080 (AGK) — 9 topics + 26 subtopics

### DIFF
--- a/supabase/migrations/20260504000001_seed_080_agk.sql
+++ b/supabase/migrations/20260504000001_seed_080_agk.sql
@@ -1,0 +1,73 @@
+-- Seed EASA subject 080 (Aircraft General Knowledge — Aeroplane) plus the 9 topics
+-- and 26 subtopics covered by the ECQB 081 import bundle (QDB/ecqb_081_full_import.zip,
+-- manifest.json v3, 168 questions).
+--
+-- This migration is data-only: subject/topic/subtopic taxonomy. Question rows are loaded
+-- separately via the import script (PostgREST + service-role key), keyed by these codes.
+--
+-- Idempotency: ON CONFLICT (code) / (subject_id, code) / (topic_id, code) DO NOTHING.
+-- Re-running is a no-op.
+
+INSERT INTO easa_subjects (code, name, short, sort_order)
+VALUES ('080', 'Aircraft General Knowledge (Aeroplane)', 'AGK', 3)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO easa_topics (subject_id, code, name, sort_order)
+SELECT s.id, t.code, t.name, t.sort_order
+FROM easa_subjects s
+CROSS JOIN (VALUES
+  ('081-01', 'System design, loads, stresses, maintenance', 1),
+  ('081-02', 'Airframe',                                    2),
+  ('081-03', 'Hydraulics',                                  3),
+  ('081-04', 'Landing gear, wheels, tyres and brakes',      4),
+  ('081-05', 'Flight controls',                             5),
+  ('081-06', 'Anti-icing systems',                          6),
+  ('081-07', 'Fuel system',                                 7),
+  ('081-08', 'Electrics',                                   8),
+  ('081-09', 'Piston Engines',                              9)
+) AS t(code, name, sort_order)
+WHERE s.code = '080'
+ON CONFLICT (subject_id, code) DO NOTHING;
+
+INSERT INTO easa_subtopics (topic_id, code, name, sort_order)
+SELECT t.id, s.code, s.name, s.sort_order
+FROM easa_topics t
+JOIN (VALUES
+  -- 081-01
+  ('081-01', '081-01-01', 'Loads and combination loadings applied to an aircraft''s structure', 1),
+  -- 081-02
+  ('081-02', '081-02-01', 'Wings, tail surfaces and control surfaces',                          1),
+  ('081-02', '081-02-02', 'Fuselage, doors, floor, wind-screen and windows',                    2),
+  -- 081-03
+  ('081-03', '081-03-02', 'Hydraulic systems',                                                  2),
+  -- 081-04
+  ('081-04', '081-04-01', 'Landing gear',                                                       1),
+  ('081-04', '081-04-02', 'Nose wheel steering',                                                2),
+  ('081-04', '081-04-03', 'Brakes',                                                             3),
+  ('081-04', '081-04-04', 'Wheels and tyres',                                                   4),
+  -- 081-05
+  ('081-05', '081-05-01', 'Aeroplane: primary flight controls',                                 1),
+  ('081-05', '081-05-02', 'Aeroplane: secondary flight controls',                               2),
+  -- 081-06
+  ('081-06', '081-06-01', 'Concept, types and operation (pitot and windshield)',                1),
+  -- 081-07
+  ('081-07', '081-07-01', 'Piston engine',                                                      1),
+  -- 081-08
+  ('081-08', '081-08-01', 'Electrics: general and definitions',                                 1),
+  ('081-08', '081-08-02', 'Batteries',                                                          2),
+  ('081-08', '081-08-03', 'Static electricity: general',                                        3),
+  ('081-08', '081-08-04', 'Generation: production, distribution and use',                       4),
+  ('081-08', '081-08-06', 'Distribution',                                                       6),
+  -- 081-09
+  ('081-09', '081-09-01', 'General',                                                            1),
+  ('081-09', '081-09-02', 'Fuel',                                                               2),
+  ('081-09', '081-09-03', 'Carburettor or injection system',                                    3),
+  ('081-09', '081-09-04', 'Air cooling systems',                                                4),
+  ('081-09', '081-09-05', 'Lubrication systems',                                                5),
+  ('081-09', '081-09-06', 'Ignition circuits',                                                  6),
+  ('081-09', '081-09-07', 'Mixture',                                                            7),
+  ('081-09', '081-09-08', 'Propellers',                                                         8),
+  ('081-09', '081-09-09', 'Performance and engine handling',                                    9)
+) AS s(topic_code, code, name, sort_order) ON s.topic_code = t.code
+WHERE t.subject_id = (SELECT id FROM easa_subjects WHERE code = '080')
+ON CONFLICT (topic_id, code) DO NOTHING;


### PR DESCRIPTION
## Summary

- Adds the 080 AGK taxonomy (1 subject + 9 topics + 26 subtopics) so the ECQB-081 question bundle has a place to land.
- Already applied to the remote DB via `supabase db push --linked` on 2026-05-03; 168 questions + 62 images imported via service-role PostgREST/Storage right after (one-shot scripts under `QDB/`, gitignored). This PR is the source-of-truth file for that taxonomy so a fresh clone reproduces live state.

## Notes

- Subtopic `sort_order` preserves real ECQB syllabus numbering — `081-08-06` → `sort_order=6` and `081-03-02` → `sort_order=2` — the bundle ships no `081-08-05` / `081-03-01` questions and we don't paper over the gaps.
- All inserts are `ON CONFLICT … DO NOTHING` — re-running the migration is a no-op.
- All FK lookups via subquery on `code` — no hard-coded UUIDs.

## Test plan

- [x] Migration applied on remote (2026-05-03) — verified counts: 1 subject, 9 topics, 26 subtopics
- [x] 168 questions inserted under bank `ba3d9779-…` (EASA PPL(A) QDB) with correct `subject_id` / `topic_id` / `subtopic_id` FK
- [x] 62 images uploaded to `question-images/080/images/`; public URL renders 200 OK including filenames with spaces
- [x] Per-subtopic question distribution matches `manifest.json` exactly (5+14+4+1+3+2+4+2+9+8+2+11+2+3+2+2+7+8+5+15+8+14+15+12+8+2 = 168)
- [ ] CI: lint, type-check, unit tests
- [ ] CodeRabbit review

## Related

- Surfaces a pre-existing latent bug in `getSyllabusTree()` — caps at 1000 questions globally because it client-side aggregates without pagination. Tracked separately in a follow-up issue (link added once issue is opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EASA Aircraft General Knowledge (Aeroplane) subject (080) with 9 topics and 26 subtopics to the training curriculum, making the full subject content available in course lists and navigation.
  * Content addition is non-disruptive to existing subjects and will appear alongside other EASA materials in the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->