### PR TITLE
fix(ci): bypass supabase link, use --db-url for prod migrations

### DIFF
--- a/.github/workflows/db-deploy.yml
+++ b/.github/workflows/db-deploy.yml
@@ -47,22 +47,30 @@ jobs:
         with:
           version: 2.78.1
 
-      - name: Link to production project
+      # Build the connection URL explicitly and pass via --db-url. The CLI's
+      # `link + SUPABASE_DB_PASSWORD env var` path was rejecting valid pooler
+      # credentials with SCRAM/SASL auth failures (observed 2026-05-21 across
+      # three password resets). Constructing the URL ourselves routes around
+      # that code path. Session pooler (port 5432) is used because direct DB
+      # (port 5432 on db.<ref>.supabase.co) is IPv6-only on Supabase.
+      - name: Build DB URL
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+        run: |
+          PW_ENC=$(jq -nr --arg p "$SUPABASE_DB_PASSWORD" '$p|@uri')
+          echo "::add-mask::$PW_ENC"
+          DB_URL="postgresql://postgres.${SUPABASE_PROJECT_REF}:${PW_ENC}@aws-1-eu-central-1.pooler.supabase.com:5432/postgres"
+          echo "::add-mask::$DB_URL"
+          echo "DB_URL=$DB_URL" >> "$GITHUB_ENV"
 
       - name: Dry-run (preview pending migrations)
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-        run: supabase db push --dry-run
+        run: supabase db push --dry-run --db-url "$DB_URL"
 
       - name: Apply migrations
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         # `--include-all` skipped intentionally — push only files in supabase/migrations
         # whose version_number is missing from remote migration_history.
-        run: supabase db push --yes
+        run: supabase db push --yes --db-url "$DB_URL"

--- a/.github/workflows/db-deploy.yml
+++ b/.github/workflows/db-deploy.yml
@@ -57,6 +57,10 @@ jobs:
         env:
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
+          if [ -z "${SUPABASE_DB_PASSWORD:-}" ]; then
+            echo "::error::SUPABASE_DB_PASSWORD secret is not set on this repo. Add it under Settings → Secrets and variables → Actions before re-running." >&2
+            exit 1
+          fi
           PW_ENC=$(jq -nr --arg p "$SUPABASE_DB_PASSWORD" '$p|@uri')
           echo "::add-mask::$PW_ENC"
           DB_URL="postgresql://postgres.${SUPABASE_PROJECT_REF}:${PW_ENC}@aws-1-eu-central-1.pooler.supabase.com:5432/postgres"


### PR DESCRIPTION
## Why

PR #657 introduced `db-deploy.yml` to auto-apply Supabase migrations on merge to master. Every run since has failed at the dry-run step with `SASL auth (FATAL: password authentication failed for user "postgres")` — even after **three** Supabase Dashboard password resets and matching repo-secret updates.

Diagnostic from the session that produced this PR:

| Auth path | Result |
|---|---|
| `supabase link` + `SUPABASE_DB_PASSWORD` env var → `supabase db push` | **fails** with SCRAM/SASL auth |
| `supabase db push --db-url 'postgresql://postgres.<ref>:<pw>@pooler:5432/postgres'` | **succeeds** |

Same password, same project, same pooler endpoint, same SHA-pinned CLI version. The CLI's `link + env var` code path is rejecting credentials that work fine via explicit `--db-url`. Reproduced both in CI (failed run `26213001355` on commit `f2de311c`) and locally.

## What changes

- Drop the `Link to production project` step entirely.
- Add `Build DB URL` step that:
  - URL-encodes the secret password with `jq … '$p|@uri'` (handles any future passwords with special chars).
  - Constructs the session-pooler URL (`postgres.<ref>` user, port 5432).
  - Applies GitHub log-masking (`::add-mask::`) to both the encoded password and the full URL so neither leaks into workflow logs.
  - Exports `DB_URL` to subsequent steps via `$GITHUB_ENV`.
- Dry-run + apply steps now pass `--db-url "$DB_URL"` and drop their `SUPABASE_DB_PASSWORD` env vars.

Session pooler (port 5432) is used because the direct DB endpoint (`db.<ref>.supabase.co`) is IPv6-only on Supabase and unreachable from many runners (including my local network during diagnostics).

## After merge

I'll re-trigger the workflow via `workflow_dispatch` (or `gh run rerun` on `26213001355`). If the dry-run lists `20260521000001_start_quiz_session_null_guard.sql` and the apply step succeeds, the queued NULL-guard migration finally lands in prod — closing the master/prod divergence that started when #656 merged.

## Test plan

- [ ] All CI checks pass on this PR (no DB writes — these only validate the YAML).
- [ ] Merge → re-trigger the workflow.
- [ ] Confirm dry-run output mentions `20260521000001_start_quiz_session_null_guard.sql`.
- [ ] Confirm apply step succeeds and the migration appears in prod `migration_history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database deployment workflow: explicitly builds and uses a database URL for migrations.
  * Adds validation and URI-encoding of the DB password, masks sensitive values in CI logs, and exposes the URL as an environment variable for pipeline steps.
  * Updates dry-run and apply migration steps to use the explicit DB URL while still only pushing pending migrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->