### PR TITLE
docs(plan): mark #668 instance #5 (#682) merged

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,7 +2,7 @@
 
 > This is the master plan. Start every new session by reading this file.
 > User writes zero code. Claude plans, builds, tests, reviews, documents.
-> Last updated: 2026-05-27 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) implemented, pending merge. 12/12 P0 done.
+> Last updated: 2026-05-27 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) merged via #686. 12/12 P0 merged.
 
 ---
 
@@ -1210,10 +1210,10 @@ Pattern hit count=2 (`admin-students.spec.ts` precedent + `admin-questions.spec.
 
 ### Status
 
-- **Merged to master:** instance #1 (`get_student_mastery_stats`, `ae087c76`), instance #2 (`get_student_streak` + `get_student_last_practiced`, `9f40caae`), instance #3 (quiz.ts counts via `get_question_counts`, `8b134663`), and instance #4 (GDPR export pagination, `4538c649`).
-- **P0 progress:** 12 of 12 P0 sites fixed — 10 P0 sites merged across instances #1–#4, 2 implemented in **#682** (admin roster + `get_admin_student_stats` → new `get_admin_dashboard_students`), pending merge.
-- **Instance #5 (#682):** replaces the admin-roster fetch-all-merge-sort-slice and the `get_admin_student_stats` RPC with one `SECURITY DEFINER` RPC (`get_admin_dashboard_students`) that joins + filters + sorts + paginates + counts in Postgres; old RPC dropped. Validated on a clean `db reset`.
+- **Merged to master:** instance #1 (`get_student_mastery_stats`, `ae087c76`), instance #2 (`get_student_streak` + `get_student_last_practiced`, `9f40caae`), instance #3 (quiz.ts counts via `get_question_counts`, `8b134663`), instance #4 (GDPR export pagination, `4538c649`), and instance #5 (admin roster → `get_admin_dashboard_students`, PR #686).
+- **P0 progress:** 12 of 12 P0 sites fixed and merged — 10 across instances #1–#4, 2 in **#682** (admin roster + `get_admin_student_stats` → new `get_admin_dashboard_students`, PR #686).
+- **Instance #5 (#682):** replaces the admin-roster fetch-all-merge-sort-slice and the `get_admin_student_stats` RPC with one `SECURITY DEFINER` RPC (`get_admin_dashboard_students`) that joins + filters + sorts + paginates + counts in Postgres; old RPC dropped. Validated on a clean `db reset`; merged via PR #686.
 - **Pending:** prod verification via synthetic + real student probes (instances #1–#2).
 - **Note:** #668 was briefly auto-closed on 2026-05-26 by a `fix #668` token in a PR #676 commit title, then reopened — the umbrella stays open until all P0/P1/P2 sites land.
 
-*Last updated: 2026-05-27 — Instance #5 (#682) implemented; 12/12 P0 done (10 merged, 2 pending merge).*
+*Last updated: 2026-05-27 — Instance #5 (#682) merged via PR #686; 12/12 P0 done and merged.*


### PR DESCRIPTION
## What & why

#682 (umbrella #668's last P0) squash-merged to master via PR #686, so all 12 P0 PostgREST-truncation sites are now fixed **and merged**. `docs/plan.md` still described instance #5 as "pending merge" in three places — this syncs it.

## Change

- Flip the three `pending merge` references (top header, **P0 progress** line, footer marker) to **merged**.
- Add instance #5 to the **Merged to master** list (PR #686).

Docs-only; no code. Umbrella #668 stays open (P1/P2 remain).

Refs #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status documentation to reflect the successful completion and merge of scheduled features. All P0 priority milestones have been merged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->