### PR TITLE
fix(dashboard,progress): aggregate mastery in Postgres to fix 1000-row truncation (#540)

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -17,6 +17,8 @@
 
 10. **Audit-event INSERT subqueries** — Every `INSERT INTO audit_events (...)` SQL block in a SECURITY DEFINER function must filter `deleted_at IS NULL` on any user/session/question/membership FK lookup used to populate `actor_id`, `actor_role`, or session-derived columns. The outer auth/ownership guards may already enforce this for the calling student, but the audit-row subqueries are independent SELECTs. First seen: issue #550 (`batch_submit_quiz`). Replicated: `complete_empty_exam_session` (cross-referenced 2026-04-27). Pattern hit count=3 — promoted from watch to hard rule.
 
+11. **Multiple permissive RLS SELECT policies** — Postgres ORs permissive policies together. If a table has more than one permissive SELECT policy (currently `student_responses`, `quiz_sessions`, `exam_configs`, `audit_events`), a per-caller RPC reading it must scope explicitly with `WHERE <owner_col> = auth.uid()` (or an `auth.uid() = p_student_id` identity guard) — RLS alone over-scopes to the broader (instructor/admin) policy. Admin/org-wide RPCs behind `is_admin()` are exempt. First seen: #540 / red-team BW3 (`get_student_mastery_stats`, 2026-05-26). See `docs/security.md` §3.
+
 ## When the security-auditor agent runs
 On every `git push` via Lefthook pre-push hook.
 Blocks on CRITICAL and HIGH findings.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -117,6 +117,13 @@ reviews:
           question/membership FK lookup used to populate actor_id, actor_role, or
           session-derived columns. The outer auth guard does not cover these independent
           subqueries. Flag any INSERT INTO audit_events subquery missing AND deleted_at IS NULL.
+        - Multi-policy RLS table reads: when a SECURITY INVOKER/DEFINER function reads a
+          table with more than one permissive SELECT policy (student_responses, quiz_sessions,
+          exam_configs, audit_events) and returns the caller's OWN rows, it must scope
+          explicitly with WHERE <owner_col> = auth.uid() (or an auth.uid() = p_student_id
+          identity guard). Postgres ORs permissive policies, so RLS alone over-scopes to the
+          broader instructor/admin policy. Admin/org-wide RPCs behind is_admin() are exempt.
+          Flag any per-caller RPC reading these tables without an explicit auth.uid() filter.
 
     - path: "supabase/migrations/**/*.sql"
       instructions: |

--- a/.spec-workflow/specs/student-mastery-stats-rpc/design.md
+++ b/.spec-workflow/specs/student-mastery-stats-rpc/design.md
@@ -8,9 +8,13 @@ Migration `supabase/migrations/20260521000005_student_mastery_stats_rpc.sql`.
   `authenticated`. Mirrors `get_question_counts` (#614).
 - **Row shape:** `topic_id IS NULL` ⇒ subject-level aggregate; `topic_id NOT NULL` ⇒ topic-level.
   Unambiguous because `questions.topic_id` is `NOT NULL` (initial_schema.sql:110).
-- **Scoping via RLS** (no manual scoping, no auth preamble): `tenant_isolation` on `questions`
-  = org + `deleted_at IS NULL` (any status); `student_responses` RLS = `student_id = auth.uid()`.
-  Unauthenticated → `auth.uid()` NULL → zero rows → empty result.
+- **Scoping:** RLS + an explicit numerator predicate. `tenant_isolation` on `questions`
+  = org + `deleted_at IS NULL` (any status). The numerator (`correct_q`) additionally
+  self-scopes with an explicit `sr.student_id = auth.uid()` — `student_responses` has a
+  second SELECT policy (`instructors_read_students`) that would otherwise let an
+  instructor/admin aggregate org-wide, so RLS alone is not enough to keep it per-caller
+  (security.md §11). No auth preamble needed: unauthenticated → `auth.uid()` NULL → zero
+  rows → empty result.
 - **Aggregation:** CTE `active_q` (`status='active'`) = denominator; CTE `correct_q`
   (`DISTINCT` correct responses joined to questions, any status) = numerator. Subject-level and
   topic-level counts each combined with **`FULL JOIN`** + `COALESCE` zero-fill (FULL, not LEFT,

--- a/.spec-workflow/specs/student-mastery-stats-rpc/design.md
+++ b/.spec-workflow/specs/student-mastery-stats-rpc/design.md
@@ -1,0 +1,42 @@
+# Design — Student Mastery Stats RPC
+
+## RPC: `public.get_student_mastery_stats()`
+Migration `supabase/migrations/20260521000005_student_mastery_stats_rpc.sql`.
+
+- No args (caller is always self). `RETURNS TABLE (subject_id uuid, topic_id uuid, total bigint,
+  correct bigint)`. `LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public`. GRANT to
+  `authenticated`. Mirrors `get_question_counts` (#614).
+- **Row shape:** `topic_id IS NULL` ⇒ subject-level aggregate; `topic_id NOT NULL` ⇒ topic-level.
+  Unambiguous because `questions.topic_id` is `NOT NULL` (initial_schema.sql:110).
+- **Scoping via RLS** (no manual scoping, no auth preamble): `tenant_isolation` on `questions`
+  = org + `deleted_at IS NULL` (any status); `student_responses` RLS = `student_id = auth.uid()`.
+  Unauthenticated → `auth.uid()` NULL → zero rows → empty result.
+- **Aggregation:** CTE `active_q` (`status='active'`) = denominator; CTE `correct_q`
+  (`DISTINCT` correct responses joined to questions, any status) = numerator. Subject-level and
+  topic-level counts each combined with **`FULL JOIN`** + `COALESCE` zero-fill (FULL, not LEFT,
+  to retain orphan subjects/topics where `correct>0, total=0`), `UNION ALL`'d.
+
+Verified end-to-end locally under `SET ROLE authenticated`: a correct response to a question
+flipped to `draft` is counted in `correct` (2) but excluded from `total` (19) — proving the
+numerator/denominator divergence holds under real RLS.
+
+## TS wiring
+- `apps/web/lib/queries/dashboard.ts` (`getSubjectProgressWithMap`): replaced the three truncating
+  reads + in-memory maps with `rpc<MasteryRow[]>(supabase, 'get_student_mastery_stats', {})` (helper
+  `apps/web/lib/supabase-rpc.ts`); subject-level rows → count map. Kept `easa_subjects` metadata
+  read and a single residual `questions.select('id, subject_id').is('deleted_at', null)` (any-status)
+  read solely for `questionSubjectMap` (last-practiced; deferred #668). Formula/filter unchanged.
+- `apps/web/lib/queries/progress.ts` (`getProgressData`): four-element `Promise.all` → three-element
+  (`easa_subjects`, `easa_topics`, RPC); partition rows into subject/topic count maps; formula/filters
+  unchanged at both levels.
+- `packages/db/src/types.ts`: hand-added `get_student_mastery_stats` (`Args: never`, Returns rows).
+
+## Tests
+- `dashboard.test.ts` / `progress.test.ts`: added `vi.mock('@/lib/supabase-rpc')` + hoisted `mockRpc`
+  (kept `from: mockFrom`); migrated mastery assertions to drive via `mockRpc`; removed the
+  `questionsCallCount` ordinal pattern; added a #540 regression test (subject past the 1000-row
+  window counted in full) and an RPC-error test.
+
+## Deferred (#668 follow-up)
+`dashboard-stats.ts` streak/last-practiced reads (`.limit(10000)`/`.limit(5000)` — ignored above
+cap) and the residual `questionSubjectMap` read remain truncated.

--- a/.spec-workflow/specs/student-mastery-stats-rpc/requirements.md
+++ b/.spec-workflow/specs/student-mastery-stats-rpc/requirements.md
@@ -1,0 +1,44 @@
+# Requirements — Student Mastery Stats RPC (#540, umbrella #668)
+
+## Problem
+Student dashboard (`/app/dashboard`) and progress (`/app/progress`) pages show zero/wrong
+per-subject mastery for high-volume students. Root cause (confirmed against prod): the mastery
+**numerator** (correct `student_responses`) and **denominator** (active `questions`) are fetched
+as raw, unpaginated reads and aggregated in JS. PostgREST silently truncates any unpaginated read
+at `max_rows=1000`, so both sides are computed from arbitrary first-1000-row subsets. Issue #540:
+student with 8,395 responses / org with 1,366 active questions → a completed subject answered
+"late" falls outside the window and shows 0%.
+
+This is instance #1 of the truncation bug **class** tracked under umbrella #668.
+
+## Scope
+**In:** per-subject and per-topic mastery aggregation (dashboard + progress).
+**Out (deferred to #668 follow-up P0):** `dashboard-stats.ts` streak (`getStreakData`) and
+last-practiced (`applyLastPracticed`) — both still truncated; the `questionSubjectMap` residual
+read remains row-capped but reproduces legacy behavior exactly.
+
+## Functional requirements
+1. Per-subject and per-topic `total`/`correct` counts come from a Postgres aggregation, not a
+   client-side row scan — never truncated.
+2. **Preserve PR #665 (commit d1cd4770) semantics exactly** (behavior-preserving; #664
+   mastery-semantics stays a separate open decision):
+   - `total` = active (`status='active'`), non-deleted questions, by the question's own subject/topic.
+   - `correct` = distinct correct responses to non-deleted questions of **any** status (draft/orphan
+     retained) — so `correct` can exceed `total`.
+   - mastery = `total>0 ? min(round(correct/total*100),100) : 0` (clamp in TS).
+   - include subject/topic if `total>0 OR correct>0` (orphan retention; filter in TS).
+   - callers continue to read raw unclamped `answeredCorrectly`.
+3. Org + own-responses scoping enforced (no cross-org / cross-student leakage).
+4. Return shapes of `getDashboardData`/`SubjectProgress` and `getProgressData`/`SubjectDetail`/
+   `TopicDetail` unchanged — no caller edits.
+
+## Non-functional / security
+- RPC is `SECURITY INVOKER` + RLS (user-confirmed deviation from initial DEFINER draft) — matches
+  `get_question_counts` (#614, same bug class). `tenant_isolation` scopes `questions`;
+  `student_responses` RLS scopes the numerator. No answer data exposed (counts only).
+- New migration + new RPC → red-team + security-auditor review required.
+
+## Acceptance
+- Unit regression test proving a subject whose responses sit past row 1000 is counted in full.
+- `pnpm test` + `pnpm check-types` green.
+- #540 stays OPEN until the deployed RPC is verified against the affected student's real data.

--- a/.spec-workflow/specs/student-mastery-stats-rpc/tasks.md
+++ b/.spec-workflow/specs/student-mastery-stats-rpc/tasks.md
@@ -13,6 +13,9 @@
 - [x] red-team: found BW3 (instructor/admin numerator leak) → fixed in bf756480
       (sr.student_id = auth.uid()); E2E coverage gaps filed as #673
 - [x] PR-level semantic sweep (master...HEAD): clean
+- [x] learner synthesis: promoted security.md §11 (multi-policy RLS → explicit auth.uid()
+      scope); sweep clean repo-wide; coderabbit-sync mirrored §11 into .coderabbit.yaml
+- [x] /fullpush gates: lint (0 errors), check-types, 3388 tests, build, clean migration reset
+- [ ] CR-local (/crlocal) review loop
 - [ ] security-auditor runs on pre-push (Lefthook) — pending push
-- [ ] learner synthesis
 - [ ] Push (on user approval) + verify deployed RPC against affected student before closing #540

--- a/.spec-workflow/specs/student-mastery-stats-rpc/tasks.md
+++ b/.spec-workflow/specs/student-mastery-stats-rpc/tasks.md
@@ -16,6 +16,6 @@
 - [x] learner synthesis: promoted security.md §11 (multi-policy RLS → explicit auth.uid()
       scope); sweep clean repo-wide; coderabbit-sync mirrored §11 into .coderabbit.yaml
 - [x] /fullpush gates: lint (0 errors), check-types, 3388 tests, build, clean migration reset
-- [ ] CR-local (/crlocal) review loop
+- [x] CR-local (/crlocal) review loop — round 1 clean (0 findings) after PR #674 CR + PR-sweep fixes
 - [ ] security-auditor runs on pre-push (Lefthook) — pending push
 - [ ] Push (on user approval) + verify deployed RPC against affected student before closing #540

--- a/.spec-workflow/specs/student-mastery-stats-rpc/tasks.md
+++ b/.spec-workflow/specs/student-mastery-stats-rpc/tasks.md
@@ -1,0 +1,13 @@
+# Tasks — Student Mastery Stats RPC
+
+- [x] Write migration `20260521000005_student_mastery_stats_rpc.sql` (SECURITY INVOKER + RLS)
+- [x] Apply + functionally verify the RPC against local DB (orphan/draft case under RLS)
+- [x] Hand-add `get_student_mastery_stats` to `packages/db/src/types.ts`
+- [x] Rewire `dashboard.ts` to the RPC; update `dashboard.test.ts` (+#540 regression, +RPC-error)
+- [x] Rewire `progress.ts` to the RPC; update `progress.test.ts` (+#540 regression, +RPC-error)
+- [x] `pnpm test` (3383 pass) + `pnpm check-types` green
+- [ ] implementation-critic on staged diff
+- [ ] Commit (NO `Closes #540`)
+- [ ] Post-commit agents: code-reviewer, semantic-reviewer, doc-updater (docs/database.md RPC
+      tables), test-writer; then red-team + security-auditor (migration touched); then learner
+- [ ] Push (on user approval) + verify deployed RPC against affected student before closing #540

--- a/.spec-workflow/specs/student-mastery-stats-rpc/tasks.md
+++ b/.spec-workflow/specs/student-mastery-stats-rpc/tasks.md
@@ -6,8 +6,13 @@
 - [x] Rewire `dashboard.ts` to the RPC; update `dashboard.test.ts` (+#540 regression, +RPC-error)
 - [x] Rewire `progress.ts` to the RPC; update `progress.test.ts` (+#540 regression, +RPC-error)
 - [x] `pnpm test` (3383 pass) + `pnpm check-types` green
-- [ ] implementation-critic on staged diff
-- [ ] Commit (NO `Closes #540`)
-- [ ] Post-commit agents: code-reviewer, semantic-reviewer, doc-updater (docs/database.md RPC
-      tables), test-writer; then red-team + security-auditor (migration touched); then learner
+- [x] implementation-critic on staged diff (added docs/database.md entry, removed dead param)
+- [x] Commit (NO `Closes #540`) — 3bb0b957
+- [x] Post-commit agents: code-reviewer (clean), semantic-reviewer (1 doc ISSUE → fixed),
+      doc-updater (clean), test-writer (+6 tests, d4d58940); then red-team
+- [x] red-team: found BW3 (instructor/admin numerator leak) → fixed in bf756480
+      (sr.student_id = auth.uid()); E2E coverage gaps filed as #673
+- [x] PR-level semantic sweep (master...HEAD): clean
+- [ ] security-auditor runs on pre-push (Lefthook) — pending push
+- [ ] learner synthesis
 - [ ] Push (on user approval) + verify deployed RPC against affected student before closing #540

--- a/apps/web/lib/queries/dashboard.test.ts
+++ b/apps/web/lib/queries/dashboard.test.ts
@@ -481,4 +481,108 @@ describe('getDashboardData', () => {
 
     await expect(getDashboardData()).rejects.toThrow('Failed to fetch mastery stats: boom')
   })
+
+  it('coerces bigint-as-string total and correct from the RPC into numbers', async () => {
+    // PostgREST may return bigint columns as strings depending on driver version.
+    // The MasteryRow type is `total: number | string` and production code calls Number().
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: '6', correct: '3' }],
+      error: null,
+    })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [{ id: 's1', code: 'AGK', name: 'Aircraft General', short: 'AGK', sort_order: 1 }],
+        })
+      if (table === 'student_responses') return buildChain({ count: 3, data: [] })
+      if (table === 'questions') return buildChain({ data: [] })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const result = await getDashboardData()
+    expect(result.subjects).toHaveLength(1)
+    const subject = result.subjects[0]!
+    expect(subject.totalQuestions).toBe(6)
+    expect(subject.answeredCorrectly).toBe(3)
+    expect(subject.masteryPercentage).toBe(50)
+  })
+
+  it('ignores topic-level RPC rows and uses only subject-level rows for subject mastery', async () => {
+    // The RPC returns both topic_id=null (subject-level) and topic_id!=null (topic-level) rows.
+    // dashboard.ts uses the `continue` guard to skip topic-level rows. If those rows were
+    // accidentally accumulated, totalQuestions and answeredCorrectly would be inflated.
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+
+    mockRpc.mockResolvedValue({
+      data: [
+        // Subject-level row: 10 total, 5 correct.
+        { subject_id: 's1', topic_id: null, total: 10, correct: 5 },
+        // Topic-level rows that must be ignored.
+        { subject_id: 's1', topic_id: 't1', total: 6, correct: 3 },
+        { subject_id: 's1', topic_id: 't2', total: 4, correct: 2 },
+      ],
+      error: null,
+    })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [{ id: 's1', code: 'AGK', name: 'Aircraft General', short: 'AGK', sort_order: 1 }],
+        })
+      if (table === 'student_responses') return buildChain({ count: 5, data: [] })
+      if (table === 'questions') return buildChain({ data: [] })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const result = await getDashboardData()
+    expect(result.subjects).toHaveLength(1)
+    const subject = result.subjects[0]!
+    // Must reflect subject-level row only, not the sum of topic rows.
+    expect(subject.totalQuestions).toBe(10)
+    expect(subject.answeredCorrectly).toBe(5)
+    expect(subject.masteryPercentage).toBe(50)
+  })
+
+  it('returns active and orphan subjects together when both appear in the same RPC result', async () => {
+    // One subject has active questions (total > 0); the other is an orphan
+    // (total: 0, correct: 1 — answered a now-draft question). Both must appear in the output.
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+
+    mockRpc.mockResolvedValue({
+      data: [
+        { subject_id: 's1', topic_id: null, total: 5, correct: 3 }, // active
+        { subject_id: 's2', topic_id: null, total: 0, correct: 1 }, // orphan
+      ],
+      error: null,
+    })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [
+            { id: 's1', code: 'AGK', name: 'Aircraft General', short: 'AGK', sort_order: 1 },
+            { id: 's2', code: 'MET', name: 'Meteorology', short: 'MET', sort_order: 2 },
+          ],
+        })
+      if (table === 'student_responses') return buildChain({ count: 4, data: [] })
+      if (table === 'questions') return buildChain({ data: [] })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const result = await getDashboardData()
+    expect(result.subjects).toHaveLength(2)
+
+    const agk = result.subjects.find((s) => s.code === 'AGK')!
+    expect(agk.totalQuestions).toBe(5)
+    expect(agk.answeredCorrectly).toBe(3)
+    expect(agk.masteryPercentage).toBe(60)
+
+    const met = result.subjects.find((s) => s.code === 'MET')!
+    expect(met.totalQuestions).toBe(0)
+    expect(met.answeredCorrectly).toBe(1)
+    expect(met.masteryPercentage).toBe(0)
+  })
 })

--- a/apps/web/lib/queries/dashboard.test.ts
+++ b/apps/web/lib/queries/dashboard.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks ----------------------------------------------------------------
 
-const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+const { mockGetUser, mockFrom, mockRpc } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockFrom: vi.fn(),
+  mockRpc: vi.fn(),
 }))
 
 vi.mock('@repo/db/server', () => ({
@@ -12,6 +13,10 @@ vi.mock('@repo/db/server', () => ({
     auth: { getUser: mockGetUser },
     from: mockFrom,
   }),
+}))
+
+vi.mock('@/lib/supabase-rpc', () => ({
+  rpc: (...args: unknown[]) => mockRpc(...args),
 }))
 
 // ---- Subject under test ---------------------------------------------------
@@ -37,18 +42,23 @@ function buildChain(returnValue: unknown) {
 /**
  * getDashboardData makes many parallel from() calls. We intercept by table name.
  * The order of from() calls:
- *   getSubjectProgressWithMap -> 'easa_subjects', 'questions', 'student_responses', 'questions'
+ *   getSubjectProgressWithMap -> 'easa_subjects', 'questions' (last-practiced map only)
  *   getTotalAnswered          -> 'student_responses' (count query)
  *   getQuestionsToday         -> 'student_responses' (count + gte filter)
  *   getStreakData             -> 'student_responses' (created_at select)
  *   applyLastPracticed        -> 'student_responses' (question_id, created_at)
  *
- * Since buildChain returns the same value for all chain calls on a table, we set
- * both `count` and `data` so all consumer shapes work from one mock value.
+ * Per-subject mastery counts (totalQuestions/answeredCorrectly) now come from the
+ * get_student_mastery_stats RPC (mocked via mockRpc), NOT from .from('questions')/
+ * .from('student_responses'). The single surviving 'questions' read only feeds the
+ * last-practiced attribution map. Since buildChain returns the same value for all chain
+ * calls on a table, we set both `count` and `data` so all consumer shapes work from one
+ * mock value.
  */
 
 beforeEach(() => {
   vi.resetAllMocks()
+  mockRpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getDashboardData', () => {
@@ -88,6 +98,11 @@ describe('getDashboardData', () => {
   it('computes question counts and mastery per subject', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
 
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: 2, correct: 1 }],
+      error: null,
+    })
+
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -116,10 +131,20 @@ describe('getDashboardData', () => {
     const subject = result.subjects[0]!
     expect(subject.code).toBe('AGK')
     expect(subject.totalQuestions).toBe(2)
+    expect(subject.answeredCorrectly).toBe(1)
+    expect(subject.masteryPercentage).toBe(50)
   })
 
   it('attributes questions to the correct subject across multiple subjects', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+
+    mockRpc.mockResolvedValue({
+      data: [
+        { subject_id: 's1', topic_id: null, total: 2, correct: 0 },
+        { subject_id: 's2', topic_id: null, total: 1, correct: 0 },
+      ],
+      error: null,
+    })
 
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
@@ -175,7 +200,12 @@ describe('getDashboardData', () => {
   it('keeps subject when it has no active questions but the student has correct responses to it', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
 
-    let questionsCallCount = 0
+    // Orphan subject: 0 active questions, 1 correct response to a now-draft question.
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: 0, correct: 1 }],
+      error: null,
+    })
+
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -186,11 +216,8 @@ describe('getDashboardData', () => {
           count: 1,
           data: [{ question_id: 'q1', created_at: '2026-03-18T10:00:00Z' }],
         })
-      if (table === 'questions') {
-        questionsCallCount++
-        if (questionsCallCount === 1) return buildChain({ data: [] })
-        return buildChain({ data: [{ id: 'q1', subject_id: 's1' }] })
-      }
+      // Last-practiced attribution map: q1 belongs to s1 (non-deleted, any status).
+      if (table === 'questions') return buildChain({ data: [{ id: 'q1', subject_id: 's1' }] })
       throw new Error(`Unexpected table: ${table}`)
     })
 
@@ -204,12 +231,16 @@ describe('getDashboardData', () => {
   })
 
   it('counts only active questions in totalQuestions but attributes draft-question responses to their subject', async () => {
-    // Central scenario for #540: subject has 2 active + 1 draft question.
-    // Student answered the draft question correctly. totalQuestions = 2 (active only),
-    // answeredCorrectly = 1 (attributed via the non-deleted secondary questions query).
+    // Central scenario for #540: subject has 2 active questions; the student answered one
+    // now-draft question correctly. The RPC reports total = 2 (active only) and correct = 1
+    // (correct response to a non-deleted, any-status question).
     mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
 
-    let questionsCallCount = 0
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: 2, correct: 1 }],
+      error: null,
+    })
+
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -220,22 +251,8 @@ describe('getDashboardData', () => {
           count: 1,
           data: [{ question_id: 'q_draft', created_at: '2026-03-18T10:00:00Z' }],
         })
-      if (table === 'questions') {
-        questionsCallCount++
-        if (questionsCallCount === 1) {
-          // First query: active questions only — q_draft is excluded
-          return buildChain({
-            data: [
-              { id: 'q1', subject_id: 's1' },
-              { id: 'q2', subject_id: 's1' },
-            ],
-          })
-        }
-        // Second query: non-deleted questions for response attribution — q_draft is included
-        return buildChain({
-          data: [{ id: 'q_draft', subject_id: 's1' }],
-        })
-      }
+      // Last-practiced attribution map only (any-status non-deleted).
+      if (table === 'questions') return buildChain({ data: [{ id: 'q_draft', subject_id: 's1' }] })
       throw new Error(`Unexpected table: ${table}`)
     })
 
@@ -250,7 +267,12 @@ describe('getDashboardData', () => {
   it('caps masteryPercentage at 100 when correct responses exceed the active question count', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
 
-    let questionsCallCount = 0
+    // 1 active question, 2 correct responses (one to a now-draft question) -> correct > total.
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: 1, correct: 2 }],
+      error: null,
+    })
+
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -264,20 +286,14 @@ describe('getDashboardData', () => {
             { question_id: 'q_draft', created_at: '2026-03-18T10:00:00Z' },
           ],
         })
-      if (table === 'questions') {
-        questionsCallCount++
-        if (questionsCallCount === 1) {
-          // First query: active questions only
-          return buildChain({ data: [{ id: 'q1', subject_id: 's1' }] })
-        }
-        // Second query: non-deleted attribution — active q1 + now-draft q_draft
+      // Last-practiced attribution map only (any-status non-deleted).
+      if (table === 'questions')
         return buildChain({
           data: [
             { id: 'q1', subject_id: 's1' },
             { id: 'q_draft', subject_id: 's1' },
           ],
         })
-      }
       throw new Error(`Unexpected table: ${table}`)
     })
 
@@ -391,6 +407,11 @@ describe('getDashboardData', () => {
 
     const practiceDate = '2026-03-17T14:00:00Z'
 
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: 1, correct: 1 }],
+      error: null,
+    })
+
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -411,5 +432,53 @@ describe('getDashboardData', () => {
     const result = await getDashboardData()
     expect(result.subjects).toHaveLength(1)
     expect(result.subjects[0]!.lastPracticedAt).toBe(practiceDate)
+  })
+
+  it('counts a subject whose responses fall outside the legacy 1000-row window (#540 regression)', async () => {
+    // The RPC aggregates in Postgres, so a subject with 1366 correct responses is reported
+    // in full — under the old client read these rows truncated at the 1000-row cap and the
+    // subject showed 0% mastery (#540).
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's_tail', topic_id: null, total: 1366, correct: 1366 }],
+      error: null,
+    })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [{ id: 's_tail', code: 'AIRLAW', name: 'Air Law', short: 'AIR', sort_order: 1 }],
+        })
+      if (table === 'student_responses') return buildChain({ count: 8395, data: [] })
+      if (table === 'questions') return buildChain({ data: [] })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const result = await getDashboardData()
+    expect(result.subjects).toHaveLength(1)
+    const subject = result.subjects[0]!
+    expect(subject.id).toBe('s_tail')
+    expect(subject.totalQuestions).toBe(1366)
+    expect(subject.answeredCorrectly).toBe(1366)
+    expect(subject.masteryPercentage).toBe(100)
+  })
+
+  it('throws when the mastery stats RPC returns an error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [{ id: 's1', code: 'AGK', name: 'Aircraft General', short: 'AGK', sort_order: 1 }],
+        })
+      if (table === 'student_responses') return buildChain({ count: 0, data: [] })
+      if (table === 'questions') return buildChain({ data: [] })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    await expect(getDashboardData()).rejects.toThrow('Failed to fetch mastery stats: boom')
   })
 })

--- a/apps/web/lib/queries/dashboard.test.ts
+++ b/apps/web/lib/queries/dashboard.test.ts
@@ -464,6 +464,39 @@ describe('getDashboardData', () => {
     expect(subject.masteryPercentage).toBe(100)
   })
 
+  it('throws when the easa_subjects read returns an error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({ data: null, error: { message: 'subjects db error' } })
+      if (table === 'student_responses') return buildChain({ count: 0, data: [] })
+      if (table === 'questions') return buildChain({ data: [] })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    await expect(getDashboardData()).rejects.toThrow('Failed to fetch subjects: subjects db error')
+  })
+
+  it('throws when the question-subject map read returns an error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [{ id: 's1', code: 'AGK', name: 'Aircraft General', short: 'AGK', sort_order: 1 }],
+        })
+      if (table === 'student_responses') return buildChain({ count: 0, data: [] })
+      if (table === 'questions')
+        return buildChain({ data: null, error: { message: 'questions map error' } })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    await expect(getDashboardData()).rejects.toThrow(
+      'Failed to fetch question-subject map: questions map error',
+    )
+  })
+
   it('throws when the mastery stats RPC returns an error', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
 

--- a/apps/web/lib/queries/dashboard.ts
+++ b/apps/web/lib/queries/dashboard.ts
@@ -82,10 +82,11 @@ type SubjectProgressResult = {
 }
 
 async function getSubjectProgressWithMap(supabase: SupabaseClient): Promise<SubjectProgressResult> {
-  const { data: subjectsData } = await supabase
+  const { data: subjectsData, error: subjectsError } = await supabase
     .from('easa_subjects')
     .select('id, code, name, short, sort_order')
     .order('sort_order')
+  if (subjectsError) throw new Error(`Failed to fetch subjects: ${subjectsError.message}`)
 
   const subjects = (subjectsData ?? []) as SubjectRow[]
   if (!subjects.length) return { subjects: [], questionSubjectMap: new Map() }
@@ -113,10 +114,13 @@ async function getSubjectProgressWithMap(supabase: SupabaseClient): Promise<Subj
   // Last-practiced attribution only (deferred #668 — this read is still truncated at the
   // 1000-row cap). NOT used for mastery. Any-status non-deleted reproduces the legacy map
   // (active ∪ non-deleted-answered) exactly, so lastPracticedAt does not regress.
-  const { data: questionMapData } = await supabase
+  const { data: questionMapData, error: questionMapError } = await supabase
     .from('questions')
     .select('id, subject_id')
     .is('deleted_at', null)
+  if (questionMapError) {
+    throw new Error(`Failed to fetch question-subject map: ${questionMapError.message}`)
+  }
 
   const questionSubjectMap = new Map<string, string>()
   for (const q of (questionMapData ?? []) as QuestionIdSubjectRow[]) {

--- a/apps/web/lib/queries/dashboard.ts
+++ b/apps/web/lib/queries/dashboard.ts
@@ -91,18 +91,26 @@ async function getSubjectProgressWithMap(supabase: SupabaseClient): Promise<Subj
   const subjects = (subjectsData ?? []) as SubjectRow[]
   if (!subjects.length) return { subjects: [], questionSubjectMap: new Map() }
 
-  // Per-subject mastery counts aggregated in Postgres (#540): the prior client-side
-  // numerator/denominator reads truncated at the PostgREST 1000-row cap. The RPC returns
-  // both subject-level (topic_id === null) and topic-level rows; we use the subject rows.
-  const { data: masteryData, error: masteryError } = await rpc<MasteryRow[]>(
-    supabase,
-    'get_student_mastery_stats',
-    {},
-  )
-  if (masteryError) throw new Error(`Failed to fetch mastery stats: ${masteryError.message}`)
+  // Two independent reads, run in parallel:
+  //  - Per-subject mastery counts aggregated in Postgres (#540): the prior client-side
+  //    numerator/denominator reads truncated at the PostgREST 1000-row cap. The RPC returns
+  //    both subject-level (topic_id === null) and topic-level rows; we use the subject rows.
+  //  - Last-practiced attribution map (deferred #668 — this read is still truncated at the
+  //    1000-row cap). NOT used for mastery. Any-status non-deleted reproduces the legacy map
+  //    (active ∪ non-deleted-answered) exactly, so lastPracticedAt does not regress.
+  const [masteryRes, questionMapRes] = await Promise.all([
+    rpc<MasteryRow[]>(supabase, 'get_student_mastery_stats', {}),
+    supabase.from('questions').select('id, subject_id').is('deleted_at', null),
+  ])
+  if (masteryRes.error) {
+    throw new Error(`Failed to fetch mastery stats: ${masteryRes.error.message}`)
+  }
+  if (questionMapRes.error) {
+    throw new Error(`Failed to fetch question-subject map: ${questionMapRes.error.message}`)
+  }
 
   const masteryBySubject = new Map<string, { total: number; correct: number }>()
-  for (const row of masteryData ?? []) {
+  for (const row of masteryRes.data ?? []) {
     if (row.topic_id !== null) continue
     if (!row.subject_id) continue
     masteryBySubject.set(row.subject_id, {
@@ -111,19 +119,8 @@ async function getSubjectProgressWithMap(supabase: SupabaseClient): Promise<Subj
     })
   }
 
-  // Last-practiced attribution only (deferred #668 — this read is still truncated at the
-  // 1000-row cap). NOT used for mastery. Any-status non-deleted reproduces the legacy map
-  // (active ∪ non-deleted-answered) exactly, so lastPracticedAt does not regress.
-  const { data: questionMapData, error: questionMapError } = await supabase
-    .from('questions')
-    .select('id, subject_id')
-    .is('deleted_at', null)
-  if (questionMapError) {
-    throw new Error(`Failed to fetch question-subject map: ${questionMapError.message}`)
-  }
-
   const questionSubjectMap = new Map<string, string>()
-  for (const q of (questionMapData ?? []) as QuestionIdSubjectRow[]) {
+  for (const q of (questionMapRes.data ?? []) as QuestionIdSubjectRow[]) {
     questionSubjectMap.set(q.id, q.subject_id)
   }
 

--- a/apps/web/lib/queries/dashboard.ts
+++ b/apps/web/lib/queries/dashboard.ts
@@ -1,5 +1,6 @@
 import { createServerSupabaseClient } from '@repo/db/server'
 import { cache } from 'react'
+import { rpc } from '@/lib/supabase-rpc'
 import {
   applyLastPracticed,
   computeExamReadiness,
@@ -38,7 +39,7 @@ export const getDashboardData = cache(async (): Promise<DashboardData> => {
   if (!user) throw new Error('Not authenticated')
 
   const [subjectResult, responses, questionsToday, streakData] = await Promise.all([
-    getSubjectProgressWithMap(supabase, user.id),
+    getSubjectProgressWithMap(supabase),
     getTotalAnswered(supabase, user.id),
     getQuestionsToday(supabase, user.id),
     getStreakData(supabase, user.id),
@@ -68,17 +69,19 @@ type SupabaseClient = Awaited<ReturnType<typeof createServerSupabaseClient>>
 
 type SubjectRow = { id: string; code: string; name: string; short: string; sort_order: number }
 type QuestionIdSubjectRow = { id: string; subject_id: string }
-type ResponseRow = { question_id: string }
+type MasteryRow = {
+  subject_id: string
+  topic_id: string | null
+  total: number | string
+  correct: number | string
+}
 
 type SubjectProgressResult = {
   subjects: SubjectProgress[]
   questionSubjectMap: Map<string, string>
 }
 
-async function getSubjectProgressWithMap(
-  supabase: SupabaseClient,
-  userId: string,
-): Promise<SubjectProgressResult> {
+async function getSubjectProgressWithMap(supabase: SupabaseClient): Promise<SubjectProgressResult> {
   const { data: subjectsData } = await supabase
     .from('easa_subjects')
     .select('id, code, name, short, sort_order')
@@ -87,59 +90,43 @@ async function getSubjectProgressWithMap(
   const subjects = (subjectsData ?? []) as SubjectRow[]
   if (!subjects.length) return { subjects: [], questionSubjectMap: new Map() }
 
-  const { data: questionCountsData } = await supabase
-    .from('questions')
-    .select('id, subject_id')
-    .eq('status', 'active')
-    .is('deleted_at', null)
+  // Per-subject mastery counts aggregated in Postgres (#540): the prior client-side
+  // numerator/denominator reads truncated at the PostgREST 1000-row cap. The RPC returns
+  // both subject-level (topic_id === null) and topic-level rows; we use the subject rows.
+  const { data: masteryData, error: masteryError } = await rpc<MasteryRow[]>(
+    supabase,
+    'get_student_mastery_stats',
+    {},
+  )
+  if (masteryError) throw new Error(`Failed to fetch mastery stats: ${masteryError.message}`)
 
-  const questionCounts = (questionCountsData ?? []) as QuestionIdSubjectRow[]
-
-  const { data: correctResponsesData } = await supabase
-    .from('student_responses')
-    .select('question_id')
-    .eq('student_id', userId)
-    .eq('is_correct', true)
-
-  const correctResponses = (correctResponsesData ?? []) as ResponseRow[]
-
-  const qCountMap = new Map<string, number>()
-  const questionSubjectMap = new Map<string, string>()
-  for (const q of questionCounts) {
-    qCountMap.set(q.subject_id, (qCountMap.get(q.subject_id) ?? 0) + 1)
-    questionSubjectMap.set(q.id, q.subject_id)
+  const masteryBySubject = new Map<string, { total: number; correct: number }>()
+  for (const row of masteryData ?? []) {
+    if (row.topic_id !== null) continue
+    if (!row.subject_id) continue
+    masteryBySubject.set(row.subject_id, {
+      total: Number(row.total),
+      correct: Number(row.correct),
+    })
   }
 
-  const correctQuestionIds = new Set(correctResponses.map((r) => r.question_id))
+  // Last-practiced attribution only (deferred #668 — this read is still truncated at the
+  // 1000-row cap). NOT used for mastery. Any-status non-deleted reproduces the legacy map
+  // (active ∪ non-deleted-answered) exactly, so lastPracticedAt does not regress.
+  const { data: questionMapData } = await supabase
+    .from('questions')
+    .select('id, subject_id')
+    .is('deleted_at', null)
 
-  // Guard the empty-array case: PostgREST rejects `.in('id', [])`. Also short-circuits
-  // the query entirely when the student has no correct responses yet.
-  const { data: correctQuestionsData } =
-    correctQuestionIds.size > 0
-      ? await supabase
-          .from('questions')
-          .select('id, subject_id')
-          .is('deleted_at', null)
-          .in('id', [...correctQuestionIds])
-      : { data: [] }
-
-  const correctQuestions = (correctQuestionsData ?? []) as QuestionIdSubjectRow[]
-
-  const correctPerSubject = new Map<string, Set<string>>()
-  for (const q of correctQuestions) {
-    let set = correctPerSubject.get(q.subject_id)
-    if (!set) {
-      set = new Set()
-      correctPerSubject.set(q.subject_id, set)
-    }
-    set.add(q.id)
+  const questionSubjectMap = new Map<string, string>()
+  for (const q of (questionMapData ?? []) as QuestionIdSubjectRow[]) {
     questionSubjectMap.set(q.id, q.subject_id)
   }
 
   const result = subjects
     .map((s) => {
-      const total = qCountMap.get(s.id) ?? 0
-      const correct = correctPerSubject.get(s.id)?.size ?? 0
+      const counts = masteryBySubject.get(s.id) ?? { total: 0, correct: 0 }
+      const { total, correct } = counts
       return {
         id: s.id,
         code: s.code,

--- a/apps/web/lib/queries/progress.test.ts
+++ b/apps/web/lib/queries/progress.test.ts
@@ -331,4 +331,74 @@ describe('getProgressData', () => {
     expect(result[0]!.answeredCorrectly).toBe(1366)
     expect(result[0]!.masteryPercentage).toBe(100)
   })
+
+  it('coerces bigint-as-string total and correct at both subject and topic level', async () => {
+    // PostgREST may return bigint columns as strings. The MasteryRow type declares
+    // `total: number | string`; production code calls Number() before arithmetic.
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [{ id: 's1', code: 'AGK', name: 'Aircraft General', short: 'AGK', sort_order: 1 }],
+        })
+      if (table === 'easa_topics')
+        return buildChain({
+          data: [{ id: 't1', code: '050-01', name: 'Airframe', subject_id: 's1', sort_order: 1 }],
+        })
+      return buildChain({ data: null })
+    })
+    mockRpc.mockResolvedValue({
+      data: [
+        // Strings instead of numbers — simulates the bigint-as-string driver path.
+        { subject_id: 's1', topic_id: null, total: '8', correct: '4' },
+        { subject_id: 's1', topic_id: 't1', total: '8', correct: '4' },
+      ],
+      error: null,
+    })
+
+    const result = await getProgressData()
+    expect(result).toHaveLength(1)
+    expect(result[0]!.totalQuestions).toBe(8)
+    expect(result[0]!.answeredCorrectly).toBe(4)
+    expect(result[0]!.masteryPercentage).toBe(50)
+    const topic = result[0]!.topics.find((t) => t.id === 't1')!
+    expect(topic.totalQuestions).toBe(8)
+    expect(topic.answeredCorrectly).toBe(4)
+    expect(topic.masteryPercentage).toBe(50)
+  })
+
+  it('returns active and orphan subjects side by side without cross-contaminating their counts', async () => {
+    // Two subjects in one RPC result: s1 is active (total > 0), s2 is an orphan
+    // (total: 0, correct > 0). Verifies the partition loop does not mix their counts.
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [
+            { id: 's1', code: 'AGK', name: 'Aircraft General', short: 'AGK', sort_order: 1 },
+            { id: 's2', code: 'MET', name: 'Meteorology', short: 'MET', sort_order: 2 },
+          ],
+        })
+      if (table === 'easa_topics') return buildChain({ data: [] })
+      return buildChain({ data: null })
+    })
+    mockRpc.mockResolvedValue({
+      data: [
+        { subject_id: 's1', topic_id: null, total: 10, correct: 7 }, // active
+        { subject_id: 's2', topic_id: null, total: 0, correct: 2 }, // orphan
+      ],
+      error: null,
+    })
+
+    const result = await getProgressData()
+    expect(result).toHaveLength(2)
+
+    const agk = result.find((s) => s.id === 's1')!
+    expect(agk.totalQuestions).toBe(10)
+    expect(agk.answeredCorrectly).toBe(7)
+    expect(agk.masteryPercentage).toBe(70)
+
+    const met = result.find((s) => s.id === 's2')!
+    expect(met.totalQuestions).toBe(0)
+    expect(met.answeredCorrectly).toBe(2)
+    expect(met.masteryPercentage).toBe(0)
+  })
 })

--- a/apps/web/lib/queries/progress.test.ts
+++ b/apps/web/lib/queries/progress.test.ts
@@ -59,6 +59,29 @@ describe('getProgressData', () => {
     await expect(getProgressData()).rejects.toThrow('Auth error: session not found')
   })
 
+  it('throws when the easa_subjects read returns an error', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({ data: null, error: { message: 'subjects db error' } })
+      if (table === 'easa_topics') return buildChain({ data: [] })
+      return buildChain({ data: null })
+    })
+    await expect(getProgressData()).rejects.toThrow('Failed to fetch subjects: subjects db error')
+  })
+
+  it('throws when the easa_topics read returns an error', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [{ id: 's1', code: 'AGK', name: 'Aircraft General', short: 'AGK', sort_order: 1 }],
+        })
+      if (table === 'easa_topics')
+        return buildChain({ data: null, error: { message: 'topics db error' } })
+      return buildChain({ data: null })
+    })
+    await expect(getProgressData()).rejects.toThrow('Failed to fetch topics: topics db error')
+  })
+
   it('throws when the mastery-stats RPC returns an error', async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects') return buildChain({ data: [] })

--- a/apps/web/lib/queries/progress.test.ts
+++ b/apps/web/lib/queries/progress.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks ----------------------------------------------------------------
 
-const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+const { mockGetUser, mockFrom, mockRpc } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockFrom: vi.fn(),
+  mockRpc: vi.fn(),
 }))
 
 vi.mock('@repo/db/server', () => ({
@@ -12,6 +13,10 @@ vi.mock('@repo/db/server', () => ({
     auth: { getUser: mockGetUser },
     from: mockFrom,
   }),
+}))
+
+vi.mock('@/lib/supabase-rpc', () => ({
+  rpc: (...args: unknown[]) => mockRpc(...args),
 }))
 
 // ---- Subject under test ---------------------------------------------------
@@ -36,6 +41,8 @@ function buildChain(returnValue: unknown) {
 
 beforeEach(() => {
   vi.resetAllMocks()
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
+  mockRpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getProgressData', () => {
@@ -52,14 +59,20 @@ describe('getProgressData', () => {
     await expect(getProgressData()).rejects.toThrow('Auth error: session not found')
   })
 
-  it('returns empty array when there are no subjects', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
-
+  it('throws when the mastery-stats RPC returns an error', async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects') return buildChain({ data: [] })
       if (table === 'easa_topics') return buildChain({ data: [] })
-      if (table === 'questions') return buildChain({ data: [] })
-      if (table === 'student_responses') return buildChain({ data: [] })
+      return buildChain({ data: null })
+    })
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } })
+    await expect(getProgressData()).rejects.toThrow('Failed to fetch mastery stats: boom')
+  })
+
+  it('returns empty array when there are no subjects', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects') return buildChain({ data: [] })
+      if (table === 'easa_topics') return buildChain({ data: [] })
       return buildChain({ data: null })
     })
 
@@ -68,8 +81,6 @@ describe('getProgressData', () => {
   })
 
   it('calculates masteryPercentage per subject based on correct responses', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
-
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -79,20 +90,12 @@ describe('getProgressData', () => {
         return buildChain({
           data: [{ id: 't1', code: '050-01', name: 'Airframe', subject_id: 's1', sort_order: 1 }],
         })
-      if (table === 'questions')
-        return buildChain({
-          data: [
-            { id: 'q1', subject_id: 's1', topic_id: 't1', status: 'active' },
-            { id: 'q2', subject_id: 's1', topic_id: 't1', status: 'active' },
-            { id: 'q3', subject_id: 's1', topic_id: 't1', status: 'active' },
-            { id: 'q4', subject_id: 's1', topic_id: 't1', status: 'active' },
-          ],
-        })
-      if (table === 'student_responses')
-        return buildChain({
-          data: [{ question_id: 'q1' }, { question_id: 'q2' }], // 2 of 4 correct
-        })
       return buildChain({ data: null })
+    })
+    // 4 active questions, 2 answered correctly -> 50%
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: 4, correct: 2 }],
+      error: null,
     })
 
     const result = await getProgressData()
@@ -104,8 +107,6 @@ describe('getProgressData', () => {
   })
 
   it('includes topic breakdown within each subject', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
-
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -118,15 +119,15 @@ describe('getProgressData', () => {
             { id: 't2', code: '050-02', name: 'Engines', subject_id: 's1', sort_order: 2 },
           ],
         })
-      if (table === 'questions')
-        return buildChain({
-          data: [
-            { id: 'q1', subject_id: 's1', topic_id: 't1', status: 'active' },
-            { id: 'q2', subject_id: 's1', topic_id: 't2', status: 'active' },
-          ],
-        })
-      if (table === 'student_responses') return buildChain({ data: [{ question_id: 'q1' }] })
       return buildChain({ data: null })
+    })
+    mockRpc.mockResolvedValue({
+      data: [
+        { subject_id: 's1', topic_id: null, total: 2, correct: 1 },
+        { subject_id: 's1', topic_id: 't1', total: 1, correct: 1 },
+        { subject_id: 's1', topic_id: 't2', total: 1, correct: 0 },
+      ],
+      error: null,
     })
 
     const result = await getProgressData()
@@ -134,13 +135,11 @@ describe('getProgressData', () => {
     expect(result[0]!.topics).toHaveLength(2)
     const t1 = result[0]!.topics.find((t) => t.id === 't1')!
     const t2 = result[0]!.topics.find((t) => t.id === 't2')!
-    expect(t1.masteryPercentage).toBe(100) // q1 correct, 1 of 1
-    expect(t2.masteryPercentage).toBe(0) // q2 not correct, 0 of 1
+    expect(t1.masteryPercentage).toBe(100) // 1 of 1 correct
+    expect(t2.masteryPercentage).toBe(0) // 0 of 1 correct
   })
 
   it('filters out subjects with zero questions AND zero responses', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
-
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -150,12 +149,12 @@ describe('getProgressData', () => {
           ],
         })
       if (table === 'easa_topics') return buildChain({ data: [] })
-      if (table === 'questions')
-        return buildChain({
-          data: [{ id: 'q1', subject_id: 's1', topic_id: null, status: 'active' }],
-        })
-      if (table === 'student_responses') return buildChain({ data: [] })
       return buildChain({ data: null })
+    })
+    // Only s1 has counts; s2 has none and must be filtered out.
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: 1, correct: 0 }],
+      error: null,
     })
 
     const result = await getProgressData()
@@ -164,20 +163,18 @@ describe('getProgressData', () => {
   })
 
   it('keeps subject when it has no active questions but the student has correct responses to it', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
-
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
           data: [{ id: 's1', code: 'AIRLAW', name: 'Air Law', short: 'AIR', sort_order: 1 }],
         })
       if (table === 'easa_topics') return buildChain({ data: [] })
-      if (table === 'questions')
-        return buildChain({
-          data: [{ id: 'q1', subject_id: 's1', topic_id: 't1', status: 'draft' }],
-        })
-      if (table === 'student_responses') return buildChain({ data: [{ question_id: 'q1' }] })
       return buildChain({ data: null })
+    })
+    // Orphan subject: 0 active questions but 1 correct response retained.
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: 0, correct: 1 }],
+      error: null,
     })
 
     const result = await getProgressData()
@@ -189,8 +186,6 @@ describe('getProgressData', () => {
   })
 
   it('keeps topic when it has no active questions but the student has correct responses to it', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
-
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -203,15 +198,16 @@ describe('getProgressData', () => {
             { id: 't2', code: 'TOP2', name: 'Topic 2', subject_id: 's1', sort_order: 2 },
           ],
         })
-      if (table === 'questions')
-        return buildChain({
-          data: [
-            { id: 'q1', subject_id: 's1', topic_id: 't1', status: 'active' },
-            { id: 'q2', subject_id: 's1', topic_id: 't2', status: 'draft' },
-          ],
-        })
-      if (table === 'student_responses') return buildChain({ data: [{ question_id: 'q2' }] })
       return buildChain({ data: null })
+    })
+    // Subject has 1 active question; t2 is an orphan topic (0 active, 1 correct).
+    mockRpc.mockResolvedValue({
+      data: [
+        { subject_id: 's1', topic_id: null, total: 1, correct: 1 },
+        { subject_id: 's1', topic_id: 't1', total: 1, correct: 0 },
+        { subject_id: 's1', topic_id: 't2', total: 0, correct: 1 },
+      ],
+      error: null,
     })
 
     const result = await getProgressData()
@@ -227,8 +223,6 @@ describe('getProgressData', () => {
   })
 
   it('counts active and draft question responses separately at the topic level', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
-
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -238,15 +232,15 @@ describe('getProgressData', () => {
         return buildChain({
           data: [{ id: 't1', code: 'MET-01', name: 'Atmosphere', subject_id: 's1', sort_order: 1 }],
         })
-      if (table === 'questions')
-        return buildChain({
-          data: [
-            { id: 'q_active', subject_id: 's1', topic_id: 't1', status: 'active' },
-            { id: 'q_draft', subject_id: 's1', topic_id: 't1', status: 'draft' },
-          ],
-        })
-      if (table === 'student_responses') return buildChain({ data: [{ question_id: 'q_draft' }] })
       return buildChain({ data: null })
+    })
+    // 1 active question, 1 correct response (to a now-draft question) -> 100%.
+    mockRpc.mockResolvedValue({
+      data: [
+        { subject_id: 's1', topic_id: null, total: 1, correct: 1 },
+        { subject_id: 's1', topic_id: 't1', total: 1, correct: 1 },
+      ],
+      error: null,
     })
 
     const result = await getProgressData()
@@ -260,20 +254,18 @@ describe('getProgressData', () => {
   })
 
   it('sets masteryPercentage to 0 when a subject has questions but none answered correctly', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
-
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
           data: [{ id: 's1', code: 'AGK', name: 'Aircraft General', short: 'AGK', sort_order: 1 }],
         })
       if (table === 'easa_topics') return buildChain({ data: [] })
-      if (table === 'questions')
-        return buildChain({
-          data: [{ id: 'q1', subject_id: 's1', topic_id: 't1', status: 'active' }],
-        })
-      if (table === 'student_responses') return buildChain({ data: [] }) // no correct responses
       return buildChain({ data: null })
+    })
+    // 1 active question, no correct responses.
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's1', topic_id: null, total: 1, correct: 0 }],
+      error: null,
     })
 
     const result = await getProgressData()
@@ -286,8 +278,6 @@ describe('getProgressData', () => {
     // #540/#664: topic t1 has 1 active + 1 now-draft question; the student answered
     // BOTH correctly. answeredCorrectly (2) stays raw (orphan-retention signal), but
     // the derived percentage must not exceed 100.
-    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } })
-
     mockFrom.mockImplementation((table: string) => {
       if (table === 'easa_subjects')
         return buildChain({
@@ -297,16 +287,14 @@ describe('getProgressData', () => {
         return buildChain({
           data: [{ id: 't1', code: 'MET-01', name: 'Atmosphere', subject_id: 's1', sort_order: 1 }],
         })
-      if (table === 'questions')
-        return buildChain({
-          data: [
-            { id: 'q_active', subject_id: 's1', topic_id: 't1', status: 'active' },
-            { id: 'q_draft', subject_id: 's1', topic_id: 't1', status: 'draft' },
-          ],
-        })
-      if (table === 'student_responses')
-        return buildChain({ data: [{ question_id: 'q_active' }, { question_id: 'q_draft' }] })
       return buildChain({ data: null })
+    })
+    mockRpc.mockResolvedValue({
+      data: [
+        { subject_id: 's1', topic_id: null, total: 1, correct: 2 },
+        { subject_id: 's1', topic_id: 't1', total: 1, correct: 2 },
+      ],
+      error: null,
     })
 
     const result = await getProgressData()
@@ -316,6 +304,31 @@ describe('getProgressData', () => {
     expect(topic.masteryPercentage).toBe(100)
     expect(result[0]!.totalQuestions).toBe(1)
     expect(result[0]!.answeredCorrectly).toBe(2)
+    expect(result[0]!.masteryPercentage).toBe(100)
+  })
+
+  it('surfaces a high-volume subject at full count without 1000-row truncation', async () => {
+    // #540 regression: under the old unpaginated client reads, a subject whose
+    // active questions / correct responses fell outside the first 1000 rows showed
+    // 0% mastery. The RPC aggregates in Postgres, so the full count survives.
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'easa_subjects')
+        return buildChain({
+          data: [{ id: 's_tail', code: 'AIRLAW', name: 'Air Law', short: 'AIR', sort_order: 1 }],
+        })
+      if (table === 'easa_topics') return buildChain({ data: [] })
+      return buildChain({ data: null })
+    })
+    mockRpc.mockResolvedValue({
+      data: [{ subject_id: 's_tail', topic_id: null, total: 1366, correct: 1366 }],
+      error: null,
+    })
+
+    const result = await getProgressData()
+    expect(result).toHaveLength(1)
+    expect(result[0]!.id).toBe('s_tail')
+    expect(result[0]!.totalQuestions).toBe(1366)
+    expect(result[0]!.answeredCorrectly).toBe(1366)
     expect(result[0]!.masteryPercentage).toBe(100)
   })
 })

--- a/apps/web/lib/queries/progress.ts
+++ b/apps/web/lib/queries/progress.ts
@@ -1,4 +1,5 @@
 import { createServerSupabaseClient } from '@repo/db/server'
+import { rpc } from '@/lib/supabase-rpc'
 
 export type SubjectDetail = {
   id: string
@@ -26,8 +27,15 @@ export type TopicDetail = {
 
 type SubjectRow = { id: string; code: string; name: string; short: string; sort_order: number }
 type TopicRow = { id: string; code: string; name: string; subject_id: string; sort_order: number }
-type QuestionRow = { id: string; subject_id: string; topic_id: string; status: string }
-type ResponseRow = { question_id: string }
+// Aggregated mastery counts from get_student_mastery_stats(). topic_id === null marks a
+// subject-level row; a non-null topic_id marks a topic-level row. bigint arrives as
+// string or number depending on driver — coerce with Number() before use.
+type MasteryRow = {
+  subject_id: string
+  topic_id: string | null
+  total: number | string
+  correct: number | string
+}
 
 export async function getProgressData(): Promise<SubjectDetail[]> {
   const supabase = await createServerSupabaseClient()
@@ -38,73 +46,53 @@ export async function getProgressData(): Promise<SubjectDetail[]> {
   if (authError) throw new Error(`Auth error: ${authError.message}`)
   if (!user) throw new Error('Not authenticated')
 
-  const [subjectsRes, topicsRes, questionsRes, correctRes] = await Promise.all([
+  const [subjectsRes, topicsRes, masteryResult] = await Promise.all([
     supabase.from('easa_subjects').select('id, code, name, short, sort_order').order('sort_order'),
     supabase
       .from('easa_topics')
       .select('id, code, name, subject_id, sort_order')
       .order('sort_order'),
-    supabase.from('questions').select('id, subject_id, topic_id, status').is('deleted_at', null),
-    supabase
-      .from('student_responses')
-      .select('question_id')
-      .eq('student_id', user.id)
-      .eq('is_correct', true),
+    rpc<MasteryRow[]>(supabase, 'get_student_mastery_stats', {}),
   ])
+
+  if (masteryResult.error) {
+    throw new Error(`Failed to fetch mastery stats: ${masteryResult.error.message}`)
+  }
 
   const subjects = (subjectsRes.data ?? []) as SubjectRow[]
   const topics = (topicsRes.data ?? []) as TopicRow[]
-  const questions = (questionsRes.data ?? []) as QuestionRow[]
-  const correctIds = new Set(((correctRes.data ?? []) as ResponseRow[]).map((r) => r.question_id))
 
-  const qBySubject = new Map<string, string[]>()
-  const qByTopic = new Map<string, string[]>()
-  const subjectByQuestionId = new Map<string, string>()
-  const topicByQuestionId = new Map<string, string>()
-  for (const q of questions) {
-    subjectByQuestionId.set(q.id, q.subject_id)
-    if (q.topic_id) topicByQuestionId.set(q.id, q.topic_id)
-    if (q.status === 'active') {
-      const subjectArr = qBySubject.get(q.subject_id)
-      if (subjectArr) subjectArr.push(q.id)
-      else qBySubject.set(q.subject_id, [q.id])
-      if (q.topic_id) {
-        const topicArr = qByTopic.get(q.topic_id)
-        if (topicArr) topicArr.push(q.id)
-        else qByTopic.set(q.topic_id, [q.id])
-      }
-    }
-  }
-
-  const correctBySubject = new Map<string, number>()
-  const correctByTopic = new Map<string, number>()
-  for (const cid of correctIds) {
-    const sid = subjectByQuestionId.get(cid)
-    if (sid) correctBySubject.set(sid, (correctBySubject.get(sid) ?? 0) + 1)
-    const tid = topicByQuestionId.get(cid)
-    if (tid) correctByTopic.set(tid, (correctByTopic.get(tid) ?? 0) + 1)
+  // Partition the aggregated rows into subject-level (topic_id === null) and
+  // topic-level (topic_id !== null) count maps. Postgres aggregates well under the
+  // 1000-row PostgREST cap, so these counts are never truncated (#540).
+  const subjectMap = new Map<string, { total: number; correct: number }>()
+  const topicMap = new Map<string, { total: number; correct: number }>()
+  for (const row of masteryResult.data ?? []) {
+    if (!row.subject_id) continue
+    const counts = { total: Number(row.total), correct: Number(row.correct) }
+    if (row.topic_id === null) subjectMap.set(row.subject_id, counts)
+    else topicMap.set(row.topic_id, counts)
   }
 
   return subjects
     .map((s) => {
-      const sQuestions = qBySubject.get(s.id) ?? []
-      const sCorrect = correctBySubject.get(s.id) ?? 0
+      const { total: sTotal, correct: sCorrect } = subjectMap.get(s.id) ?? { total: 0, correct: 0 }
 
       const subjectTopics = topics
         .filter((t) => t.subject_id === s.id)
         .map((t) => {
-          const tQuestions = qByTopic.get(t.id) ?? []
-          const tCorrect = correctByTopic.get(t.id) ?? 0
+          const { total: tTotal, correct: tCorrect } = topicMap.get(t.id) ?? {
+            total: 0,
+            correct: 0,
+          }
           return {
             id: t.id,
             code: t.code,
             name: t.name,
-            totalQuestions: tQuestions.length,
+            totalQuestions: tTotal,
             answeredCorrectly: tCorrect,
             masteryPercentage:
-              tQuestions.length > 0
-                ? Math.min(Math.round((tCorrect / tQuestions.length) * 100), 100)
-                : 0,
+              tTotal > 0 ? Math.min(Math.round((tCorrect / tTotal) * 100), 100) : 0,
           }
         })
         .filter((t) => t.totalQuestions > 0 || t.answeredCorrectly > 0)
@@ -114,12 +102,9 @@ export async function getProgressData(): Promise<SubjectDetail[]> {
         code: s.code,
         name: s.name,
         short: s.short,
-        totalQuestions: sQuestions.length,
+        totalQuestions: sTotal,
         answeredCorrectly: sCorrect,
-        masteryPercentage:
-          sQuestions.length > 0
-            ? Math.min(Math.round((sCorrect / sQuestions.length) * 100), 100)
-            : 0,
+        masteryPercentage: sTotal > 0 ? Math.min(Math.round((sCorrect / sTotal) * 100), 100) : 0,
         topics: subjectTopics,
       }
     })

--- a/apps/web/lib/queries/progress.ts
+++ b/apps/web/lib/queries/progress.ts
@@ -55,6 +55,12 @@ export async function getProgressData(): Promise<SubjectDetail[]> {
     rpc<MasteryRow[]>(supabase, 'get_student_mastery_stats', {}),
   ])
 
+  if (subjectsRes.error) {
+    throw new Error(`Failed to fetch subjects: ${subjectsRes.error.message}`)
+  }
+  if (topicsRes.error) {
+    throw new Error(`Failed to fetch topics: ${topicsRes.error.message}`)
+  }
   if (masteryResult.error) {
     throw new Error(`Failed to fetch mastery stats: ${masteryResult.error.message}`)
   }

--- a/docs/database.md
+++ b/docs/database.md
@@ -658,6 +658,7 @@ verb_noun pattern:
   get_daily_activity         ← read, analytics: daily answer counts (zero-filled)
   get_subject_scores         ← read, analytics: avg scores by subject
   get_question_counts        ← read, per-(subject, topic, subtopic) question counts; replaces client-side counting that truncated at the PostgREST 1000-row cap (#614)
+  get_student_mastery_stats  ← read, student: per-(subject) and per-(subject,topic) mastery counts (total=active questions, correct=distinct correct to non-deleted any-status questions); replaces client-side aggregation that truncated at the PostgREST 1000-row cap (#540, umbrella #668)
 ```
 
 ### Security Model
@@ -2045,6 +2046,25 @@ Returns aggregated question counts grouped by `(subject_id, topic_id, subtopic_i
 **Migration:** `20260520000001_get_question_counts_rpc.sql`
 
 **Rationale:** Replaces client-side counting that silently truncated at the PostgREST 1000-row cap once the question bank crossed 1000 rows (#614).
+
+---
+
+#### `get_student_mastery_stats` — per-subject & per-topic mastery counts for the calling student
+
+Returns mastery counts at two granularities in one result set: a subject-level row (`topic_id IS NULL`) and topic-level rows (`topic_id NOT NULL`) per `(subject_id[, topic_id])`. Used by the student dashboard (`lib/queries/dashboard.ts`) and progress page (`lib/queries/progress.ts`) to compute per-subject/topic mastery without paging through the student's full response history.
+
+**Security:** `SECURITY INVOKER` (caller-context). RLS scopes the result — `tenant_isolation` on `questions` (org + `deleted_at IS NULL`, any status) and the `student_responses` policy (`student_id = auth.uid()`) — so no manual `auth.uid()` check is needed. An unauthenticated caller resolves `auth.uid()` to NULL and receives an empty set.
+
+**Parameters:** none (caller is always self).
+
+**Returns:** `TABLE(subject_id UUID, topic_id UUID, total BIGINT, correct BIGINT)`
+- `total` — `COUNT(DISTINCT)` of `status = 'active'` questions (denominator).
+- `correct` — `COUNT(DISTINCT)` of questions answered correctly, **any** status (numerator); can exceed `total` when the student answered a now-draft question (orphan retention, #540/#664). The percentage clamp and the `total>0 OR correct>0` orphan-retention filter stay in TypeScript, which consumes the raw counts.
+- `topic_id IS NULL` marks the subject-level aggregate row — a safe sentinel because `questions.topic_id` is `NOT NULL`.
+
+**Migration:** `20260521000005_student_mastery_stats_rpc.sql`
+
+**Rationale:** Replaces client-side numerator/denominator aggregation that silently truncated at the PostgREST 1000-row cap for students with >1000 responses or orgs with >1000 active questions (#540, instance #1 of umbrella #668).
 
 ---
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -2058,8 +2058,8 @@ Returns mastery counts at two granularities in one result set: a subject-level r
 **Parameters:** none (caller is always self).
 
 **Returns:** `TABLE(subject_id UUID, topic_id UUID, total BIGINT, correct BIGINT)`
-- `total` — `COUNT(DISTINCT)` of `status = 'active'` questions (denominator).
-- `correct` — `COUNT(DISTINCT)` of questions answered correctly, **any** status (numerator); can exceed `total` when the student answered a now-draft question (orphan retention, #540/#664). The percentage clamp and the `total>0 OR correct>0` orphan-retention filter stay in TypeScript, which consumes the raw counts.
+- `total` — `COUNT(*)` of `status = 'active'` questions in the `active_q` CTE (denominator; rows are already unique by `questions.id` PK, so no `DISTINCT` keyword is needed).
+- `correct` — count of **distinct** questions answered correctly, **any** status (numerator; the `correct_q` CTE dedups via `SELECT DISTINCT q.id`, then `COUNT(*)` over that set, so multiple correct attempts on one question count once); can exceed `total` when the student answered a now-draft question (orphan retention, #540/#664). The percentage clamp and the `total>0 OR correct>0` orphan-retention filter stay in TypeScript, which consumes the raw counts.
 - `topic_id IS NULL` marks the subject-level aggregate row — a safe sentinel because `questions.topic_id` is `NOT NULL`.
 
 **Migration:** `20260521000005_student_mastery_stats_rpc.sql`

--- a/docs/database.md
+++ b/docs/database.md
@@ -2053,7 +2053,7 @@ Returns aggregated question counts grouped by `(subject_id, topic_id, subtopic_i
 
 Returns mastery counts at two granularities in one result set: a subject-level row (`topic_id IS NULL`) and topic-level rows (`topic_id NOT NULL`) per `(subject_id[, topic_id])`. Used by the student dashboard (`lib/queries/dashboard.ts`) and progress page (`lib/queries/progress.ts`) to compute per-subject/topic mastery without paging through the student's full response history.
 
-**Security:** `SECURITY INVOKER` (caller-context). RLS scopes the result — `tenant_isolation` on `questions` (org + `deleted_at IS NULL`, any status) and the `student_responses` policy (`student_id = auth.uid()`) — so no manual `auth.uid()` check is needed. An unauthenticated caller resolves `auth.uid()` to NULL and receives an empty set.
+**Security:** `SECURITY INVOKER` (caller-context). The denominator is org-scoped by `tenant_isolation` on `questions` (org + `deleted_at IS NULL`, any status). `student_responses` has TWO SELECT policies — `students_read_responses` (`student_id = auth.uid()`) and `instructors_read_students` (org + instructor/admin role) — so RLS alone would let an instructor/admin caller aggregate org-wide. The numerator therefore self-scopes with an explicit `sr.student_id = auth.uid()` in `correct_q` (load-bearing, not redundant — matches the legacy client read's `.eq('student_id', userId)`). No `SECURITY DEFINER` auth preamble is needed: an unauthenticated caller resolves `auth.uid()` to NULL and receives an empty set.
 
 **Parameters:** none (caller is always self).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -229,6 +229,18 @@ pnpm --filter @repo/web e2e:redteam
 
 This runs a suite of adversarial tests that exploit cross-tenant access, RLS bypass, session forgery, and other attack vectors. If a test fails, the defense doesn't hold — treat as blocking.
 
+### Multiple Permissive SELECT Policies — RPCs Must Scope Explicitly
+
+PostgreSQL combines multiple **permissive** RLS policies with **OR**. When a table carries more than one permissive `SELECT` policy — typically a narrow per-user policy plus a broader role policy — RLS alone does **not** restrict a read to the calling user. A `SECURITY INVOKER` or `SECURITY DEFINER` function meant to return the **caller's own** rows from such a table MUST add an explicit predicate (`WHERE <owner_col> = auth.uid()`, or an `auth.uid() = p_student_id` identity guard). The explicit filter is load-bearing, not redundant.
+
+**Why:** `student_responses` has both `students_read_responses` (`student_id = auth.uid()`) and `instructors_read_students` (org + role in instructor/admin). `get_student_mastery_stats` (SECURITY INVOKER) aggregated it relying on RLS, so an instructor/admin caller received **every** student's counts instead of their own (#540 / red-team BW3). Fix: explicit `WHERE sr.student_id = auth.uid()` in the numerator CTE.
+
+**Tables with multiple permissive SELECT policies** (audit when adding an RPC that reads one): `student_responses`, `quiz_sessions`, `exam_configs`, `audit_events`.
+
+**Migration discipline:** when porting a client-side Supabase query to an RPC, replicate the old query's explicit ownership filters (`.eq('student_id', userId)`) in SQL — do not assume RLS subsumes them. Admin/org-wide RPCs behind an `is_admin()` gate are intentionally broad and exempt.
+
+Verified repo-wide at promotion (2026-05-26): the only offender was `get_student_mastery_stats` (fixed); all other per-caller readers (`get_daily_activity`, `get_subject_scores`, `list_my_*`, report RPCs) already carry explicit `auth.uid()` scoping.
+
 ---
 
 ## 4. Correct Answer Stripping (Critical)

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,10 +1,4 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
 export type Database = {
   graphql_public: {
@@ -73,18 +67,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "audit_events_actor_id_fkey"
-            columns: ["actor_id"]
+            foreignKeyName: 'audit_events_actor_id_fkey'
+            columns: ['actor_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "audit_events_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'audit_events_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -127,25 +121,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "courses_created_by_fkey"
-            columns: ["created_by"]
+            foreignKeyName: 'courses_created_by_fkey'
+            columns: ['created_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "courses_deleted_by_fkey"
-            columns: ["deleted_by"]
+            foreignKeyName: 'courses_deleted_by_fkey'
+            columns: ['deleted_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "courses_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'courses_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -197,11 +191,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "easa_subtopics_topic_id_fkey"
-            columns: ["topic_id"]
+            foreignKeyName: 'easa_subtopics_topic_id_fkey'
+            columns: ['topic_id']
             isOneToOne: false
-            referencedRelation: "easa_topics"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_topics'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -229,11 +223,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "easa_topics_subject_id_fkey"
-            columns: ["subject_id"]
+            foreignKeyName: 'easa_topics_subject_id_fkey'
+            columns: ['subject_id']
             isOneToOne: false
-            referencedRelation: "easa_subjects"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_subjects'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -261,25 +255,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "exam_config_distributions_exam_config_id_fkey"
-            columns: ["exam_config_id"]
+            foreignKeyName: 'exam_config_distributions_exam_config_id_fkey'
+            columns: ['exam_config_id']
             isOneToOne: false
-            referencedRelation: "exam_configs"
-            referencedColumns: ["id"]
+            referencedRelation: 'exam_configs'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "exam_config_distributions_subtopic_id_fkey"
-            columns: ["subtopic_id"]
+            foreignKeyName: 'exam_config_distributions_subtopic_id_fkey'
+            columns: ['subtopic_id']
             isOneToOne: false
-            referencedRelation: "easa_subtopics"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_subtopics'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "exam_config_distributions_topic_id_fkey"
-            columns: ["topic_id"]
+            foreignKeyName: 'exam_config_distributions_topic_id_fkey'
+            columns: ['topic_id']
             isOneToOne: false
-            referencedRelation: "easa_topics"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_topics'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -322,18 +316,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "exam_configs_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'exam_configs_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "exam_configs_subject_id_fkey"
-            columns: ["subject_id"]
+            foreignKeyName: 'exam_configs_subject_id_fkey'
+            columns: ['subject_id']
             isOneToOne: false
-            referencedRelation: "easa_subjects"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_subjects'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -358,18 +352,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "flagged_questions_question_id_fkey"
-            columns: ["question_id"]
+            foreignKeyName: 'flagged_questions_question_id_fkey'
+            columns: ['question_id']
             isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
+            referencedRelation: 'questions'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "flagged_questions_student_id_fkey"
-            columns: ["student_id"]
+            foreignKeyName: 'flagged_questions_student_id_fkey'
+            columns: ['student_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -427,18 +421,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "fsrs_cards_question_id_fkey"
-            columns: ["question_id"]
+            foreignKeyName: 'fsrs_cards_question_id_fkey'
+            columns: ['question_id']
             isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
+            referencedRelation: 'questions'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "fsrs_cards_student_id_fkey"
-            columns: ["student_id"]
+            foreignKeyName: 'fsrs_cards_student_id_fkey'
+            columns: ['student_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -493,46 +487,46 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "internal_exam_codes_consumed_session_id_fkey"
-            columns: ["consumed_session_id"]
+            foreignKeyName: 'internal_exam_codes_consumed_session_id_fkey'
+            columns: ['consumed_session_id']
             isOneToOne: false
-            referencedRelation: "quiz_sessions"
-            referencedColumns: ["id"]
+            referencedRelation: 'quiz_sessions'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "internal_exam_codes_issued_by_fkey"
-            columns: ["issued_by"]
+            foreignKeyName: 'internal_exam_codes_issued_by_fkey'
+            columns: ['issued_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "internal_exam_codes_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'internal_exam_codes_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "internal_exam_codes_student_id_fkey"
-            columns: ["student_id"]
+            foreignKeyName: 'internal_exam_codes_student_id_fkey'
+            columns: ['student_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "internal_exam_codes_subject_id_fkey"
-            columns: ["subject_id"]
+            foreignKeyName: 'internal_exam_codes_subject_id_fkey'
+            columns: ['subject_id']
             isOneToOne: false
-            referencedRelation: "easa_subjects"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_subjects'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "internal_exam_codes_voided_by_fkey"
-            columns: ["voided_by"]
+            foreignKeyName: 'internal_exam_codes_voided_by_fkey'
+            columns: ['voided_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -593,32 +587,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "lessons_course_id_fkey"
-            columns: ["course_id"]
+            foreignKeyName: 'lessons_course_id_fkey'
+            columns: ['course_id']
             isOneToOne: false
-            referencedRelation: "courses"
-            referencedColumns: ["id"]
+            referencedRelation: 'courses'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "lessons_created_by_fkey"
-            columns: ["created_by"]
+            foreignKeyName: 'lessons_created_by_fkey'
+            columns: ['created_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "lessons_deleted_by_fkey"
-            columns: ["deleted_by"]
+            foreignKeyName: 'lessons_deleted_by_fkey'
+            columns: ['deleted_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "lessons_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'lessons_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -652,11 +646,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "fk_organizations_deleted_by"
-            columns: ["deleted_by"]
+            foreignKeyName: 'fk_organizations_deleted_by'
+            columns: ['deleted_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -693,25 +687,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "question_banks_created_by_fkey"
-            columns: ["created_by"]
+            foreignKeyName: 'question_banks_created_by_fkey'
+            columns: ['created_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "question_banks_deleted_by_fkey"
-            columns: ["deleted_by"]
+            foreignKeyName: 'question_banks_deleted_by_fkey'
+            columns: ['deleted_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "question_banks_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'question_banks_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: true
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -742,18 +736,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "question_comments_question_id_fkey"
-            columns: ["question_id"]
+            foreignKeyName: 'question_comments_question_id_fkey'
+            columns: ['question_id']
             isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
+            referencedRelation: 'questions'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "question_comments_user_id_fkey"
-            columns: ["user_id"]
+            foreignKeyName: 'question_comments_user_id_fkey'
+            columns: ['user_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -829,53 +823,53 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "questions_bank_id_fkey"
-            columns: ["bank_id"]
+            foreignKeyName: 'questions_bank_id_fkey'
+            columns: ['bank_id']
             isOneToOne: false
-            referencedRelation: "question_banks"
-            referencedColumns: ["id"]
+            referencedRelation: 'question_banks'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "questions_created_by_fkey"
-            columns: ["created_by"]
+            foreignKeyName: 'questions_created_by_fkey'
+            columns: ['created_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "questions_deleted_by_fkey"
-            columns: ["deleted_by"]
+            foreignKeyName: 'questions_deleted_by_fkey'
+            columns: ['deleted_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "questions_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'questions_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "questions_subject_id_fkey"
-            columns: ["subject_id"]
+            foreignKeyName: 'questions_subject_id_fkey'
+            columns: ['subject_id']
             isOneToOne: false
-            referencedRelation: "easa_subjects"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_subjects'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "questions_subtopic_id_fkey"
-            columns: ["subtopic_id"]
+            foreignKeyName: 'questions_subtopic_id_fkey'
+            columns: ['subtopic_id']
             isOneToOne: false
-            referencedRelation: "easa_subtopics"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_subtopics'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "questions_topic_id_fkey"
-            columns: ["topic_id"]
+            foreignKeyName: 'questions_topic_id_fkey'
+            columns: ['topic_id']
             isOneToOne: false
-            referencedRelation: "easa_topics"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_topics'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -918,18 +912,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "quiz_drafts_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'quiz_drafts_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "quiz_drafts_student_id_fkey"
-            columns: ["student_id"]
+            foreignKeyName: 'quiz_drafts_student_id_fkey'
+            columns: ['student_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -963,18 +957,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "quiz_session_answers_question_id_fkey"
-            columns: ["question_id"]
+            foreignKeyName: 'quiz_session_answers_question_id_fkey'
+            columns: ['question_id']
             isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
+            referencedRelation: 'questions'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "quiz_session_answers_session_id_fkey"
-            columns: ["session_id"]
+            foreignKeyName: 'quiz_session_answers_session_id_fkey'
+            columns: ['session_id']
             isOneToOne: false
-            referencedRelation: "quiz_sessions"
-            referencedColumns: ["id"]
+            referencedRelation: 'quiz_sessions'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1035,32 +1029,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "quiz_sessions_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'quiz_sessions_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "quiz_sessions_student_id_fkey"
-            columns: ["student_id"]
+            foreignKeyName: 'quiz_sessions_student_id_fkey'
+            columns: ['student_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "quiz_sessions_subject_id_fkey"
-            columns: ["subject_id"]
+            foreignKeyName: 'quiz_sessions_subject_id_fkey'
+            columns: ['subject_id']
             isOneToOne: false
-            referencedRelation: "easa_subjects"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_subjects'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "quiz_sessions_topic_id_fkey"
-            columns: ["topic_id"]
+            foreignKeyName: 'quiz_sessions_topic_id_fkey'
+            columns: ['topic_id']
             isOneToOne: false
-            referencedRelation: "easa_topics"
-            referencedColumns: ["id"]
+            referencedRelation: 'easa_topics'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1100,32 +1094,32 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "student_responses_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'student_responses_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "student_responses_question_id_fkey"
-            columns: ["question_id"]
+            foreignKeyName: 'student_responses_question_id_fkey'
+            columns: ['question_id']
             isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
+            referencedRelation: 'questions'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "student_responses_session_id_fkey"
-            columns: ["session_id"]
+            foreignKeyName: 'student_responses_session_id_fkey'
+            columns: ['session_id']
             isOneToOne: false
-            referencedRelation: "quiz_sessions"
-            referencedColumns: ["id"]
+            referencedRelation: 'quiz_sessions'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "student_responses_student_id_fkey"
-            columns: ["student_id"]
+            foreignKeyName: 'student_responses_student_id_fkey'
+            columns: ['student_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1162,11 +1156,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "user_consents_user_id_fkey"
-            columns: ["user_id"]
+            foreignKeyName: 'user_consents_user_id_fkey'
+            columns: ['user_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1206,18 +1200,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "fk_users_deleted_by"
-            columns: ["deleted_by"]
+            foreignKeyName: 'fk_users_deleted_by'
+            columns: ['deleted_by']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "users_organization_id_fkey"
-            columns: ["organization_id"]
+            foreignKeyName: 'users_organization_id_fkey'
+            columns: ['organization_id']
             isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1244,18 +1238,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "flagged_questions_question_id_fkey"
-            columns: ["question_id"]
+            foreignKeyName: 'flagged_questions_question_id_fkey'
+            columns: ['question_id']
             isOneToOne: false
-            referencedRelation: "questions"
-            referencedColumns: ["id"]
+            referencedRelation: 'questions'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "flagged_questions_student_id_fkey"
-            columns: ["student_id"]
+            foreignKeyName: 'flagged_questions_student_id_fkey'
+            columns: ['student_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -1390,6 +1384,15 @@ export type Database = {
           total_questions: number
         }[]
       }
+      get_student_mastery_stats: {
+        Args: never
+        Returns: {
+          correct: number
+          subject_id: string
+          topic_id: string | null
+          total: number
+        }[]
+      }
       get_subject_scores: {
         Args: { p_limit?: number; p_student_id: string }
         Returns: {
@@ -1484,33 +1487,31 @@ export type Database = {
   }
 }
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -1519,23 +1520,23 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -1544,23 +1545,23 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -1569,36 +1570,36 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
+    | keyof DefaultSchema['Enums']
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
+    | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
     : never
 
 export const Constants = {
@@ -1609,4 +1610,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-

--- a/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
+++ b/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
@@ -1,0 +1,108 @@
+-- Per-subject and per-topic mastery counts for the calling student (#540, umbrella #668).
+--
+-- Replaces client-side aggregation in dashboard.ts / progress.ts that fetched the
+-- correct-responses numerator and the active-questions denominator as raw, unpaginated
+-- row sets. PostgREST silently truncates any unpaginated read at the 1000-row cap, so a
+-- student with >1000 responses (issue #540: 8,395) or an org with >1000 active questions
+-- (1,366) had per-subject mastery computed from an arbitrary first-1000-row subset — a
+-- completed subject answered "late" fell outside the window and showed 0%. Aggregation
+-- now runs inside Postgres (GROUP BY -> a few dozen count rows, well under the cap).
+--
+-- SECURITY INVOKER + RLS (same model as get_question_counts, #614, the prior fix for this
+-- identical bug class): the `tenant_isolation` policy on `questions` scopes every read to
+-- the caller's organization + deleted_at IS NULL (any status), and the `student_responses`
+-- RLS policy (student_id = auth.uid()) scopes the numerator to the caller. No manual
+-- org-scoping and no auth preamble are needed — an unauthenticated caller resolves
+-- auth.uid() to NULL, both policies match zero rows, and the function returns an empty set.
+--
+-- Preserves the PR #665 / d1cd4770 semantics EXACTLY (behaviour-preserving TS->SQL move):
+--   total   = COUNT(DISTINCT q.id) WHERE status = 'active'   (denominator; RLS already
+--             enforces org + deleted_at IS NULL).
+--   correct = COUNT(DISTINCT sr.question_id) for is_correct responses to questions of ANY
+--             status (numerator; RLS enforces org + non-deleted) — so `correct` can EXCEED
+--             `total` when the student answered a now-draft question. The percentage clamp
+--             (min(.,100)) and the "include if total>0 OR correct>0" orphan-retention filter
+--             stay in TypeScript, which still consumes the raw counts.
+--
+-- The result set carries BOTH granularities in one round trip, distinguished by topic_id:
+--   topic_id IS NULL  -> subject-level aggregate row (NULL sentinel; safe because
+--                        questions.topic_id is NOT NULL, so no real question can ever
+--                        produce a NULL group key).
+--   topic_id NOT NULL -> topic-level aggregate row.
+
+CREATE OR REPLACE FUNCTION public.get_student_mastery_stats()
+RETURNS TABLE (
+  subject_id uuid,
+  topic_id   uuid,
+  total      bigint,
+  correct    bigint
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+SET search_path = public
+AS $$
+  WITH
+  -- DENOMINATOR: active questions visible to the caller (RLS = org + non-deleted).
+  active_q AS (
+    SELECT q.id, q.subject_id, q.topic_id
+    FROM questions q
+    WHERE q.status = 'active'
+  ),
+  -- NUMERATOR: distinct questions the caller answered correctly, attributed to the
+  -- question's own subject/topic. Any status (RLS = own responses + org + non-deleted).
+  correct_q AS (
+    SELECT DISTINCT q.id, q.subject_id, q.topic_id
+    FROM student_responses sr
+    JOIN questions q ON q.id = sr.question_id
+    WHERE sr.is_correct = true
+  ),
+  subj_total AS (
+    SELECT aq.subject_id, COUNT(*)::bigint AS total
+    FROM active_q aq
+    GROUP BY aq.subject_id
+  ),
+  subj_correct AS (
+    SELECT cq.subject_id, COUNT(*)::bigint AS correct
+    FROM correct_q cq
+    GROUP BY cq.subject_id
+  ),
+  topic_total AS (
+    SELECT aq.subject_id, aq.topic_id, COUNT(*)::bigint AS total
+    FROM active_q aq
+    GROUP BY aq.subject_id, aq.topic_id
+  ),
+  topic_correct AS (
+    SELECT cq.subject_id, cq.topic_id, COUNT(*)::bigint AS correct
+    FROM correct_q cq
+    GROUP BY cq.subject_id, cq.topic_id
+  )
+  -- Subject-level rows (topic_id = NULL sentinel). FULL JOIN keeps a subject present on
+  -- either side: active-only (correct absent -> 0) AND orphan correct-only (total absent
+  -- -> 0, the #540/#664 retention case). LEFT JOIN would drop pure-orphan subjects.
+  SELECT
+    COALESCE(st.subject_id, sc.subject_id) AS subject_id,
+    NULL::uuid                             AS topic_id,
+    COALESCE(st.total, 0)                  AS total,
+    COALESCE(sc.correct, 0)                AS correct
+  FROM subj_total st
+  FULL JOIN subj_correct sc ON sc.subject_id = st.subject_id
+
+  UNION ALL
+
+  -- Topic-level rows.
+  SELECT
+    COALESCE(tt.subject_id, tc.subject_id) AS subject_id,
+    COALESCE(tt.topic_id, tc.topic_id)     AS topic_id,
+    COALESCE(tt.total, 0)                  AS total,
+    COALESCE(tc.correct, 0)                AS correct
+  FROM topic_total tt
+  FULL JOIN topic_correct tc
+    ON tc.subject_id = tt.subject_id
+   AND tc.topic_id = tt.topic_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_student_mastery_stats() TO authenticated;
+
+COMMENT ON FUNCTION public.get_student_mastery_stats() IS
+  'Per-(subject) and per-(subject,topic) mastery counts for the calling student. total=active questions; correct=distinct correct responses to non-deleted questions of any status (can exceed total). topic_id NULL = subject-level row. SECURITY INVOKER + RLS scopes to caller org + own responses. Replaces client-side aggregation that truncated at the 1000-row cap (#540, umbrella #668).';

--- a/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
+++ b/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
@@ -10,10 +10,12 @@
 --
 -- SECURITY INVOKER + RLS (same model as get_question_counts, #614, the prior fix for this
 -- identical bug class): the `tenant_isolation` policy on `questions` scopes every read to
--- the caller's organization + deleted_at IS NULL (any status), and the `student_responses`
--- RLS policy (student_id = auth.uid()) scopes the numerator to the caller. No manual
--- org-scoping and no auth preamble are needed — an unauthenticated caller resolves
--- auth.uid() to NULL, both policies match zero rows, and the function returns an empty set.
+-- the caller's organization + deleted_at IS NULL (any status). The numerator additionally
+-- self-scopes with an explicit `sr.student_id = auth.uid()` (see correct_q) — student_responses
+-- has a second SELECT policy (instructors_read_students) that would otherwise let an
+-- instructor/admin aggregate org-wide, so RLS alone is not enough to keep it per-caller. No
+-- manual org-scoping and no auth preamble are needed — an unauthenticated caller resolves
+-- auth.uid() to NULL, the filters match zero rows, and the function returns an empty set.
 --
 -- Preserves the PR #665 / d1cd4770 semantics EXACTLY (behaviour-preserving TS->SQL move):
 --   total   = COUNT(DISTINCT q.id) WHERE status = 'active'   (denominator; RLS already
@@ -53,12 +55,18 @@ AS $$
     WHERE q.status = 'active'
   ),
   -- NUMERATOR: distinct questions the caller answered correctly, attributed to the
-  -- question's own subject/topic. Any status (RLS = own responses + org + non-deleted).
+  -- question's own subject/topic; any status (the questions JOIN is org + non-deleted via RLS).
+  -- The explicit `sr.student_id = auth.uid()` is REQUIRED, not redundant: student_responses
+  -- has a second SELECT policy (instructors_read_students) that lets an instructor/admin read
+  -- ALL responses in their org, so RLS alone would aggregate org-wide for those roles. This
+  -- self-scope keeps the numerator per-caller for every role (matches the legacy client read's
+  -- .eq('student_id', userId)). Unauthenticated → auth.uid() NULL → zero rows.
   correct_q AS (
     SELECT DISTINCT q.id, q.subject_id, q.topic_id
     FROM student_responses sr
     JOIN questions q ON q.id = sr.question_id
-    WHERE sr.is_correct = true
+    WHERE sr.student_id = auth.uid()
+      AND sr.is_correct = true
   ),
   subj_total AS (
     SELECT aq.subject_id, COUNT(*)::bigint AS total

--- a/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
+++ b/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
@@ -18,7 +18,8 @@
 -- auth.uid() to NULL, the filters match zero rows, and the function returns an empty set.
 --
 -- Preserves the PR #665 / d1cd4770 semantics EXACTLY (behaviour-preserving TS->SQL move):
---   total   = COUNT(DISTINCT q.id) WHERE status = 'active'   (denominator; RLS already
+--   total   = COUNT(*) over the active_q CTE (status = 'active') — rows are unique by the
+--             questions.id PK, so this equals COUNT(DISTINCT q.id) (denominator; RLS already
 --             enforces org + deleted_at IS NULL).
 --   correct = count of DISTINCT questions answered correctly — the correct_q CTE dedups
 --             per question via SELECT DISTINCT q.id (so multiple correct attempts on the

--- a/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
+++ b/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
@@ -113,10 +113,11 @@ AS $$
    AND tc.topic_id = tt.topic_id;
 $$;
 
--- Supabase's default function privileges also grant EXECUTE to anon (same as
--- get_question_counts and the other student-facing INVOKER RPCs). That is safe: an anon
--- caller resolves auth.uid() to NULL, and the RLS policies on questions/student_responses
--- yield an empty set. RLS — not the EXECUTE grant — is the access boundary here.
+-- This migration grants EXECUTE only to `authenticated` (same as get_question_counts).
+-- Supabase's platform defaults ALSO implicitly grant EXECUTE to `anon` on new functions — this
+-- migration does not add that, and it is safe to leave: an anon caller resolves auth.uid() to
+-- NULL and the RLS policies on questions/student_responses yield an empty set. RLS — not the
+-- EXECUTE grant — is the access boundary here.
 GRANT EXECUTE ON FUNCTION public.get_student_mastery_stats() TO authenticated;
 
 COMMENT ON FUNCTION public.get_student_mastery_stats() IS

--- a/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
+++ b/supabase/migrations/20260521000005_student_mastery_stats_rpc.sql
@@ -18,9 +18,12 @@
 -- Preserves the PR #665 / d1cd4770 semantics EXACTLY (behaviour-preserving TS->SQL move):
 --   total   = COUNT(DISTINCT q.id) WHERE status = 'active'   (denominator; RLS already
 --             enforces org + deleted_at IS NULL).
---   correct = COUNT(DISTINCT sr.question_id) for is_correct responses to questions of ANY
---             status (numerator; RLS enforces org + non-deleted) — so `correct` can EXCEED
---             `total` when the student answered a now-draft question. The percentage clamp
+--   correct = count of DISTINCT questions answered correctly — the correct_q CTE dedups
+--             per question via SELECT DISTINCT q.id (so multiple correct attempts on the
+--             same question count once), then COUNT(*) over that set. is_correct responses
+--             to questions of ANY status (numerator; RLS enforces org + non-deleted) — so
+--             `correct` can EXCEED `total` when the student answered a now-draft question.
+--             The percentage clamp
 --             (min(.,100)) and the "include if total>0 OR correct>0" orphan-retention filter
 --             stay in TypeScript, which still consumes the raw counts.
 --
@@ -102,6 +105,10 @@ AS $$
    AND tc.topic_id = tt.topic_id;
 $$;
 
+-- Supabase's default function privileges also grant EXECUTE to anon (same as
+-- get_question_counts and the other student-facing INVOKER RPCs). That is safe: an anon
+-- caller resolves auth.uid() to NULL, and the RLS policies on questions/student_responses
+-- yield an empty set. RLS — not the EXECUTE grant — is the access boundary here.
 GRANT EXECUTE ON FUNCTION public.get_student_mastery_stats() TO authenticated;
 
 COMMENT ON FUNCTION public.get_student_mastery_stats() IS


### PR DESCRIPTION
## Problem

Student dashboard (`/app/dashboard`) and progress (`/app/progress`) showed zero/wrong per-subject mastery for high-volume students. **Root cause (confirmed against prod):** both the mastery **numerator** (correct `student_responses`) and **denominator** (active `questions`) were fetched as raw, unpaginated reads and aggregated in JS. PostgREST silently truncates any unpaginated read at `max_rows=1000`, so both sides were computed from arbitrary first-1000-row subsets — a completed subject answered "late" fell outside the window and showed 0%. Direct SQL bypasses PostgREST, which is why every data probe looked clean. (Affected student: 8,395 responses; her org has 1,366 active questions — both > 1000.)

This is **instance #1 of umbrella #668** (the `max_rows=1000` truncation bug class).

## Fix

New student-facing `SECURITY INVOKER` RPC **`get_student_mastery_stats()`** (migration `20260521000005`) aggregates per-subject **and** per-topic `total`/`correct` in Postgres (`GROUP BY` → a few dozen count rows, never the underlying rows). `dashboard.ts` and `progress.ts` are rewired to call it. Mirrors the `get_question_counts` precedent (#614, same bug class).

**Behavior-preserving** — PR #665 mastery semantics are kept verbatim (clamp + orphan-retention filter stay in TS; raw `answeredCorrectly` unchanged). #664 mastery-semantics remains a separate open decision.

## Security (red-team caught a real bug — fixed in this PR)

`student_responses` has **two** permissive SELECT RLS policies (`students_read_responses` + `instructors_read_students`). Postgres ORs them, so an RLS-only numerator would let an instructor/admin caller aggregate **org-wide** counts instead of their own. Fixed by an explicit `sr.student_id = auth.uid()` in the numerator CTE (restores the legacy client read's `.eq('student_id', userId)`). **Verified locally:** an admin who answered nothing now gets `correct=0`; a student gets `correct=2, total=19` (incl. a draft-orphan). Promoted to hard rule **security.md §11** (+ `.coderabbit.yaml` sync); repo-wide sweep found no other offenders.

## Scope & follow-ups

- **In scope:** per-subject/topic mastery (resolves the #540 symptom).
- **Deferred (#668):** `dashboard-stats.ts` streak / last-practiced reads remain truncated.
- **#673** (P1/M): red-team E2E coverage for the RPC (unauth / cross-org / instructor self-scope).

## Verification

- New #540 regression test (subject past the legacy 1000-row window counted in full) + RPC-error test in both suites; **3388 unit tests pass**, check-types, build, and a clean `supabase db reset` all green.
- End-to-end verified against the local DB under `SET ROLE authenticated` (orphan/draft + BW3 cases).

## ⚠️ Do not auto-close #540

Intentionally **no closing keyword**. #540 stays open until the deployed RPC is verified against the affected student's real data (probe `get_student_mastery_stats()` for her account post-deploy). Part of umbrella **#668**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a student-facing RPC to return per-subject and per-topic mastery aggregates; dashboards and progress views now use it.

* **Bug Fixes**
  * Fixed truncation of mastery/progress counts for users with large histories; big counts and bigint strings handled correctly.

* **Security**
  * Added RLS/security guidance requiring explicit per-caller ownership predicates for per-user RPCs; updated security rules accordingly.

* **Documentation**
  * Documented RPC contract, mastery semantics, and security model.

* **Tests**
  * Updated and added regression and error-case tests to exercise the RPC-driven flows.

* **Chores**
  * Updated generated DB typings to include the new RPC.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->