### PR TITLE
ci: auto-apply Supabase migrations to prod on merge to master

### DIFF
--- a/.github/workflows/db-deploy.yml
+++ b/.github/workflows/db-deploy.yml
@@ -40,6 +40,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v1
         with:

--- a/.github/workflows/db-deploy.yml
+++ b/.github/workflows/db-deploy.yml
@@ -1,0 +1,66 @@
+name: DB Deploy
+
+# Auto-applies Supabase migrations to production on merge to master.
+#
+# Why: PR #652 (2026-05-20) shipped app code that called a new RPC, but the
+# migration introducing that RPC was never applied to prod — exam-config page
+# 500'd until the migration was applied manually. Issue #654 tracks closing
+# this gap permanently.
+#
+# Behavior:
+#   - Triggers only when supabase/migrations/** changes on master.
+#   - Dry-runs first to surface what will apply (visible in workflow logs).
+#   - Then applies via `supabase db push`. Idempotent: already-applied migrations
+#     are skipped via the remote migration_history table.
+#   - Fails loudly if remote has migrations not in the local tree — indicates
+#     drift that should not be silently reconciled (see PR #641 incident).
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'supabase/migrations/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize migration pushes — never run two at once against the same prod DB.
+  group: db-deploy-prod
+  cancel-in-progress: false
+
+env:
+  SUPABASE_PROJECT_REF: uepvblipahxizozxvwjn
+
+jobs:
+  push:
+    name: Apply migrations to prod
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v1
+        with:
+          version: 2.78.1
+
+      - name: Link to production project
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Dry-run (preview pending migrations)
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: supabase db push --dry-run
+
+      - name: Apply migrations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        # `--include-all` skipped intentionally — push only files in supabase/migrations
+        # whose version_number is missing from remote migration_history.
+        run: supabase db push --yes


### PR DESCRIPTION
## Summary

Closes #654. Adds `.github/workflows/db-deploy.yml` to apply Supabase migrations automatically when merged to master.

## Why

PR #652 (2026-05-20) shipped app code calling a new RPC, but the migration introducing the RPC was never applied to prod. The exam-config page 500'd for every admin until I applied the migration manually via `npx supabase db push` from my workstation. That manual step is the gap.

Today's incident also surfaced a *prior* manual-deploy incident: PR #641's migration was pushed to prod from a feature branch on 2026-05-08 but the PR itself sat unmerged for 13 days — silent divergence between git history and live DB. Both incidents share the same root cause: there is no automated path from "migration merged to master" → "migration applied to prod."

## Behavior

- **Trigger:** `push` to `master` with changes in `supabase/migrations/**` (path filter). Manual `workflow_dispatch` also wired for one-off retries.
- **Sequence:** link → dry-run (logs the pending list) → apply (`supabase db push --yes`).
- **Idempotent:** already-applied migrations are skipped via the remote `migration_history` table. Re-running the workflow is safe.
- **Concurrency:** `db-deploy-prod` group with `cancel-in-progress: false` — pushes serialize, never two against prod at once.
- **Drift detection:** `supabase db push` fails if the remote has a migration version not present locally (the exact error that surfaced PR #641's silent divergence today). Treat workflow failures with `Remote migration versions not found in local migrations directory` as a signal to investigate before any further deploy.

## Required secrets (action item before first run)

Two repo-level secrets needed. I cannot set these from here — the user must add them in repo Settings → Secrets and variables → Actions:

1. **`SUPABASE_ACCESS_TOKEN`** — personal access token from `supabase login` or https://supabase.com/dashboard/account/tokens.
2. **`SUPABASE_DB_PASSWORD`** — production project database password (Settings → Database → Connection string → Reset database password if unknown).

The workflow also references an `environment: production` — this is optional but worth configuring with approval rules / restricted reviewers if you want a manual gate before each prod deploy. Without the environment configured, the job runs immediately on push.

## Things deliberately NOT in this PR (follow-ups)

- **PR-time dry-run:** would post the pending-migration list as a PR comment. Useful but not on the critical path; would need a separate workflow with restricted secret access for fork-PR safety. Acceptable as a follow-up issue.
- **Coordinated app/DB deploy ordering:** today's behavior is "DB applies within seconds of merge; Vercel app deploy takes minutes." The brief skew window is bounded and usually self-heals (the app calling a missing RPC retries on next request after schema cache refresh). A true coordinated deploy would require a Vercel deploy hook — meaningful complexity, separate scope.
- **Rollback runbook:** documented separately in #654's acceptance criteria. Down migrations are not in scope here.

## Test plan

- [ ] User adds `SUPABASE_ACCESS_TOKEN` + `SUPABASE_DB_PASSWORD` repo secrets.
- [ ] After merge, push a no-op migration touch (e.g. trailing whitespace) to verify the workflow triggers, succeeds, and reports "no pending migrations" on the dry-run line.
- [ ] Confirm the workflow does NOT trigger on PRs (only push to master).
- [ ] Confirm the workflow does NOT trigger on commits that don't touch `supabase/migrations/**`.

## Related

- Issue #654 — the gap this closes
- PR #641 — silent 13-day master/prod divergence (2026-05-08 → 2026-05-21)
- PR #652 — today's incident (prod RPC missing after app deploy)
- PR #656 — `start_quiz_session` NULL guard (will be the first migration to flow through this workflow once merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated production database migration deployment workflow to safely apply schema changes.
  * Includes a dry-run verification step, manual trigger support, and safeguards to prevent concurrent production migration runs.
  * Reduces manual deployment steps and helps ensure migrations are applied reliably with verification before execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->