### PR TITLE
fix(admin): replace client-side question counts with get_question_counts RPC

### DIFF
--- a/apps/web/app/app/admin/exam-config/queries.test.ts
+++ b/apps/web/app/app/admin/exam-config/queries.test.ts
@@ -404,46 +404,76 @@ describe('getExamConfigData', () => {
   })
 
   describe('error propagation', () => {
-    it('throws when the subjects query fails', async () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    it('throws a sanitized message when the subjects query fails', async () => {
       mockAdmin()
       buildTableMocks({ subjectsError: { message: 'subjects DB error' } })
 
-      await expect(getExamConfigData()).rejects.toThrow('subjects DB error')
+      await expect(getExamConfigData()).rejects.toThrow('Failed to load exam configuration')
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[getExamConfigData] DB error:',
+        'subjects DB error',
+      )
     })
 
-    it('throws when the topics query fails', async () => {
+    it('throws a sanitized message when the topics query fails', async () => {
       mockAdmin()
       buildTableMocks({ topicsError: { message: 'topics DB error' } })
 
-      await expect(getExamConfigData()).rejects.toThrow('topics DB error')
+      await expect(getExamConfigData()).rejects.toThrow('Failed to load exam configuration')
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[getExamConfigData] DB error:',
+        'topics DB error',
+      )
     })
 
-    it('throws when the subtopics query fails', async () => {
+    it('throws a sanitized message when the subtopics query fails', async () => {
       mockAdmin()
       buildTableMocks({ subtopicsError: { message: 'subtopics DB error' } })
 
-      await expect(getExamConfigData()).rejects.toThrow('subtopics DB error')
+      await expect(getExamConfigData()).rejects.toThrow('Failed to load exam configuration')
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[getExamConfigData] DB error:',
+        'subtopics DB error',
+      )
     })
 
-    it('throws when the exam_configs query fails', async () => {
+    it('throws a sanitized message when the exam_configs query fails', async () => {
       mockAdmin()
       buildTableMocks({ configsError: { message: 'configs DB error' } })
 
-      await expect(getExamConfigData()).rejects.toThrow('configs DB error')
+      await expect(getExamConfigData()).rejects.toThrow('Failed to load exam configuration')
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[getExamConfigData] DB error:',
+        'configs DB error',
+      )
     })
 
-    it('throws when the exam_config_distributions query fails', async () => {
+    it('throws a sanitized message when the exam_config_distributions query fails', async () => {
       mockAdmin()
       buildTableMocks({ distributionsError: { message: 'distributions DB error' } })
 
-      await expect(getExamConfigData()).rejects.toThrow('distributions DB error')
+      await expect(getExamConfigData()).rejects.toThrow('Failed to load exam configuration')
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[getExamConfigData] DB error:',
+        'distributions DB error',
+      )
     })
 
-    it('throws when the question counts RPC fails', async () => {
+    it('throws a sanitized message when the question counts RPC fails', async () => {
       mockAdmin()
       buildTableMocks({ questionCountsError: { message: 'question counts RPC error' } })
 
-      await expect(getExamConfigData()).rejects.toThrow('question counts RPC error')
+      await expect(getExamConfigData()).rejects.toThrow('Failed to load exam configuration')
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[getExamConfigData] DB error:',
+        'question counts RPC error',
+      )
     })
   })
 

--- a/apps/web/app/app/admin/exam-config/queries.test.ts
+++ b/apps/web/app/app/admin/exam-config/queries.test.ts
@@ -151,6 +151,7 @@ describe('getExamConfigData', () => {
 
       const result = await getExamConfigData()
 
+      expect(mockRpc).toHaveBeenCalledWith('get_question_counts', { p_status: 'active' })
       expect(result).toHaveLength(2)
       expect(result[0]!.id).toBe('sub-1')
       expect(result[1]!.id).toBe('sub-2')

--- a/apps/web/app/app/admin/exam-config/queries.test.ts
+++ b/apps/web/app/app/admin/exam-config/queries.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockRequireAdmin = vi.hoisted(() => vi.fn())
 const mockFrom = vi.hoisted(() => vi.fn())
+const mockRpc = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/auth/require-admin', () => ({ requireAdmin: mockRequireAdmin }))
 
@@ -40,8 +41,16 @@ const DISTRIBUTION_1 = {
   question_count: 20,
 }
 
-const QUESTION_1 = { subject_id: 'sub-1', topic_id: 'top-1', subtopic_id: null }
-const QUESTION_2 = { subject_id: 'sub-1', topic_id: 'top-1', subtopic_id: 'stp-1' }
+// Grouped row shape returned by get_question_counts RPC:
+// { subject_id, topic_id, subtopic_id, n }. Two rows below put top-1 at n=2
+// (1 with null subtopic + 1 with stp-1) and stp-1 at n=1.
+const COUNT_ROW_TOPIC_ONLY = { subject_id: 'sub-1', topic_id: 'top-1', subtopic_id: null, n: 1 }
+const COUNT_ROW_TOPIC_AND_SUBTOPIC = {
+  subject_id: 'sub-1',
+  topic_id: 'top-1',
+  subtopic_id: 'stp-1',
+  n: 1,
+}
 
 type FakeError = { message: string } | null
 
@@ -61,8 +70,8 @@ function buildTableMocks({
   configsData = [CONFIG_1] as unknown[],
   distributionsError = null,
   distributionsData = [DISTRIBUTION_1] as unknown[],
-  questionsError = null,
-  questionsData = [QUESTION_1, QUESTION_2] as unknown[],
+  questionCountsError = null,
+  questionCountsData = [COUNT_ROW_TOPIC_ONLY, COUNT_ROW_TOPIC_AND_SUBTOPIC] as unknown[],
 }: {
   subjectsError?: FakeError
   subjectsData?: unknown[]
@@ -74,8 +83,8 @@ function buildTableMocks({
   configsData?: unknown[]
   distributionsError?: FakeError
   distributionsData?: unknown[]
-  questionsError?: FakeError
-  questionsData?: unknown[]
+  questionCountsError?: FakeError
+  questionCountsData?: unknown[]
 } = {}) {
   // .order() is the terminal for easa_subjects, easa_topics, easa_subtopics
   const makeOrderChain = (data: unknown[], error: FakeError) => ({
@@ -83,7 +92,7 @@ function buildTableMocks({
     order: vi.fn().mockResolvedValue({ data, error }),
   })
 
-  // .is(null) is the last filter for exam_configs and questions; returns a thenable
+  // .is(null) is the last filter for exam_configs; returns a thenable
   const makeFilterChain = (data: unknown[], error: FakeError) => {
     const resolved = { data, error }
     // Make the object itself thenable so Promise.all resolves it
@@ -113,17 +122,17 @@ function buildTableMocks({
         return makeFilterChain(configsData, configsError)
       case 'exam_config_distributions':
         return makeSelectChain(distributionsData, distributionsError)
-      case 'questions':
-        return makeFilterChain(questionsData, questionsError)
       default:
         throw new Error(`Unexpected table in test: ${table}`)
     }
   })
+
+  mockRpc.mockResolvedValue({ data: questionCountsData, error: questionCountsError })
 }
 
 function mockAdmin() {
   mockRequireAdmin.mockResolvedValue({
-    supabase: { from: mockFrom },
+    supabase: { from: mockFrom, rpc: mockRpc },
     organizationId: ORG_ID,
   })
 }
@@ -243,10 +252,12 @@ describe('getExamConfigData', () => {
   })
 
   describe('question counting', () => {
-    it('sets availableQuestions on topics from question rows', async () => {
+    it('sums n into topic availableQuestions across grouped rows', async () => {
       mockAdmin()
-      // QUESTION_1 and QUESTION_2 both belong to topic top-1
-      buildTableMocks({ questionsData: [QUESTION_1, QUESTION_2] })
+      // top-1 appears in two rows: n=1 (no subtopic) + n=1 (with stp-1) → total 2
+      buildTableMocks({
+        questionCountsData: [COUNT_ROW_TOPIC_ONLY, COUNT_ROW_TOPIC_AND_SUBTOPIC],
+      })
 
       const result = await getExamConfigData()
       const topic1 = result[0]!.topics[0]!
@@ -254,10 +265,11 @@ describe('getExamConfigData', () => {
       expect(topic1.availableQuestions).toBe(2)
     })
 
-    it('sets availableQuestions on subtopics from question rows', async () => {
+    it('sums n into subtopic availableQuestions from rows where subtopic_id is set', async () => {
       mockAdmin()
-      // QUESTION_2 has subtopic_id = stp-1
-      buildTableMocks({ questionsData: [QUESTION_1, QUESTION_2] })
+      buildTableMocks({
+        questionCountsData: [COUNT_ROW_TOPIC_ONLY, COUNT_ROW_TOPIC_AND_SUBTOPIC],
+      })
 
       const result = await getExamConfigData()
       const subtopic1 = result[0]!.topics[0]!.subtopics[0]!
@@ -265,9 +277,9 @@ describe('getExamConfigData', () => {
       expect(subtopic1.availableQuestions).toBe(1)
     })
 
-    it('returns zero availableQuestions when no questions match the topic', async () => {
+    it('returns zero availableQuestions when no question count rows match the topic', async () => {
       mockAdmin()
-      buildTableMocks({ questionsData: [] })
+      buildTableMocks({ questionCountsData: [] })
 
       const result = await getExamConfigData()
       const topic1 = result[0]!.topics[0]!
@@ -277,8 +289,9 @@ describe('getExamConfigData', () => {
 
     it('uses topic-level count on a distribution when subtopic_id is null', async () => {
       mockAdmin()
-      // QUESTION_1 maps to top-1 (no subtopic)
-      buildTableMocks({ questionsData: [QUESTION_1, QUESTION_1] })
+      buildTableMocks({
+        questionCountsData: [{ subject_id: 'sub-1', topic_id: 'top-1', subtopic_id: null, n: 2 }],
+      })
 
       const result = await getExamConfigData()
       const dist = result[0]!.config?.distributions[0]
@@ -292,7 +305,9 @@ describe('getExamConfigData', () => {
       const distWithSubtopic = { ...DISTRIBUTION_1, subtopic_id: 'stp-1' }
       buildTableMocks({
         distributionsData: [distWithSubtopic],
-        questionsData: [QUESTION_2, QUESTION_2],
+        questionCountsData: [
+          { subject_id: 'sub-1', topic_id: 'top-1', subtopic_id: 'stp-1', n: 2 },
+        ],
       })
 
       const result = await getExamConfigData()
@@ -300,6 +315,39 @@ describe('getExamConfigData', () => {
 
       // distWithSubtopic has subtopic_id: stp-1 so it reads subtopicCounts
       expect(dist?.availableQuestions).toBe(2)
+    })
+
+    it('reflects full counts across topics totalling more than 1000 questions', async () => {
+      mockAdmin()
+      const topics = Array.from({ length: 5 }, (_, i) => ({
+        id: `top-large-${i}`,
+        subject_id: 'sub-1',
+        code: `TL${i}`,
+        name: `Large Topic ${i}`,
+      }))
+      const countRows = topics.map((t) => ({
+        subject_id: 'sub-1',
+        topic_id: t.id,
+        subtopic_id: null,
+        n: 300,
+      }))
+      buildTableMocks({
+        topicsData: topics,
+        subtopicsData: [],
+        configsData: [],
+        distributionsData: [],
+        questionCountsData: countRows,
+      })
+
+      const result = await getExamConfigData()
+      const subject1 = result[0]!
+
+      expect(subject1.topics).toHaveLength(5)
+      const total = subject1.topics.reduce((sum, t) => sum + t.availableQuestions, 0)
+      expect(total).toBe(1500)
+      for (const t of subject1.topics) {
+        expect(t.availableQuestions).toBe(300)
+      }
     })
   })
 
@@ -390,11 +438,11 @@ describe('getExamConfigData', () => {
       await expect(getExamConfigData()).rejects.toThrow('distributions DB error')
     })
 
-    it('throws when the questions query fails', async () => {
+    it('throws when the question counts RPC fails', async () => {
       mockAdmin()
-      buildTableMocks({ questionsError: { message: 'questions DB error' } })
+      buildTableMocks({ questionCountsError: { message: 'question counts RPC error' } })
 
-      await expect(getExamConfigData()).rejects.toThrow('questions DB error')
+      await expect(getExamConfigData()).rejects.toThrow('question counts RPC error')
     })
   })
 

--- a/apps/web/app/app/admin/exam-config/queries.test.ts
+++ b/apps/web/app/app/admin/exam-config/queries.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks ----------------------------------------------------------------
 
@@ -408,6 +408,10 @@ describe('getExamConfigData', () => {
 
     beforeEach(() => {
       consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore()
     })
 
     it('throws a sanitized message when the subjects query fails', async () => {

--- a/apps/web/app/app/admin/exam-config/queries.ts
+++ b/apps/web/app/app/admin/exam-config/queries.ts
@@ -36,7 +36,10 @@ export async function getExamConfigData(): Promise<SubjectWithConfig[]> {
     distributionsRes,
     questionCountsRes,
   ]) {
-    if (res.error) throw new Error(`[getExamConfigData] ${res.error.message}`)
+    if (res.error) {
+      console.error('[getExamConfigData] DB error:', res.error.message)
+      throw new Error('Failed to load exam configuration')
+    }
   }
 
   const subjects = subjectsRes.data ?? []

--- a/apps/web/app/app/admin/exam-config/queries.ts
+++ b/apps/web/app/app/admin/exam-config/queries.ts
@@ -11,7 +11,7 @@ export async function getExamConfigData(): Promise<SubjectWithConfig[]> {
   const { supabase, organizationId } = await requireAdmin()
 
   // Fetch all data in parallel
-  const [subjectsRes, topicsRes, subtopicsRes, configsRes, distributionsRes, questionsRes] =
+  const [subjectsRes, topicsRes, subtopicsRes, configsRes, distributionsRes, questionCountsRes] =
     await Promise.all([
       supabase.from('easa_subjects').select('id, code, name, short').order('sort_order'),
       supabase.from('easa_topics').select('id, subject_id, code, name').order('sort_order'),
@@ -24,12 +24,7 @@ export async function getExamConfigData(): Promise<SubjectWithConfig[]> {
       supabase
         .from('exam_config_distributions')
         .select('id, exam_config_id, topic_id, subtopic_id, question_count'),
-      supabase
-        .from('questions')
-        .select('subject_id, topic_id, subtopic_id')
-        .eq('organization_id', organizationId)
-        .eq('status', 'active')
-        .is('deleted_at', null),
+      supabase.rpc('get_question_counts', { p_status: 'active' }),
     ])
 
   // Throw on any query error so the Suspense error boundary catches it
@@ -39,7 +34,7 @@ export async function getExamConfigData(): Promise<SubjectWithConfig[]> {
     subtopicsRes,
     configsRes,
     distributionsRes,
-    questionsRes,
+    questionCountsRes,
   ]) {
     if (res.error) throw new Error(`[getExamConfigData] ${res.error.message}`)
   }
@@ -50,15 +45,16 @@ export async function getExamConfigData(): Promise<SubjectWithConfig[]> {
   const configs = configsRes.data ?? []
   // Distributions are org-scoped via RLS on parent exam_configs
   const distributions = distributionsRes.data ?? []
-  const questions = questionsRes.data ?? []
+  const questionCounts = questionCountsRes.data ?? []
 
-  // Count questions per topic/subtopic
+  // Sum question counts per topic/subtopic. Each topic appears once per subtopic
+  // in the grouped result, so we must sum n, not assign.
   const topicCounts = new Map<string, number>()
   const subtopicCounts = new Map<string, number>()
-  for (const q of questions) {
-    if (q.topic_id) topicCounts.set(q.topic_id, (topicCounts.get(q.topic_id) ?? 0) + 1)
-    if (q.subtopic_id)
-      subtopicCounts.set(q.subtopic_id, (subtopicCounts.get(q.subtopic_id) ?? 0) + 1)
+  for (const row of questionCounts) {
+    if (row.topic_id) topicCounts.set(row.topic_id, (topicCounts.get(row.topic_id) ?? 0) + row.n)
+    if (row.subtopic_id)
+      subtopicCounts.set(row.subtopic_id, (subtopicCounts.get(row.subtopic_id) ?? 0) + row.n)
   }
 
   // Build config map

--- a/apps/web/app/app/admin/internal-exams/queries.test.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.test.ts
@@ -406,14 +406,18 @@ describe('listInternalExamCodes', () => {
   describe('error propagation', () => {
     it('throws a sanitized message and logs the raw error when the codes query fails', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      mockAdmin()
-      mockAdminFrom.mockReturnValue(buildChain(null, { message: 'codes DB error' }))
+      try {
+        mockAdmin()
+        mockAdminFrom.mockReturnValue(buildChain(null, { message: 'codes DB error' }))
 
-      await expect(listInternalExamCodes()).rejects.toThrow('Failed to load internal exam codes')
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[listInternalExamCodes] DB error:',
-        'codes DB error',
-      )
+        await expect(listInternalExamCodes()).rejects.toThrow('Failed to load internal exam codes')
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[listInternalExamCodes] DB error:',
+          'codes DB error',
+        )
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
     })
   })
 
@@ -569,16 +573,20 @@ describe('listInternalExamAttempts', () => {
   describe('error propagation', () => {
     it('throws a sanitized message and logs the raw error when the attempts query fails', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      mockAdmin()
-      mockAdminFrom.mockReturnValue(buildChain(null, { message: 'attempts DB error' }))
+      try {
+        mockAdmin()
+        mockAdminFrom.mockReturnValue(buildChain(null, { message: 'attempts DB error' }))
 
-      await expect(listInternalExamAttempts()).rejects.toThrow(
-        'Failed to load internal exam attempts',
-      )
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[listInternalExamAttempts] DB error:',
-        'attempts DB error',
-      )
+        await expect(listInternalExamAttempts()).rejects.toThrow(
+          'Failed to load internal exam attempts',
+        )
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[listInternalExamAttempts] DB error:',
+          'attempts DB error',
+        )
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
     })
   })
 

--- a/apps/web/app/app/admin/internal-exams/queries.test.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.test.ts
@@ -404,11 +404,16 @@ describe('listInternalExamCodes', () => {
   })
 
   describe('error propagation', () => {
-    it('throws when the codes query returns an error', async () => {
+    it('throws a sanitized message and logs the raw error when the codes query fails', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       mockAdmin()
       mockAdminFrom.mockReturnValue(buildChain(null, { message: 'codes DB error' }))
 
-      await expect(listInternalExamCodes()).rejects.toThrow('codes DB error')
+      await expect(listInternalExamCodes()).rejects.toThrow('Failed to load internal exam codes')
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[listInternalExamCodes] DB error:',
+        'codes DB error',
+      )
     })
   })
 
@@ -562,11 +567,18 @@ describe('listInternalExamAttempts', () => {
   })
 
   describe('error propagation', () => {
-    it('throws when the attempts query returns an error', async () => {
+    it('throws a sanitized message and logs the raw error when the attempts query fails', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       mockAdmin()
       mockAdminFrom.mockReturnValue(buildChain(null, { message: 'attempts DB error' }))
 
-      await expect(listInternalExamAttempts()).rejects.toThrow('attempts DB error')
+      await expect(listInternalExamAttempts()).rejects.toThrow(
+        'Failed to load internal exam attempts',
+      )
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[listInternalExamAttempts] DB error:',
+        'attempts DB error',
+      )
     })
   })
 

--- a/apps/web/app/app/admin/internal-exams/queries.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.ts
@@ -126,7 +126,10 @@ export async function listInternalExamCodes(
     data: unknown
     error: { message: string } | null
   }>)) ?? { data: null, error: null }
-  if (error) throw new Error(`[listInternalExamCodes] ${error.message}`)
+  if (error) {
+    console.error('[listInternalExamCodes] DB error:', error.message)
+    throw new Error('Failed to load internal exam codes')
+  }
   const raw = Array.isArray(data) ? (data as CodeRowRaw[]) : []
 
   let mapped: InternalExamCodeRow[] = raw.map((r) => ({
@@ -205,7 +208,10 @@ export async function listInternalExamAttempts(
     data: unknown
     error: { message: string } | null
   }>)) ?? { data: null, error: null }
-  if (error) throw new Error(`[listInternalExamAttempts] ${error.message}`)
+  if (error) {
+    console.error('[listInternalExamAttempts] DB error:', error.message)
+    throw new Error('Failed to load internal exam attempts')
+  }
   const raw = Array.isArray(data) ? (data as AttemptRowRaw[]) : []
 
   let mapped: InternalExamAttemptRow[] = raw.map((r) => ({

--- a/apps/web/app/app/admin/syllabus/queries.test.ts
+++ b/apps/web/app/app/admin/syllabus/queries.test.ts
@@ -78,6 +78,7 @@ describe('getSyllabusTree', () => {
 
     const tree = await getSyllabusTree()
 
+    expect(mockRpc).toHaveBeenCalledWith('get_question_counts')
     expect(tree).toHaveLength(1)
     // Length asserted above — safe to access [0]
     const subject = tree[0]!

--- a/apps/web/app/app/admin/syllabus/queries.test.ts
+++ b/apps/web/app/app/admin/syllabus/queries.test.ts
@@ -165,6 +165,30 @@ describe('getSyllabusTree', () => {
     expect(tree).toEqual([])
   })
 
+  it('throws a sanitized message and logs the raw DB error when a query fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // subjects query returns an error; the other three are healthy
+    const errorChain = {
+      select: vi.fn(),
+      order: vi.fn().mockResolvedValue({ data: null, error: { message: 'connection refused' } }),
+    }
+    errorChain.select.mockReturnValue(errorChain)
+
+    mockFrom
+      .mockReturnValueOnce(errorChain)
+      .mockReturnValueOnce(makeOrderedChain([]))
+      .mockReturnValueOnce(makeOrderedChain([]))
+    mockRpc.mockResolvedValue({ data: [], error: null })
+    mockCreateServerSupabaseClient.mockResolvedValue({ from: mockFrom, rpc: mockRpc })
+
+    await expect(getSyllabusTree()).rejects.toThrow('Failed to load syllabus tree')
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[getSyllabusTree] DB error:',
+      'connection refused',
+    )
+  })
+
   it('reflects the full question count when the bank exceeds the PostgREST 1000-row cap', async () => {
     const subjects = [
       { id: 's1', code: '010', name: 'Air Law', short: 'AL', sort_order: 1 },

--- a/apps/web/app/app/admin/syllabus/queries.test.ts
+++ b/apps/web/app/app/admin/syllabus/queries.test.ts
@@ -167,26 +167,29 @@ describe('getSyllabusTree', () => {
 
   it('throws a sanitized message and logs the raw DB error when a query fails', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      // subjects query returns an error; the other three are healthy
+      const errorChain = {
+        select: vi.fn(),
+        order: vi.fn().mockResolvedValue({ data: null, error: { message: 'connection refused' } }),
+      }
+      errorChain.select.mockReturnValue(errorChain)
 
-    // subjects query returns an error; the other three are healthy
-    const errorChain = {
-      select: vi.fn(),
-      order: vi.fn().mockResolvedValue({ data: null, error: { message: 'connection refused' } }),
+      mockFrom
+        .mockReturnValueOnce(errorChain)
+        .mockReturnValueOnce(makeOrderedChain([]))
+        .mockReturnValueOnce(makeOrderedChain([]))
+      mockRpc.mockResolvedValue({ data: [], error: null })
+      mockCreateServerSupabaseClient.mockResolvedValue({ from: mockFrom, rpc: mockRpc })
+
+      await expect(getSyllabusTree()).rejects.toThrow('Failed to load syllabus tree')
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[getSyllabusTree] DB error:',
+        'connection refused',
+      )
+    } finally {
+      consoleErrorSpy.mockRestore()
     }
-    errorChain.select.mockReturnValue(errorChain)
-
-    mockFrom
-      .mockReturnValueOnce(errorChain)
-      .mockReturnValueOnce(makeOrderedChain([]))
-      .mockReturnValueOnce(makeOrderedChain([]))
-    mockRpc.mockResolvedValue({ data: [], error: null })
-    mockCreateServerSupabaseClient.mockResolvedValue({ from: mockFrom, rpc: mockRpc })
-
-    await expect(getSyllabusTree()).rejects.toThrow('Failed to load syllabus tree')
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      '[getSyllabusTree] DB error:',
-      'connection refused',
-    )
   })
 
   it('reflects the full question count when the bank exceeds the PostgREST 1000-row cap', async () => {

--- a/apps/web/app/app/admin/syllabus/queries.test.ts
+++ b/apps/web/app/app/admin/syllabus/queries.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // ---- Mocks ----------------------------------------------------------------
 
 const mockFrom = vi.hoisted(() => vi.fn())
+const mockRpc = vi.hoisted(() => vi.fn())
 const mockCreateServerSupabaseClient = vi.hoisted(() => vi.fn())
 
 vi.mock('@repo/db/server', () => ({
@@ -29,31 +30,21 @@ function makeOrderedChain(data: unknown[]) {
 }
 
 /**
- * For the questions query which ends in .select('subject_id, topic_id, subtopic_id')
- * with no subsequent .order() call — select() is the thenable leaf.
- */
-function makeSelectOnlyChain(data: unknown[]) {
-  return {
-    select: vi.fn().mockResolvedValue({ data, error: null }),
-  }
-}
-
-/**
  * Mock all four DB calls for a full tree fetch.
- * subjects/topics/subtopics use ordered chains; questions uses select-only chain.
+ * subjects/topics/subtopics use ordered chains; question counts come from the RPC.
  */
 function mockAllFrom(
   subjects: unknown[],
   topics: unknown[],
   subtopics: unknown[],
-  questions: unknown[],
+  countRows: unknown[],
 ) {
   mockFrom
     .mockReturnValueOnce(makeOrderedChain(subjects))
     .mockReturnValueOnce(makeOrderedChain(topics))
     .mockReturnValueOnce(makeOrderedChain(subtopics))
-    .mockReturnValueOnce(makeSelectOnlyChain(questions))
-  mockCreateServerSupabaseClient.mockResolvedValue({ from: mockFrom })
+  mockRpc.mockResolvedValue({ data: countRows, error: null })
+  mockCreateServerSupabaseClient.mockResolvedValue({ from: mockFrom, rpc: mockRpc })
 }
 
 // ---- Tests ----------------------------------------------------------------
@@ -77,14 +68,13 @@ describe('getSyllabusTree', () => {
     const subtopics = [
       { id: 'st1', topic_id: 't1', code: '010-01-01', name: 'Aims', sort_order: 1 },
     ]
-    // 2 questions with full refs (subject + topic + subtopic), 1 with only subject ref
-    const questions = [
-      { subject_id: 's1', topic_id: 't1', subtopic_id: 'st1' },
-      { subject_id: 's1', topic_id: 't1', subtopic_id: 'st1' },
-      { subject_id: 's1', topic_id: null, subtopic_id: null },
+    // 2 questions grouped at (s1, t1, st1) + 1 question with only a subject ref
+    const countRows = [
+      { subject_id: 's1', topic_id: 't1', subtopic_id: 'st1', n: 2 },
+      { subject_id: 's1', topic_id: null, subtopic_id: null, n: 1 },
     ]
 
-    mockAllFrom(subjects, topics, subtopics, questions)
+    mockAllFrom(subjects, topics, subtopics, countRows)
 
     const tree = await getSyllabusTree()
 
@@ -161,19 +151,46 @@ describe('getSyllabusTree', () => {
       chain.select.mockReturnValue(chain)
       return chain
     }
-    const makeNullSelectOnlyChain = () => ({
-      select: vi.fn().mockResolvedValue({ data: null, error: null }),
-    })
 
     mockFrom
       .mockReturnValueOnce(makeNullOrderedChain())
       .mockReturnValueOnce(makeNullOrderedChain())
       .mockReturnValueOnce(makeNullOrderedChain())
-      .mockReturnValueOnce(makeNullSelectOnlyChain())
-    mockCreateServerSupabaseClient.mockResolvedValue({ from: mockFrom })
+    mockRpc.mockResolvedValue({ data: null, error: null })
+    mockCreateServerSupabaseClient.mockResolvedValue({ from: mockFrom, rpc: mockRpc })
 
     const tree = await getSyllabusTree()
 
     expect(tree).toEqual([])
+  })
+
+  it('reflects the full question count when the bank exceeds the PostgREST 1000-row cap', async () => {
+    const subjects = [
+      { id: 's1', code: '010', name: 'Air Law', short: 'AL', sort_order: 1 },
+      { id: 's2', code: '020', name: 'Aircraft', short: 'AC', sort_order: 2 },
+    ]
+    const topics = [
+      { id: 't1', subject_id: 's1', code: '010-01', name: 'ICAO', sort_order: 1 },
+      { id: 't2', subject_id: 's2', code: '020-01', name: 'Airframe', sort_order: 1 },
+    ]
+    const subtopics = [
+      { id: 'st1', topic_id: 't1', code: '010-01-01', name: 'Aims', sort_order: 1 },
+      { id: 'st2', topic_id: 't2', code: '020-01-01', name: 'Frame', sort_order: 1 },
+    ]
+    const countRows = [
+      { subject_id: 's1', topic_id: 't1', subtopic_id: 'st1', n: 800 },
+      { subject_id: 's2', topic_id: 't2', subtopic_id: 'st2', n: 900 },
+    ]
+
+    mockAllFrom(subjects, topics, subtopics, countRows)
+
+    const tree = await getSyllabusTree()
+
+    expect(tree[0]!.questionCount).toBe(800)
+    expect(tree[0]!.topics[0]!.questionCount).toBe(800)
+    expect(tree[0]!.topics[0]!.subtopics[0]!.questionCount).toBe(800)
+    expect(tree[1]!.questionCount).toBe(900)
+    expect(tree[1]!.topics[0]!.questionCount).toBe(900)
+    expect(tree[1]!.topics[0]!.subtopics[0]!.questionCount).toBe(900)
   })
 })

--- a/apps/web/app/app/admin/syllabus/queries.ts
+++ b/apps/web/app/app/admin/syllabus/queries.ts
@@ -4,10 +4,11 @@ import type { SyllabusSubject, SyllabusTree } from './types'
 type SubjectRow = { id: string; code: string; name: string; short: string; sort_order: number }
 type TopicRow = { id: string; subject_id: string; code: string; name: string; sort_order: number }
 type SubtopicRow = { id: string; topic_id: string; code: string; name: string; sort_order: number }
-type QuestionRef = {
+type QuestionCountRow = {
   subject_id: string | null
   topic_id: string | null
   subtopic_id: string | null
+  n: number
 }
 
 export async function getSyllabusTree(): Promise<SyllabusTree> {
@@ -17,28 +18,28 @@ export async function getSyllabusTree(): Promise<SyllabusTree> {
     supabase.from('easa_subjects').select('*').order('sort_order'),
     supabase.from('easa_topics').select('*').order('sort_order'),
     supabase.from('easa_subtopics').select('*').order('sort_order'),
-    supabase.from('questions').select('subject_id, topic_id, subtopic_id'),
+    supabase.rpc('get_question_counts'),
   ])
 
   const subjects = (subjectsRes.data ?? []) as SubjectRow[]
   const topics = (topicsRes.data ?? []) as TopicRow[]
   const subtopics = (subtopicsRes.data ?? []) as SubtopicRow[]
-  const questions = (countsRes.data ?? []) as QuestionRef[]
+  const countRows = (countsRes.data ?? []) as QuestionCountRow[]
 
-  // Count questions per subject/topic/subtopic
+  // Sum question counts per subject/topic/subtopic (each row contributes to all three levels)
   const subjectCounts = new Map<string, number>()
   const topicCounts = new Map<string, number>()
   const subtopicCounts = new Map<string, number>()
 
-  for (const q of questions) {
-    if (q.subject_id) {
-      subjectCounts.set(q.subject_id, (subjectCounts.get(q.subject_id) ?? 0) + 1)
+  for (const row of countRows) {
+    if (row.subject_id) {
+      subjectCounts.set(row.subject_id, (subjectCounts.get(row.subject_id) ?? 0) + row.n)
     }
-    if (q.topic_id) {
-      topicCounts.set(q.topic_id, (topicCounts.get(q.topic_id) ?? 0) + 1)
+    if (row.topic_id) {
+      topicCounts.set(row.topic_id, (topicCounts.get(row.topic_id) ?? 0) + row.n)
     }
-    if (q.subtopic_id) {
-      subtopicCounts.set(q.subtopic_id, (subtopicCounts.get(q.subtopic_id) ?? 0) + 1)
+    if (row.subtopic_id) {
+      subtopicCounts.set(row.subtopic_id, (subtopicCounts.get(row.subtopic_id) ?? 0) + row.n)
     }
   }
 

--- a/apps/web/app/app/admin/syllabus/queries.ts
+++ b/apps/web/app/app/admin/syllabus/queries.ts
@@ -21,6 +21,13 @@ export async function getSyllabusTree(): Promise<SyllabusTree> {
     supabase.rpc('get_question_counts'),
   ])
 
+  for (const res of [subjectsRes, topicsRes, subtopicsRes, countsRes]) {
+    if (res.error) {
+      console.error('[getSyllabusTree] DB error:', res.error.message)
+      throw new Error('Failed to load syllabus tree')
+    }
+  }
+
   const subjects = (subjectsRes.data ?? []) as SubjectRow[]
   const topics = (topicsRes.data ?? []) as TopicRow[]
   const subtopics = (subtopicsRes.data ?? []) as SubtopicRow[]

--- a/apps/web/app/app/admin/syllabus/queries.ts
+++ b/apps/web/app/app/admin/syllabus/queries.ts
@@ -4,12 +4,6 @@ import type { SyllabusSubject, SyllabusTree } from './types'
 type SubjectRow = { id: string; code: string; name: string; short: string; sort_order: number }
 type TopicRow = { id: string; subject_id: string; code: string; name: string; sort_order: number }
 type SubtopicRow = { id: string; topic_id: string; code: string; name: string; sort_order: number }
-type QuestionCountRow = {
-  subject_id: string | null
-  topic_id: string | null
-  subtopic_id: string | null
-  n: number
-}
 
 export async function getSyllabusTree(): Promise<SyllabusTree> {
   const supabase = await createServerSupabaseClient()
@@ -31,7 +25,7 @@ export async function getSyllabusTree(): Promise<SyllabusTree> {
   const subjects = (subjectsRes.data ?? []) as SubjectRow[]
   const topics = (topicsRes.data ?? []) as TopicRow[]
   const subtopics = (subtopicsRes.data ?? []) as SubtopicRow[]
-  const countRows = (countsRes.data ?? []) as QuestionCountRow[]
+  const countRows = countsRes.data ?? []
 
   // Sum question counts per subject/topic/subtopic (each row contributes to all three levels)
   const subjectCounts = new Map<string, number>()

--- a/docs/database.md
+++ b/docs/database.md
@@ -650,6 +650,7 @@ verb_noun pattern:
   get_student_progress       ← read, aggregated progress view
   get_daily_activity         ← read, analytics: daily answer counts (zero-filled)
   get_subject_scores         ← read, analytics: avg scores by subject
+  get_question_counts        ← read, per-(subject, topic, subtopic) question counts; replaces client-side counting that truncated at the PostgREST 1000-row cap (#614)
 ```
 
 ### Security Model
@@ -1940,6 +1941,26 @@ Returns paginated session reports for the authenticated student with subject nam
 **Returns:** `TABLE(id UUID, mode TEXT, total_questions INT, correct_count INT, score_percentage NUMERIC, started_at TIMESTAMPTZ, ended_at TIMESTAMPTZ, subject_id UUID, subject_name TEXT, answered_count BIGINT, total_count BIGINT)`
 
 **Migration:** `20260410000010_get_session_reports_rpc.sql`
+
+---
+
+#### `get_question_counts` — per-(subject, topic, subtopic) question counts
+
+Returns aggregated question counts grouped by `(subject_id, topic_id, subtopic_id)`. Used by the admin exam-config and syllabus pages to show available-question totals per node without paging through the full question bank.
+
+**Security:** `SECURITY INVOKER` (caller-context). RLS scopes the result to the caller's organisation via the existing `tenant_isolation` policy on `questions` — no manual `auth.uid()` check needed.
+
+**Parameters:** `p_status TEXT DEFAULT NULL`
+- `NULL` — count all non-deleted questions (active + draft); used by `admin/syllabus/queries.ts`.
+- `'active'` — count only active questions; used by `admin/exam-config/queries.ts` (drafts are not eligible for exams).
+
+**Returns:** `TABLE(subject_id UUID, topic_id UUID, subtopic_id UUID, n BIGINT)`
+
+**Filters:** `deleted_at IS NULL` always; `status = p_status` when `p_status` is non-NULL.
+
+**Migration:** `20260520000001_get_question_counts_rpc.sql`
+
+**Rationale:** Replaces client-side counting that silently truncated at the PostgREST 1000-row cap once the question bank crossed 1000 rows (#614).
 
 ---
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1948,7 +1948,7 @@ Returns paginated session reports for the authenticated student with subject nam
 
 Returns aggregated question counts grouped by `(subject_id, topic_id, subtopic_id)`. Used by the admin exam-config and syllabus pages to show available-question totals per node without paging through the full question bank.
 
-**Security:** `SECURITY INVOKER` (caller-context). RLS scopes the result to the caller's organisation via the existing `tenant_isolation` policy on `questions` — no manual `auth.uid()` check needed.
+**Security:** `SECURITY INVOKER` (caller-context). RLS scopes the result to the caller's organization via the existing `tenant_isolation` policy on `questions` — no manual `auth.uid()` check needed.
 
 **Parameters:** `p_status TEXT DEFAULT NULL`
 - `NULL` — count all non-deleted questions (active + draft); used by `admin/syllabus/queries.ts`.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "pnpm": {
     "overrides": {
       "undici": ">=7.24.0 <8",
-      "zod": "^4.4.3"
+      "zod": "^4.4.3",
+      "next": ">=16.2.6",
+      "fast-uri": ">=3.1.2"
     }
   },
   "packageManager": "pnpm@9.15.0",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "overrides": {
       "undici": ">=7.24.0 <8",
       "zod": "^4.4.3",
-      "next": ">=16.2.6",
-      "fast-uri": ">=3.1.2"
+      "next": ">=16.2.6 <17",
+      "fast-uri": ">=3.1.2 <4"
     }
   },
   "packageManager": "pnpm@9.15.0",

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,11 +1,12 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: '14.1'
-  }
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -72,18 +73,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'audit_events_actor_id_fkey'
-            columns: ['actor_id']
+            foreignKeyName: "audit_events_actor_id_fkey"
+            columns: ["actor_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'audit_events_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "audit_events_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -126,25 +127,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'courses_created_by_fkey'
-            columns: ['created_by']
+            foreignKeyName: "courses_created_by_fkey"
+            columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'courses_deleted_by_fkey'
-            columns: ['deleted_by']
+            foreignKeyName: "courses_deleted_by_fkey"
+            columns: ["deleted_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'courses_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "courses_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -196,11 +197,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'easa_subtopics_topic_id_fkey'
-            columns: ['topic_id']
+            foreignKeyName: "easa_subtopics_topic_id_fkey"
+            columns: ["topic_id"]
             isOneToOne: false
-            referencedRelation: 'easa_topics'
-            referencedColumns: ['id']
+            referencedRelation: "easa_topics"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -228,11 +229,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'easa_topics_subject_id_fkey'
-            columns: ['subject_id']
+            foreignKeyName: "easa_topics_subject_id_fkey"
+            columns: ["subject_id"]
             isOneToOne: false
-            referencedRelation: 'easa_subjects'
-            referencedColumns: ['id']
+            referencedRelation: "easa_subjects"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -260,25 +261,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'exam_config_distributions_exam_config_id_fkey'
-            columns: ['exam_config_id']
+            foreignKeyName: "exam_config_distributions_exam_config_id_fkey"
+            columns: ["exam_config_id"]
             isOneToOne: false
-            referencedRelation: 'exam_configs'
-            referencedColumns: ['id']
+            referencedRelation: "exam_configs"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'exam_config_distributions_subtopic_id_fkey'
-            columns: ['subtopic_id']
+            foreignKeyName: "exam_config_distributions_subtopic_id_fkey"
+            columns: ["subtopic_id"]
             isOneToOne: false
-            referencedRelation: 'easa_subtopics'
-            referencedColumns: ['id']
+            referencedRelation: "easa_subtopics"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'exam_config_distributions_topic_id_fkey'
-            columns: ['topic_id']
+            foreignKeyName: "exam_config_distributions_topic_id_fkey"
+            columns: ["topic_id"]
             isOneToOne: false
-            referencedRelation: 'easa_topics'
-            referencedColumns: ['id']
+            referencedRelation: "easa_topics"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -321,18 +322,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'exam_configs_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "exam_configs_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'exam_configs_subject_id_fkey'
-            columns: ['subject_id']
+            foreignKeyName: "exam_configs_subject_id_fkey"
+            columns: ["subject_id"]
             isOneToOne: false
-            referencedRelation: 'easa_subjects'
-            referencedColumns: ['id']
+            referencedRelation: "easa_subjects"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -357,18 +358,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'flagged_questions_question_id_fkey'
-            columns: ['question_id']
+            foreignKeyName: "flagged_questions_question_id_fkey"
+            columns: ["question_id"]
             isOneToOne: false
-            referencedRelation: 'questions'
-            referencedColumns: ['id']
+            referencedRelation: "questions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'flagged_questions_student_id_fkey'
-            columns: ['student_id']
+            foreignKeyName: "flagged_questions_student_id_fkey"
+            columns: ["student_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -381,7 +382,7 @@ export type Database = {
           id: string
           lapses: number
           last_review: string | null
-          last_was_correct: boolean
+          last_was_correct: boolean | null
           question_id: string
           reps: number
           scheduled_days: number
@@ -398,7 +399,7 @@ export type Database = {
           id?: string
           lapses?: number
           last_review?: string | null
-          last_was_correct?: boolean
+          last_was_correct?: boolean | null
           question_id: string
           reps?: number
           scheduled_days?: number
@@ -415,7 +416,7 @@ export type Database = {
           id?: string
           lapses?: number
           last_review?: string | null
-          last_was_correct?: boolean
+          last_was_correct?: boolean | null
           question_id?: string
           reps?: number
           scheduled_days?: number
@@ -426,18 +427,112 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'fsrs_cards_question_id_fkey'
-            columns: ['question_id']
+            foreignKeyName: "fsrs_cards_question_id_fkey"
+            columns: ["question_id"]
             isOneToOne: false
-            referencedRelation: 'questions'
-            referencedColumns: ['id']
+            referencedRelation: "questions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'fsrs_cards_student_id_fkey'
-            columns: ['student_id']
+            foreignKeyName: "fsrs_cards_student_id_fkey"
+            columns: ["student_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      internal_exam_codes: {
+        Row: {
+          code: string
+          consumed_at: string | null
+          consumed_session_id: string | null
+          deleted_at: string | null
+          expires_at: string
+          id: string
+          issued_at: string
+          issued_by: string
+          organization_id: string
+          student_id: string
+          subject_id: string
+          void_reason: string | null
+          voided_at: string | null
+          voided_by: string | null
+        }
+        Insert: {
+          code: string
+          consumed_at?: string | null
+          consumed_session_id?: string | null
+          deleted_at?: string | null
+          expires_at: string
+          id?: string
+          issued_at?: string
+          issued_by: string
+          organization_id: string
+          student_id: string
+          subject_id: string
+          void_reason?: string | null
+          voided_at?: string | null
+          voided_by?: string | null
+        }
+        Update: {
+          code?: string
+          consumed_at?: string | null
+          consumed_session_id?: string | null
+          deleted_at?: string | null
+          expires_at?: string
+          id?: string
+          issued_at?: string
+          issued_by?: string
+          organization_id?: string
+          student_id?: string
+          subject_id?: string
+          void_reason?: string | null
+          voided_at?: string | null
+          voided_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "internal_exam_codes_consumed_session_id_fkey"
+            columns: ["consumed_session_id"]
+            isOneToOne: false
+            referencedRelation: "quiz_sessions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "internal_exam_codes_issued_by_fkey"
+            columns: ["issued_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "internal_exam_codes_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "internal_exam_codes_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "internal_exam_codes_subject_id_fkey"
+            columns: ["subject_id"]
+            isOneToOne: false
+            referencedRelation: "easa_subjects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "internal_exam_codes_voided_by_fkey"
+            columns: ["voided_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -498,32 +593,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'lessons_course_id_fkey'
-            columns: ['course_id']
+            foreignKeyName: "lessons_course_id_fkey"
+            columns: ["course_id"]
             isOneToOne: false
-            referencedRelation: 'courses'
-            referencedColumns: ['id']
+            referencedRelation: "courses"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'lessons_created_by_fkey'
-            columns: ['created_by']
+            foreignKeyName: "lessons_created_by_fkey"
+            columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'lessons_deleted_by_fkey'
-            columns: ['deleted_by']
+            foreignKeyName: "lessons_deleted_by_fkey"
+            columns: ["deleted_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'lessons_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "lessons_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -557,11 +652,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'fk_organizations_deleted_by'
-            columns: ['deleted_by']
+            foreignKeyName: "fk_organizations_deleted_by"
+            columns: ["deleted_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -598,25 +693,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'question_banks_created_by_fkey'
-            columns: ['created_by']
+            foreignKeyName: "question_banks_created_by_fkey"
+            columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'question_banks_deleted_by_fkey'
-            columns: ['deleted_by']
+            foreignKeyName: "question_banks_deleted_by_fkey"
+            columns: ["deleted_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'question_banks_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "question_banks_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: true
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -647,18 +742,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'question_comments_question_id_fkey'
-            columns: ['question_id']
+            foreignKeyName: "question_comments_question_id_fkey"
+            columns: ["question_id"]
             isOneToOne: false
-            referencedRelation: 'questions'
-            referencedColumns: ['id']
+            referencedRelation: "questions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'question_comments_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "question_comments_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -734,53 +829,53 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'questions_bank_id_fkey'
-            columns: ['bank_id']
+            foreignKeyName: "questions_bank_id_fkey"
+            columns: ["bank_id"]
             isOneToOne: false
-            referencedRelation: 'question_banks'
-            referencedColumns: ['id']
+            referencedRelation: "question_banks"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'questions_created_by_fkey'
-            columns: ['created_by']
+            foreignKeyName: "questions_created_by_fkey"
+            columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'questions_deleted_by_fkey'
-            columns: ['deleted_by']
+            foreignKeyName: "questions_deleted_by_fkey"
+            columns: ["deleted_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'questions_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "questions_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'questions_subject_id_fkey'
-            columns: ['subject_id']
+            foreignKeyName: "questions_subject_id_fkey"
+            columns: ["subject_id"]
             isOneToOne: false
-            referencedRelation: 'easa_subjects'
-            referencedColumns: ['id']
+            referencedRelation: "easa_subjects"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'questions_subtopic_id_fkey'
-            columns: ['subtopic_id']
+            foreignKeyName: "questions_subtopic_id_fkey"
+            columns: ["subtopic_id"]
             isOneToOne: false
-            referencedRelation: 'easa_subtopics'
-            referencedColumns: ['id']
+            referencedRelation: "easa_subtopics"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'questions_topic_id_fkey'
-            columns: ['topic_id']
+            foreignKeyName: "questions_topic_id_fkey"
+            columns: ["topic_id"]
             isOneToOne: false
-            referencedRelation: 'easa_topics'
-            referencedColumns: ['id']
+            referencedRelation: "easa_topics"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -823,18 +918,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'quiz_drafts_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "quiz_drafts_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'quiz_drafts_student_id_fkey'
-            columns: ['student_id']
+            foreignKeyName: "quiz_drafts_student_id_fkey"
+            columns: ["student_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -868,18 +963,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'quiz_session_answers_question_id_fkey'
-            columns: ['question_id']
+            foreignKeyName: "quiz_session_answers_question_id_fkey"
+            columns: ["question_id"]
             isOneToOne: false
-            referencedRelation: 'questions'
-            referencedColumns: ['id']
+            referencedRelation: "questions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'quiz_session_answers_session_id_fkey'
-            columns: ['session_id']
+            foreignKeyName: "quiz_session_answers_session_id_fkey"
+            columns: ["session_id"]
             isOneToOne: false
-            referencedRelation: 'quiz_sessions'
-            referencedColumns: ['id']
+            referencedRelation: "quiz_sessions"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -940,32 +1035,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'quiz_sessions_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "quiz_sessions_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'quiz_sessions_student_id_fkey'
-            columns: ['student_id']
+            foreignKeyName: "quiz_sessions_student_id_fkey"
+            columns: ["student_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'quiz_sessions_subject_id_fkey'
-            columns: ['subject_id']
+            foreignKeyName: "quiz_sessions_subject_id_fkey"
+            columns: ["subject_id"]
             isOneToOne: false
-            referencedRelation: 'easa_subjects'
-            referencedColumns: ['id']
+            referencedRelation: "easa_subjects"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'quiz_sessions_topic_id_fkey'
-            columns: ['topic_id']
+            foreignKeyName: "quiz_sessions_topic_id_fkey"
+            columns: ["topic_id"]
             isOneToOne: false
-            referencedRelation: 'easa_topics'
-            referencedColumns: ['id']
+            referencedRelation: "easa_topics"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1005,32 +1100,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'student_responses_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "student_responses_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'student_responses_question_id_fkey'
-            columns: ['question_id']
+            foreignKeyName: "student_responses_question_id_fkey"
+            columns: ["question_id"]
             isOneToOne: false
-            referencedRelation: 'questions'
-            referencedColumns: ['id']
+            referencedRelation: "questions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'student_responses_session_id_fkey'
-            columns: ['session_id']
+            foreignKeyName: "student_responses_session_id_fkey"
+            columns: ["session_id"]
             isOneToOne: false
-            referencedRelation: 'quiz_sessions'
-            referencedColumns: ['id']
+            referencedRelation: "quiz_sessions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'student_responses_student_id_fkey'
-            columns: ['student_id']
+            foreignKeyName: "student_responses_student_id_fkey"
+            columns: ["student_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1067,11 +1162,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'user_consents_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "user_consents_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1111,18 +1206,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'fk_users_deleted_by'
-            columns: ['deleted_by']
+            foreignKeyName: "fk_users_deleted_by"
+            columns: ["deleted_by"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'users_organization_id_fkey'
-            columns: ['organization_id']
+            foreignKeyName: "users_organization_id_fkey"
+            columns: ["organization_id"]
             isOneToOne: false
-            referencedRelation: 'organizations'
-            referencedColumns: ['id']
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1149,18 +1244,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'flagged_questions_question_id_fkey'
-            columns: ['question_id']
+            foreignKeyName: "flagged_questions_question_id_fkey"
+            columns: ["question_id"]
             isOneToOne: false
-            referencedRelation: 'questions'
-            referencedColumns: ['id']
+            referencedRelation: "questions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'flagged_questions_student_id_fkey'
-            columns: ['student_id']
+            foreignKeyName: "flagged_questions_student_id_fkey"
+            columns: ["student_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1183,6 +1278,14 @@ export type Database = {
           p_selected_option_id: string
           p_session_id: string
         }
+        Returns: Json
+      }
+      complete_empty_exam_session: {
+        Args: { p_session_id: string }
+        Returns: Json
+      }
+      complete_overdue_exam_session: {
+        Args: { p_session_id: string }
         Returns: Json
       }
       complete_quiz_session: {
@@ -1231,6 +1334,15 @@ export type Database = {
           day: string
           incorrect: number
           total: number
+        }[]
+      }
+      get_question_counts: {
+        Args: { p_status?: string }
+        Returns: {
+          n: number
+          subject_id: string
+          subtopic_id: string
+          topic_id: string
         }[]
       }
       get_quiz_questions: {
@@ -1289,6 +1401,14 @@ export type Database = {
         }[]
       }
       is_admin: { Args: never; Returns: boolean }
+      issue_internal_exam_code: {
+        Args: { p_student_id: string; p_subject_id: string }
+        Returns: {
+          code: string
+          code_id: string
+          expires_at: string
+        }[]
+      }
       record_consent: {
         Args: {
           p_accepted: boolean
@@ -1301,6 +1421,17 @@ export type Database = {
       }
       record_login: { Args: never; Returns: undefined }
       start_exam_session: { Args: { p_subject_id: string }; Returns: Json }
+      start_internal_exam_session: {
+        Args: { p_code: string }
+        Returns: {
+          pass_mark: number
+          question_ids: string[]
+          session_id: string
+          started_at: string
+          time_limit_seconds: number
+          total_questions: number
+        }[]
+      }
       start_quiz_session: {
         Args: {
           p_mode: string
@@ -1324,6 +1455,25 @@ export type Database = {
           is_correct: boolean
         }[]
       }
+      upsert_exam_config: {
+        Args: {
+          p_distributions: Json
+          p_enabled: boolean
+          p_pass_mark: number
+          p_subject_id: string
+          p_time_limit_seconds: number
+          p_total_questions: number
+        }
+        Returns: string
+      }
+      void_internal_exam_code: {
+        Args: { p_code_id: string; p_reason: string }
+        Returns: {
+          code_id: string
+          session_ended: boolean
+          session_id: string
+        }[]
+      }
     }
     Enums: {
       [_ in never]: never
@@ -1334,31 +1484,33 @@ export type Database = {
   }
 }
 
-type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
-    ? (DefaultSchema['Tables'] & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -1367,23 +1519,23 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -1392,23 +1544,23 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -1417,36 +1569,36 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
 export const Constants = {
@@ -1457,3 +1609,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 overrides:
   undici: '>=7.24.0 <8'
   zod: ^4.4.3
-  next: '>=16.2.6'
-  fast-uri: '>=3.1.2'
+  next: '>=16.2.6 <17'
+  fast-uri: '>=3.1.2 <4'
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   undici: '>=7.24.0 <8'
   zod: ^4.4.3
+  next: '>=16.2.6'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -51,16 +53,16 @@ importers:
         version: link:../../packages/ui
       '@sentry/nextjs':
         specifier: ^10.51.0
-        version: 10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.105.4(esbuild@0.27.4))
+        version: 10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.105.4(esbuild@0.27.4))
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.4)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -71,8 +73,8 @@ importers:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.5)
       next:
-        specifier: 16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: '>=16.2.6'
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -184,8 +186,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
       next:
-        specifier: ^16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: '>=16.2.6'
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1000,53 +1002,53 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.2.4':
-    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
-  '@next/swc-darwin-arm64@16.2.4':
-    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.4':
-    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.4':
-    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.2.4':
-    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.2.4':
-    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.2.4':
-    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.2.4':
-    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.4':
-    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1843,7 +1845,7 @@ packages:
     resolution: {integrity: sha512-Bh3DeieTnbOOfhFEWbT57vgxlCdoTU7+x5or8QLa8VGCmZEekIdt0rGd8exbG1msI4g6SusCiJzbF/8bucmY/A==}
     engines: {node: '>=18'}
     peerDependencies:
-      next: ^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0
+      next: '>=16.2.6'
 
   '@sentry/node-core@10.51.0':
     resolution: {integrity: sha512-VP9DMEzBEuauABrfDHYz/pRYa74M09uRJLz0ls3yel3sKhYHMyCB29ZxbKcciUhD4d33dwgi8DbaPZV2H/wnfQ==}
@@ -2188,13 +2190,14 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/analytics@2.0.1':
     resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
     peerDependencies:
       '@remix-run/react': ^2
       '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
+      next: '>=16.2.6'
       nuxt: '>= 3'
       react: ^18 || ^19 || ^19.0.0-rc
       svelte: '>= 4'
@@ -2222,7 +2225,7 @@ packages:
     resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
     peerDependencies:
       '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
+      next: '>=16.2.6'
       nuxt: '>= 3'
       react: ^18 || ^19 || ^19.0.0-rc
       svelte: '>= 4'
@@ -2895,8 +2898,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -3736,8 +3739,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.4:
-    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5482,30 +5485,30 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@next/env@16.2.4': {}
+  '@next/env@16.2.6': {}
 
-  '@next/swc-darwin-arm64@16.2.4':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.4':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.4':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.4':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.4':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.4':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.4':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.4':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -6166,7 +6169,7 @@ snapshots:
 
   '@sentry/core@10.51.0': {}
 
-  '@sentry/nextjs@10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.105.4(esbuild@0.27.4))':
+  '@sentry/nextjs@10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.105.4(esbuild@0.27.4))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -6179,7 +6182,7 @@ snapshots:
       '@sentry/react': 10.51.0(react@19.2.5)
       '@sentry/vercel-edge': 10.51.0
       '@sentry/webpack-plugin': 5.2.1(webpack@5.105.4(esbuild@0.27.4))
-      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       rollup: 4.60.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -6557,14 +6560,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vercel/analytics@2.0.1(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
-      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  '@vercel/speed-insights@2.0.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
-      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
@@ -6747,7 +6750,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7226,7 +7229,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -8220,9 +8223,9 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 16.2.4
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.24
       caniuse-lite: 1.0.30001791
@@ -8231,14 +8234,14 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.4
-      '@next/swc-darwin-x64': 16.2.4
-      '@next/swc-linux-arm64-gnu': 16.2.4
-      '@next/swc-linux-arm64-musl': 16.2.4
-      '@next/swc-linux-x64-gnu': 16.2.4
-      '@next/swc-linux-x64-musl': 16.2.4
-      '@next/swc-win32-arm64-msvc': 16.2.4
-      '@next/swc-win32-x64-msvc': 16.2.4
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.5)
       next:
-        specifier: '>=16.2.6'
+        specifier: '>=16.2.6 <17'
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6
@@ -186,7 +186,7 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
       next:
-        specifier: '>=16.2.6'
+        specifier: '>=16.2.6 <17'
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       typescript:
         specifier: ^6.0.3

--- a/supabase/migrations/20260520000001_get_question_counts_rpc.sql
+++ b/supabase/migrations/20260520000001_get_question_counts_rpc.sql
@@ -1,0 +1,40 @@
+-- Aggregated question counts per (subject_id, topic_id, subtopic_id).
+--
+-- Replaces client-side counting in admin/exam-config and admin/syllabus pages.
+-- Client fetches were silently truncating at the PostgREST 1000-row cap once
+-- the question bank crossed 1000 rows; see issue #614.
+--
+-- SECURITY INVOKER + RLS scopes the result to the caller's organization via the
+-- existing tenant_isolation policy on `questions`.
+--
+-- p_status:
+--   NULL     -> count all non-deleted questions (active + draft); used by syllabus
+--   'active' -> count only active questions; used by exam-config (drafts are not eligible for exams)
+
+CREATE OR REPLACE FUNCTION public.get_question_counts(p_status text DEFAULT NULL)
+RETURNS TABLE (
+  subject_id uuid,
+  topic_id uuid,
+  subtopic_id uuid,
+  n bigint
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+SET search_path = public
+AS $$
+  SELECT
+    q.subject_id,
+    q.topic_id,
+    q.subtopic_id,
+    COUNT(*)::bigint AS n
+  FROM questions q
+  WHERE q.deleted_at IS NULL
+    AND (p_status IS NULL OR q.status = p_status)
+  GROUP BY q.subject_id, q.topic_id, q.subtopic_id
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_question_counts(text) TO authenticated;
+
+COMMENT ON FUNCTION public.get_question_counts(text) IS
+  'Per-(subject, topic, subtopic) question counts. RLS-scoped to caller org. p_status=''active'' for exam-config (active-only); NULL for syllabus (active+draft). Replaces client-side counting that truncated at the 1000-row cap (#614).';


### PR DESCRIPTION
## Summary

- PostgREST silently caps query results at 1000 rows. Admin **exam-config** and **syllabus** pages counted questions client-side by fetching every row, so once a tenant crossed 1000 questions the counts truncated invisibly.
- Live prod impact (Egmont Aviation, 1366 active questions): OPS topic 060-02 showed `2 available` instead of `176`, blocking exam configuration. AGK 082-* topics also clipped.
- Adds SECURITY INVOKER RPC `get_question_counts(p_status text DEFAULT NULL)` that does `GROUP BY` server-side and returns ~30 aggregate rows. RLS on `questions` scopes the result to the caller's org via the existing `tenant_isolation` policy — no manual `auth.uid()` check needed.
- Closes #614 (the same anti-pattern was filed for the syllabus page).

## Behavior

| Caller | p_status | Result |
|--------|----------|--------|
| `admin/exam-config/queries.ts` | `'active'` | Active-only (drafts can't be used in exams) |
| `admin/syllabus/queries.ts` | `NULL` (default) | Active + draft (admins see authoring progress) |

Both client sites now sum `row.n` into the existing per-(subject/topic/subtopic) maps.

## Notes

- `packages/db/src/types.ts` was regenerated from local; the diff also picks up several pre-existing RPCs that had drifted from the schema (`complete_overdue_exam_session`, `internal_exam_codes`, `upsert_exam_config`, etc.), so existing `.rpc(...)` calls are now correctly typed.
- Pre-commit hook was bypassed on this commit (`--no-verify`, with maintainer authorization) because the dev environment can't run `pnpm install` cleanly (exFAT symlink limitation, documented in MEMORY). CI runs the full type-check on this PR.

## Test plan

- [ ] CI green (type-check, lint, unit tests, e2e)
- [ ] Manual: visit `/app/admin/exam-config` → OPS subject → confirm topic 060-02 shows `176 available`
- [ ] Manual: visit `/app/admin/exam-config` → AGK subject → confirm 082-* topics show their real counts (082-02 = 74, 082-04 = 35, etc.)
- [ ] Manual: visit `/app/admin/syllabus` → AGK total reflects the full bank (311) and OPS shows 179
- [ ] Confirm new regression tests in `exam-config/queries.test.ts` and `syllabus/queries.test.ts` actually exercise the >1000-row path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inaccurate question-count totals in exam configuration and syllabus views (handles large banks and correct topic/subtopic distribution).
  * Internal exam pages now show a sanitized "Failed to load ..." message on backend errors; original errors are logged.

* **Performance**
  * Faster and more reliable loading of exam configuration and syllabus via server-side aggregation of question counts.

* **Documentation**
  * Added docs for the new server-side question-count aggregation RPC.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->