### PR TITLE
fix(rpc): reject NULL p_mode in start_quiz_session whitelist

### DIFF
--- a/apps/web/e2e/redteam/start-quiz-session-mode-confusion.spec.ts
+++ b/apps/web/e2e/redteam/start-quiz-session-mode-confusion.spec.ts
@@ -9,11 +9,15 @@
  *         batch_submit_quiz against a self-assembled question set, effectively
  *         generating a fake exam report without completing a real exam.
  *
- * Defense: Migration 081 adds an early `IF p_mode NOT IN ('smart_review',
- *          'quick_quiz') THEN RAISE EXCEPTION 'mode_not_allowed'` immediately
- *          after the auth check in start_quiz_session. The whitelist runs BEFORE
- *          the active-user gate so mode_not_allowed cannot be used to probe
- *          'user inactive' via timing or error differences.
+ * Defense: Migration 081 adds an early `IF p_mode IS NULL OR p_mode NOT IN
+ *          ('smart_review', 'quick_quiz') THEN RAISE EXCEPTION
+ *          'mode_not_allowed'` immediately after the auth check. The `IS NULL`
+ *          clause is required because Postgres 3-valued logic returns NULL for
+ *          `NULL NOT IN (...)` and `IF NULL THEN` evaluates as false — without
+ *          it, NULL bypasses the guard. The whitelist runs BEFORE the
+ *          active-user gate so mode_not_allowed cannot be used to probe
+ *          'user inactive' via timing or error differences. The NULL guard
+ *          ships in migration 20260521000001_start_quiz_session_null_guard.
  *
  * No afterEach cleanup — the RPC raises before any INSERT reaches the table.
  * Both attacks assert count === 0 new rows as a positive verification of the
@@ -113,6 +117,35 @@ test.describe('Vector — start_quiz_session p_mode whitelist (issue #629)', () 
 
     // Positive no-insert assertion: zero quiz_sessions rows were created for
     // this attacker after the test started.
+    const { count, error: countError } = await admin
+      .from('quiz_sessions')
+      .select('id', { count: 'exact', head: true })
+      .eq('student_id', attackerUserId)
+      .gte('created_at', testStartIso)
+    expect(countError).toBeNull()
+    expect(count).toBe(0)
+  })
+
+  // Attack 3 sends p_mode as an EXPLICIT JSON null (not an omitted argument).
+  // Omitting the argument would be rejected by PostgREST at the HTTP layer
+  // before the function runs — a different code path. Explicit null reaches
+  // the SQL function, which without the `IS NULL OR` guard would proceed past
+  // the active-user gate (Postgres 3-valued logic: `NULL NOT IN (...)`
+  // evaluates to NULL, and `IF NULL THEN` is false). The mode-whitelist guard
+  // must reject NULL with the same `mode_not_allowed` symbol as exam modes,
+  // so an attacker cannot distinguish "mode rejected" from "auth passed,
+  // failed at INSERT" via error string.
+  test('Attack 3 — explicit-null mode is rejected before the active-user gate', async () => {
+    const { error } = await attackerClient.rpc('start_quiz_session', {
+      p_mode: null as unknown as string,
+      p_subject_id: subjectId,
+      p_topic_id: topicId,
+      p_question_ids: questionIds,
+    })
+
+    expect(error).not.toBeNull()
+    expect(error?.message ?? '').toContain('mode_not_allowed')
+
     const { count, error: countError } = await admin
       .from('quiz_sessions')
       .select('id', { count: 'exact', head: true })

--- a/packages/db/src/__integration__/rpc-start-session.integration.test.ts
+++ b/packages/db/src/__integration__/rpc-start-session.integration.test.ts
@@ -396,4 +396,22 @@ describe('RPC: start_quiz_session input validation', () => {
     expect(error?.message).toContain('mode_not_allowed')
     expect(data).toBeNull()
   })
+
+  // Without `IS NULL OR`, Postgres 3-valued logic makes `NULL NOT IN (...)`
+  // evaluate to NULL, the IF skips, and the function proceeds past the
+  // active-user gate. NULL would then fail at INSERT against the NOT NULL
+  // constraint with a different error message, letting a caller distinguish
+  // auth-passed from mode-rejected. The guard must reject NULL with the same
+  // `mode_not_allowed` symbol as other invalid modes.
+  it('rejects p_mode=null with mode_not_allowed', async () => {
+    const { data, error } = await studentClient.rpc('start_quiz_session', {
+      p_mode: null as unknown as string,
+      p_subject_id: refs.subjectId,
+      p_topic_id: refs.topicId,
+      p_question_ids: questionIds.slice(0, 1),
+    })
+    expect(error).not.toBeNull()
+    expect(error?.message).toContain('mode_not_allowed')
+    expect(data).toBeNull()
+  })
 })

--- a/supabase/migrations/20260521000001_start_quiz_session_null_guard.sql
+++ b/supabase/migrations/20260521000001_start_quiz_session_null_guard.sql
@@ -1,0 +1,113 @@
+-- Bug: mig 20260508000001 whitelist guard `IF p_mode NOT IN ('smart_review',
+-- 'quick_quiz')` does not reject NULL. Postgres 3-valued logic evaluates
+-- `NULL NOT IN (...)` to NULL, and `IF NULL THEN` is false, so a NULL p_mode
+-- skips the RAISE and falls through to the active-user gate. The active-user
+-- gate runs a different query, so a NULL p_mode leaks a different timing /
+-- error signal than an invalid p_mode — defeating the timing-oracle closure
+-- that mig 20260508000001 specifically aimed for.
+--
+-- CodeRabbit flagged this on PR #641; the in-place edit was prepared on
+-- 2026-05-08 but never pushed. PR #641 merged on 2026-05-21 as a
+-- history-reconciliation of the prod-deployed body (without the NULL guard),
+-- so this migration re-creates the function with the corrected guard.
+
+CREATE OR REPLACE FUNCTION start_quiz_session(
+  p_mode         text,
+  p_subject_id   uuid,
+  p_topic_id     uuid,
+  p_question_ids uuid[]
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_session_id uuid;
+  v_uid uuid := auth.uid();
+  v_org_id uuid;
+  v_role text;
+  v_count int;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Whitelist: only student-facing practice modes are permitted here.
+  -- mock_exam => start_exam_session; internal_exam => start_internal_exam_session.
+  -- NULL must be rejected explicitly: Postgres 3-valued logic returns NULL for
+  -- `NULL NOT IN (...)`, and `IF NULL THEN` is false, so omitting the IS NULL
+  -- check would let a NULL p_mode bypass the guard and reach the active-user
+  -- gate — leaking an auth-passed timing/error signal before failing at INSERT.
+  IF p_mode IS NULL OR p_mode NOT IN ('smart_review', 'quick_quiz') THEN
+    RAISE EXCEPTION 'mode_not_allowed';
+  END IF;
+
+  SELECT organization_id, role
+  INTO v_org_id, v_role
+  FROM users
+  WHERE id = v_uid
+    AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  IF p_question_ids IS NULL OR array_length(p_question_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'no_questions_provided';
+  END IF;
+
+  -- Reject duplicate UUIDs. unnest + JOIN below would silently double-count
+  -- and pass the COUNT equality check, then create an inconsistent session.
+  SELECT count(DISTINCT qid) INTO v_count
+  FROM unnest(p_question_ids) AS qid;
+  IF v_count <> array_length(p_question_ids, 1) THEN
+    RAISE EXCEPTION 'invalid_question_ids';
+  END IF;
+
+  -- Verify every UUID resolves to an active, in-org, non-deleted question
+  -- matching the (subject, topic) scope. NULL p_subject_id / p_topic_id =>
+  -- smart_review; corresponding match is skipped, org + active + soft-delete
+  -- always apply.
+  SELECT count(*) INTO v_count
+  FROM unnest(p_question_ids) AS qid
+  JOIN public.questions q ON q.id = qid
+  WHERE q.organization_id = v_org_id
+    AND (p_subject_id IS NULL OR q.subject_id = p_subject_id)
+    AND (p_topic_id   IS NULL OR q.topic_id   = p_topic_id)
+    AND q.status = 'active'
+    AND q.deleted_at IS NULL;
+
+  IF v_count <> array_length(p_question_ids, 1) THEN
+    RAISE EXCEPTION 'invalid_question_ids';
+  END IF;
+
+  INSERT INTO quiz_sessions
+    (organization_id, student_id, mode, subject_id, topic_id,
+     config, total_questions)
+  VALUES (
+    v_org_id,
+    v_uid,
+    p_mode,
+    p_subject_id,
+    p_topic_id,
+    jsonb_build_object('question_ids', to_jsonb(p_question_ids)),
+    array_length(p_question_ids, 1)
+  )
+  RETURNING id INTO v_session_id;
+
+  -- Audit log
+  INSERT INTO audit_events
+    (organization_id, actor_id, actor_role, event_type, resource_type, resource_id)
+  VALUES (
+    v_org_id,
+    v_uid,
+    v_role,
+    'quiz_session.started',
+    'quiz_session',
+    v_session_id
+  );
+
+  RETURN v_session_id;
+END;
+$$;


### PR DESCRIPTION
## Summary

Closes the Postgres 3-valued-logic gap CodeRabbit flagged on PR #641 (issue #629 follow-up).

`NULL NOT IN ('smart_review','quick_quiz')` evaluates to NULL — not TRUE — so `IF NULL THEN` is false. A NULL `p_mode` bypassed the whitelist, fell through to the active-user gate, and only failed at INSERT against `mode NOT NULL` with a different error string. That leaked an auth-passed timing/error signal — exactly the channel mig `20260508000001` was designed to close.

## Why a new migration (not an in-place edit)

PR #641 merged on 2026-05-21 as a history-reconciliation of the body that was deployed manually to prod on 2026-05-08. The Supabase `migration_history` table on prod records `20260508000001` as applied with the buggy body. Editing the existing migration file in place would NOT re-run on `supabase db push` because the version is already recorded. The fix must ship as a new timestamped migration that re-creates the function with `CREATE OR REPLACE FUNCTION`.

## Change

Single line in the guard:

```diff
-IF p_mode NOT IN ('smart_review', 'quick_quiz') THEN
+IF p_mode IS NULL OR p_mode NOT IN ('smart_review', 'quick_quiz') THEN
   RAISE EXCEPTION 'mode_not_allowed';
 END IF;
```

Inline comment in the migration explains the 3VL pitfall for future readers.

## Coverage

- **Vitest integration** (`packages/db/src/__integration__/rpc-start-session.integration.test.ts`) — new case asserts explicit `p_mode: null` raises `mode_not_allowed`.
- **Playwright red-team** (`apps/web/e2e/redteam/start-quiz-session-mode-confusion.spec.ts`) — new Attack 3 sends explicit JSON null and verifies zero `quiz_sessions` rows created.
- **Spec header comments** — updated Defense block to reflect the IS NULL clause and the 3VL rationale.

## Deploy

Once merged: `npx supabase db push` from master will apply `20260521000001_start_quiz_session_null_guard.sql` to prod. `CREATE OR REPLACE FUNCTION` overwrites the existing function definition without touching the `mode_not_allowed` exception interface — no caller code changes.

## Related

- PR #641 — history-reconciliation merge (the buggy body)
- Issue #629 — original mode-confusion vector
- Issue #654 — CI auto-apply migrations (would prevent this whole class of incident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for quiz session creation to properly reject null and invalid mode values, preventing potential bypass of input guards.

* **Tests**
  * Added regression tests to verify invalid mode inputs are consistently rejected with appropriate error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->