### PR TITLE
fix(reads): paginate listOrgStudents + getComments (#668 instance #7)

### DIFF
--- a/apps/web/app/app/admin/internal-exams/_components/internal-exams-content.tsx
+++ b/apps/web/app/app/admin/internal-exams/_components/internal-exams-content.tsx
@@ -1,9 +1,5 @@
-import {
-  listExamSubjects,
-  listInternalExamAttempts,
-  listInternalExamCodes,
-  listOrgStudents,
-} from '../queries'
+import { listExamSubjects, listInternalExamAttempts, listInternalExamCodes } from '../queries'
+import { listOrgStudents } from '../students-queries'
 import { InternalExamsTabs } from './internal-exams-tabs'
 
 export async function InternalExamsContent() {

--- a/apps/web/app/app/admin/internal-exams/queries.ts
+++ b/apps/web/app/app/admin/internal-exams/queries.ts
@@ -7,7 +7,6 @@ import type {
   InternalExamCodeStatus,
   ListAttemptsFilters,
   ListCodesFilters,
-  OrgStudentOption,
 } from './types'
 
 const DEFAULT_LIMIT = 50
@@ -239,34 +238,6 @@ export async function listInternalExamAttempts(
   const nextCursor = hasMore ? (rows[rows.length - 1]?.startedAt ?? null) : null
 
   return { rows, nextCursor }
-}
-
-type StudentRowRaw = { id: string; full_name: string | null; email: string | null }
-
-export async function listOrgStudents(): Promise<OrgStudentOption[]> {
-  const { organizationId } = await requireAdmin()
-
-  // Cross-row reads on `users` are unreliable under tenant_isolation RLS
-  // (self-referential subquery). Mirrors apps/web/app/app/admin/students/queries.ts.
-  const { data, error } = await adminClient
-    .from('users')
-    .select('id, full_name, email')
-    .eq('organization_id', organizationId)
-    .eq('role', 'student')
-    .is('deleted_at', null)
-    .order('full_name', { ascending: true })
-
-  if (error) {
-    console.error('[listOrgStudents] DB error:', error.message)
-    throw new Error('Failed to load students')
-  }
-
-  const rows = (data ?? []) as StudentRowRaw[]
-  return rows.map((r) => ({
-    id: r.id,
-    fullName: r.full_name ?? '',
-    email: r.email ?? '',
-  }))
 }
 
 type SubjectRowRaw = { id: string; code: string; name: string }

--- a/apps/web/app/app/admin/internal-exams/students-queries.test.ts
+++ b/apps/web/app/app/admin/internal-exams/students-queries.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const mockRequireAdmin = vi.hoisted(() => vi.fn())
+const mockAdminFrom = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/auth/require-admin', () => ({ requireAdmin: mockRequireAdmin }))
+vi.mock('@repo/db/admin', () => ({ adminClient: { from: mockAdminFrom } }))
+
+// ---- Subject under test ---------------------------------------------------
+
+import { listOrgStudents } from './students-queries'
+
+// ---- Helpers ---------------------------------------------------------------
+
+const ORG_ID = 'org-001'
+
+function mockAdmin() {
+  mockRequireAdmin.mockResolvedValue({
+    organizationId: ORG_ID,
+    userId: 'admin-001',
+  })
+}
+
+/**
+ * Builds a chainable Supabase mock. Every chain method returns the same builder.
+ * The builder is thenable — awaiting it resolves to { data, error, count }.
+ * `count` is derived from data length when data is an array (for getCount calls),
+ * or passed explicitly as null for page calls where data is the real payload.
+ */
+function buildChain(
+  data: unknown,
+  error: { message: string } | null = null,
+  count: number | null = Array.isArray(data) ? data.length : null,
+) {
+  const resolved = { data, error, count }
+  const builder: Record<string, unknown> = {}
+  for (const fn of ['select', 'eq', 'is', 'order', 'range']) {
+    builder[fn] = vi.fn().mockReturnValue(builder)
+  }
+  // biome-ignore lint/suspicious/noThenProperty: supabase chain must be thenable to mock awaiting the query builder
+  builder.then = (cb: (v: typeof resolved) => unknown) => Promise.resolve(resolved).then(cb)
+  return builder
+}
+
+// ---- Tests ----------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('listOrgStudents', () => {
+  describe('happy path', () => {
+    it('maps rows to OrgStudentOption with id, fullName, and email', async () => {
+      mockAdmin()
+      const rows = [
+        { id: 'stu-1', full_name: 'Alice Smith', email: 'alice@example.com' },
+        { id: 'stu-2', full_name: 'Bob Jones', email: 'bob@example.com' },
+      ]
+      // fetchAllRows calls getCount first (reads .count), then getPage (reads .data)
+      mockAdminFrom
+        .mockReturnValueOnce(buildChain(null, null, rows.length)) // count call
+        .mockReturnValueOnce(buildChain(rows)) // page call
+
+      const result = await listOrgStudents()
+
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({
+        id: 'stu-1',
+        fullName: 'Alice Smith',
+        email: 'alice@example.com',
+      })
+      expect(result[1]).toEqual({ id: 'stu-2', fullName: 'Bob Jones', email: 'bob@example.com' })
+    })
+
+    it('falls back to empty string when full_name or email is null', async () => {
+      mockAdmin()
+      const rows = [{ id: 'stu-1', full_name: null, email: null }]
+      mockAdminFrom
+        .mockReturnValueOnce(buildChain(null, null, rows.length))
+        .mockReturnValueOnce(buildChain(rows))
+
+      const result = await listOrgStudents()
+
+      expect(result[0]).toEqual({ id: 'stu-1', fullName: '', email: '' })
+    })
+
+    it('returns an empty array when no students exist', async () => {
+      mockAdmin()
+      // count=0 → fetchAllRows loop never executes → data=[]
+      mockAdminFrom.mockReturnValueOnce(buildChain(null, null, 0))
+
+      const result = await listOrgStudents()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('error propagation', () => {
+    it('throws a sanitized message and logs the raw error when the DB query fails', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        mockAdmin()
+        // getCount resolves with an error → fetchAllRows short-circuits → listOrgStudents throws
+        mockAdminFrom.mockReturnValueOnce(buildChain(null, { message: 'boom' }, null))
+
+        await expect(listOrgStudents()).rejects.toThrow('Failed to load students')
+        expect(consoleErrorSpy).toHaveBeenCalledWith('[listOrgStudents] DB error:', 'boom')
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
+    })
+
+    it('propagates errors from requireAdmin', async () => {
+      mockRequireAdmin.mockRejectedValue(new Error('Forbidden'))
+
+      await expect(listOrgStudents()).rejects.toThrow('Forbidden')
+    })
+  })
+})

--- a/apps/web/app/app/admin/internal-exams/students-queries.test.ts
+++ b/apps/web/app/app/admin/internal-exams/students-queries.test.ts
@@ -52,7 +52,7 @@ beforeEach(() => {
 
 describe('listOrgStudents', () => {
   describe('happy path', () => {
-    it('maps rows to OrgStudentOption with id, fullName, and email', async () => {
+    it('returns student options with id, full name, and email', async () => {
       mockAdmin()
       const rows = [
         { id: 'stu-1', full_name: 'Alice Smith', email: 'alice@example.com' },
@@ -128,7 +128,7 @@ describe('listOrgStudents', () => {
       }
     })
 
-    it('propagates errors from requireAdmin', async () => {
+    it('rejects when the caller is not an admin', async () => {
       mockRequireAdmin.mockRejectedValue(new Error('Forbidden'))
 
       await expect(listOrgStudents()).rejects.toThrow('Forbidden')

--- a/apps/web/app/app/admin/internal-exams/students-queries.test.ts
+++ b/apps/web/app/app/admin/internal-exams/students-queries.test.ts
@@ -112,6 +112,22 @@ describe('listOrgStudents', () => {
       }
     })
 
+    it('throws when a page query fails after the count succeeds', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        mockAdmin()
+        // count succeeds with a non-zero total, then the first page query errors
+        mockAdminFrom
+          .mockReturnValueOnce(buildChain(null, null, 5))
+          .mockReturnValueOnce(buildChain(null, { message: 'page timeout' }, null))
+
+        await expect(listOrgStudents()).rejects.toThrow('Failed to load students')
+        expect(consoleErrorSpy).toHaveBeenCalledWith('[listOrgStudents] DB error:', 'page timeout')
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
+    })
+
     it('propagates errors from requireAdmin', async () => {
       mockRequireAdmin.mockRejectedValue(new Error('Forbidden'))
 

--- a/apps/web/app/app/admin/internal-exams/students-queries.ts
+++ b/apps/web/app/app/admin/internal-exams/students-queries.ts
@@ -1,0 +1,44 @@
+import { adminClient } from '@repo/db/admin'
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { fetchAllRows } from '@/lib/supabase-paginate'
+import type { OrgStudentOption } from './types'
+
+type StudentRowRaw = { id: string; full_name: string | null; email: string | null }
+
+export async function listOrgStudents(): Promise<OrgStudentOption[]> {
+  const { organizationId } = await requireAdmin()
+
+  // Cross-row reads on `users` are unreliable under tenant_isolation RLS
+  // (self-referential subquery). Mirrors apps/web/app/app/admin/students/queries.ts.
+  // Paginated via fetchAllRows to defeat the PostgREST 1000-row cap (#668).
+  const { data, error } = await fetchAllRows<StudentRowRaw>(
+    () =>
+      adminClient
+        .from('users')
+        .select('*', { count: 'exact', head: true })
+        .eq('organization_id', organizationId)
+        .eq('role', 'student')
+        .is('deleted_at', null),
+    (from, to) =>
+      adminClient
+        .from('users')
+        .select('id, full_name, email')
+        .eq('organization_id', organizationId)
+        .eq('role', 'student')
+        .is('deleted_at', null)
+        .order('full_name', { ascending: true })
+        .order('id', { ascending: true })
+        .range(from, to),
+  )
+
+  if (error) {
+    console.error('[listOrgStudents] DB error:', error.message)
+    throw new Error('Failed to load students')
+  }
+
+  return data.map((r) => ({
+    id: r.id,
+    fullName: r.full_name ?? '',
+    email: r.email ?? '',
+  }))
+}

--- a/apps/web/app/app/admin/internal-exams/students-queries.ts
+++ b/apps/web/app/app/admin/internal-exams/students-queries.ts
@@ -5,30 +5,37 @@ import type { OrgStudentOption } from './types'
 
 type StudentRowRaw = { id: string; full_name: string | null; email: string | null }
 
+// adminClient (service role) bypasses RLS: cross-row reads on `users` are
+// unreliable under tenant_isolation RLS (self-referential subquery). Mirrors
+// apps/web/app/app/admin/students/queries.ts. The count and page queries share
+// the identical org + role + deleted_at filter so the total matches the page set.
+function studentsCountQuery(organizationId: string) {
+  return adminClient
+    .from('users')
+    .select('*', { count: 'exact', head: true })
+    .eq('organization_id', organizationId)
+    .eq('role', 'student')
+    .is('deleted_at', null)
+}
+
+function studentsPageQuery(organizationId: string, from: number, to: number) {
+  return adminClient
+    .from('users')
+    .select('id, full_name, email')
+    .eq('organization_id', organizationId)
+    .eq('role', 'student')
+    .is('deleted_at', null)
+    .order('full_name', { ascending: true })
+    .order('id', { ascending: true })
+    .range(from, to)
+}
+
+// Paginated via fetchAllRows to defeat the PostgREST 1000-row cap (#668).
 export async function listOrgStudents(): Promise<OrgStudentOption[]> {
   const { organizationId } = await requireAdmin()
-
-  // Cross-row reads on `users` are unreliable under tenant_isolation RLS
-  // (self-referential subquery). Mirrors apps/web/app/app/admin/students/queries.ts.
-  // Paginated via fetchAllRows to defeat the PostgREST 1000-row cap (#668).
   const { data, error } = await fetchAllRows<StudentRowRaw>(
-    () =>
-      adminClient
-        .from('users')
-        .select('*', { count: 'exact', head: true })
-        .eq('organization_id', organizationId)
-        .eq('role', 'student')
-        .is('deleted_at', null),
-    (from, to) =>
-      adminClient
-        .from('users')
-        .select('id, full_name, email')
-        .eq('organization_id', organizationId)
-        .eq('role', 'student')
-        .is('deleted_at', null)
-        .order('full_name', { ascending: true })
-        .order('id', { ascending: true })
-        .range(from, to),
+    () => studentsCountQuery(organizationId),
+    (from, to) => studentsPageQuery(organizationId, from, to),
   )
 
   if (error) {

--- a/apps/web/app/app/quiz/actions/comment-queries.test.ts
+++ b/apps/web/app/app/quiz/actions/comment-queries.test.ts
@@ -84,7 +84,18 @@ describe('fetchQuestionComments', () => {
     expect(result).toEqual({ data: [], error: { message: 'boom' } })
   })
 
-  it('queries the question_comments table and forwards the questionId', async () => {
+  it('surfaces a page-level error after the count succeeds', async () => {
+    // count succeeds with a non-zero total, then the first page query errors
+    mockFrom
+      .mockReturnValueOnce(buildChain({ count: 3, data: null, error: null }))
+      .mockReturnValueOnce(buildChain({ count: null, data: null, error: { message: 'page fail' } }))
+
+    const result = await fetchQuestionComments(mockSupabase, QUESTION_ID)
+
+    expect(result).toEqual({ data: [], error: { message: 'page fail' } })
+  })
+
+  it('reads from the question_comments table', async () => {
     mockFrom.mockReturnValue(buildChain({ count: 1, data: [COMMENT_ROW], error: null }))
 
     await fetchQuestionComments(mockSupabase, QUESTION_ID)

--- a/apps/web/app/app/quiz/actions/comment-queries.test.ts
+++ b/apps/web/app/app/quiz/actions/comment-queries.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---- Mocks -----------------------------------------------------------------
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+}))
+
+const mockSupabase = {
+  from: mockFrom,
+} as unknown as import('@supabase/supabase-js').SupabaseClient<import('@repo/db/types').Database>
+
+// ---- Subject under test ----------------------------------------------------
+
+import { fetchQuestionComments } from './comment-queries'
+
+// ---- Helpers ---------------------------------------------------------------
+
+/**
+ * Builds a fluent Supabase chain that resolves to the given return value.
+ * fetchAllRows calls getCount (reads `count`) then getPage (reads `data`).
+ * We return a single object carrying BOTH so one chain mock serves both calls.
+ */
+function buildChain(returnValue: unknown) {
+  const awaitable = {
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable for Supabase chain mock
+    then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+      Promise.resolve(returnValue).then(resolve, reject),
+  }
+  return new Proxy(awaitable as Record<string, unknown>, {
+    get(target, prop) {
+      if (prop === 'then') return target.then
+      return (..._args: unknown[]) => buildChain(returnValue)
+    },
+  })
+}
+
+// ---- Fixtures --------------------------------------------------------------
+
+const USER_ID = '00000000-0000-4000-a000-000000000001'
+const QUESTION_ID = '00000000-0000-4000-a000-000000000011'
+const COMMENT_ID = '00000000-0000-4000-a000-000000000099'
+
+const COMMENT_ROW = {
+  id: COMMENT_ID,
+  question_id: QUESTION_ID,
+  user_id: USER_ID,
+  body: 'Great question about altimetry.',
+  created_at: '2026-03-20T10:00:00Z',
+  users: { full_name: 'Alice Pilot', role: 'student' },
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+describe('fetchQuestionComments', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns all comments for a question when the query succeeds', async () => {
+    mockFrom.mockReturnValue(buildChain({ count: 1, data: [COMMENT_ROW], error: null }))
+
+    const result = await fetchQuestionComments(mockSupabase, QUESTION_ID)
+
+    expect(result).toEqual({ data: [COMMENT_ROW], error: null })
+  })
+
+  it('returns an empty array when the question has no comments', async () => {
+    mockFrom.mockReturnValue(buildChain({ count: 0, data: [], error: null }))
+
+    const result = await fetchQuestionComments(mockSupabase, QUESTION_ID)
+
+    expect(result).toEqual({ data: [], error: null })
+  })
+
+  it('surfaces a database error and returns no rows', async () => {
+    // getCount returns the error — fetchAllRows short-circuits to { data: [], error }
+    mockFrom.mockReturnValue(buildChain({ count: null, data: null, error: { message: 'boom' } }))
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const result = await fetchQuestionComments(mockSupabase, QUESTION_ID)
+
+    consoleSpy.mockRestore()
+    expect(result).toEqual({ data: [], error: { message: 'boom' } })
+  })
+
+  it('queries the question_comments table and forwards the questionId', async () => {
+    mockFrom.mockReturnValue(buildChain({ count: 1, data: [COMMENT_ROW], error: null }))
+
+    await fetchQuestionComments(mockSupabase, QUESTION_ID)
+
+    expect(mockFrom).toHaveBeenCalledWith('question_comments')
+  })
+})

--- a/apps/web/app/app/quiz/actions/comment-queries.test.ts
+++ b/apps/web/app/app/quiz/actions/comment-queries.test.ts
@@ -74,13 +74,12 @@ describe('fetchQuestionComments', () => {
   })
 
   it('surfaces a database error and returns no rows', async () => {
-    // getCount returns the error — fetchAllRows short-circuits to { data: [], error }
+    // getCount returns the error — fetchAllRows short-circuits to { data: [], error }.
+    // The helper does not log (logging is the caller's job in comments.ts).
     mockFrom.mockReturnValue(buildChain({ count: null, data: null, error: { message: 'boom' } }))
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     const result = await fetchQuestionComments(mockSupabase, QUESTION_ID)
 
-    consoleSpy.mockRestore()
     expect(result).toEqual({ data: [], error: { message: 'boom' } })
   })
 

--- a/apps/web/app/app/quiz/actions/comment-queries.test.ts
+++ b/apps/web/app/app/quiz/actions/comment-queries.test.ts
@@ -93,12 +93,4 @@ describe('fetchQuestionComments', () => {
 
     expect(result).toEqual({ data: [], error: { message: 'page fail' } })
   })
-
-  it('reads from the question_comments table', async () => {
-    mockFrom.mockReturnValue(buildChain({ count: 1, data: [COMMENT_ROW], error: null }))
-
-    await fetchQuestionComments(mockSupabase, QUESTION_ID)
-
-    expect(mockFrom).toHaveBeenCalledWith('question_comments')
-  })
 })

--- a/apps/web/app/app/quiz/actions/comment-queries.ts
+++ b/apps/web/app/app/quiz/actions/comment-queries.ts
@@ -2,8 +2,11 @@ import type { Database } from '@repo/db/types'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { fetchAllRows } from '@/lib/supabase-paginate'
 
+// users!user_id is the FK-hint form (code-style.md §5): fail loudly on FK
+// resolution errors instead of silently returning null. Mirrors the
+// `users!student_id` embeds in admin/internal-exams/queries.ts.
 export const COMMENT_SELECT =
-  'id, question_id, user_id, body, created_at, users(full_name, role)' as const
+  'id, question_id, user_id, body, created_at, users!user_id(full_name, role)' as const
 
 export function fetchQuestionComments(supabase: SupabaseClient<Database>, questionId: string) {
   return fetchAllRows(

--- a/apps/web/app/app/quiz/actions/comment-queries.ts
+++ b/apps/web/app/app/quiz/actions/comment-queries.ts
@@ -1,0 +1,26 @@
+import type { Database } from '@repo/db/types'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { fetchAllRows } from '@/lib/supabase-paginate'
+
+export const COMMENT_SELECT =
+  'id, question_id, user_id, body, created_at, users(full_name, role)' as const
+
+export function fetchQuestionComments(supabase: SupabaseClient<Database>, questionId: string) {
+  return fetchAllRows(
+    () =>
+      supabase
+        .from('question_comments')
+        .select('*', { count: 'exact', head: true })
+        .eq('question_id', questionId)
+        .is('deleted_at', null),
+    (from, to) =>
+      supabase
+        .from('question_comments')
+        .select(COMMENT_SELECT)
+        .eq('question_id', questionId)
+        .is('deleted_at', null)
+        .order('created_at', { ascending: true })
+        .order('id', { ascending: true })
+        .range(from, to),
+  )
+}

--- a/apps/web/app/app/quiz/actions/comments.test.ts
+++ b/apps/web/app/app/quiz/actions/comments.test.ts
@@ -131,7 +131,7 @@ describe('getComments', () => {
     expect(result).toEqual({ success: true, comments: [] })
   })
 
-  it('forwards the parsed questionId to the query helper', async () => {
+  it('loads comments for the parsed question ID', async () => {
     setupAuthenticatedUser()
     mockFetchQuestionComments.mockResolvedValue({ data: [], error: null })
 

--- a/apps/web/app/app/quiz/actions/comments.test.ts
+++ b/apps/web/app/app/quiz/actions/comments.test.ts
@@ -131,15 +131,6 @@ describe('getComments', () => {
     expect(result).toEqual({ success: true, comments: [] })
   })
 
-  it('loads comments for the parsed question ID', async () => {
-    setupAuthenticatedUser()
-    mockFetchQuestionComments.mockResolvedValue({ data: [], error: null })
-
-    await getComments({ questionId: QUESTION_ID })
-
-    expect(mockFetchQuestionComments).toHaveBeenCalledWith(expect.anything(), QUESTION_ID)
-  })
-
   // ---- error handling ------------------------------------------------------
 
   it('returns a failure when the database query errors', async () => {

--- a/apps/web/app/app/quiz/actions/comments.test.ts
+++ b/apps/web/app/app/quiz/actions/comments.test.ts
@@ -17,7 +17,7 @@ vi.mock('@repo/db/server', () => ({
 
 vi.mock('./comment-queries', () => ({
   fetchQuestionComments: mockFetchQuestionComments,
-  COMMENT_SELECT: 'id, question_id, user_id, body, created_at, users(full_name, role)',
+  COMMENT_SELECT: 'id, question_id, user_id, body, created_at, users!user_id(full_name, role)',
 }))
 
 // ---- Subject under test ----------------------------------------------------

--- a/apps/web/app/app/quiz/actions/comments.test.ts
+++ b/apps/web/app/app/quiz/actions/comments.test.ts
@@ -15,10 +15,13 @@ vi.mock('@repo/db/server', () => ({
   }),
 }))
 
-vi.mock('./comment-queries', () => ({
-  fetchQuestionComments: mockFetchQuestionComments,
-  COMMENT_SELECT: 'id, question_id, user_id, body, created_at, users!user_id(full_name, role)',
-}))
+vi.mock('./comment-queries', async () => {
+  const actual = await vi.importActual<typeof import('./comment-queries')>('./comment-queries')
+  return {
+    ...actual,
+    fetchQuestionComments: mockFetchQuestionComments,
+  }
+})
 
 // ---- Subject under test ----------------------------------------------------
 

--- a/apps/web/app/app/quiz/actions/comments.test.ts
+++ b/apps/web/app/app/quiz/actions/comments.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks -----------------------------------------------------------------
 
-const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+const { mockGetUser, mockFrom, mockFetchQuestionComments } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockFrom: vi.fn(),
+  mockFetchQuestionComments: vi.fn(),
 }))
 
 vi.mock('@repo/db/server', () => ({
@@ -12,6 +13,11 @@ vi.mock('@repo/db/server', () => ({
     auth: { getUser: mockGetUser },
     from: mockFrom,
   }),
+}))
+
+vi.mock('./comment-queries', () => ({
+  fetchQuestionComments: mockFetchQuestionComments,
+  COMMENT_SELECT: 'id, question_id, user_id, body, created_at, users(full_name, role)',
 }))
 
 // ---- Subject under test ----------------------------------------------------
@@ -109,7 +115,7 @@ describe('getComments', () => {
 
   it('returns comments for the given question when the query succeeds', async () => {
     setupAuthenticatedUser()
-    mockFrom.mockReturnValue(buildChain({ data: [COMMENT_ROW], error: null }))
+    mockFetchQuestionComments.mockResolvedValue({ data: [COMMENT_ROW], error: null })
 
     const result = await getComments({ questionId: QUESTION_ID })
 
@@ -118,27 +124,30 @@ describe('getComments', () => {
 
   it('returns an empty array when the question has no comments', async () => {
     setupAuthenticatedUser()
-    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    mockFetchQuestionComments.mockResolvedValue({ data: [], error: null })
 
     const result = await getComments({ questionId: QUESTION_ID })
 
     expect(result).toEqual({ success: true, comments: [] })
   })
 
-  it('queries the question_comments table', async () => {
+  it('forwards the parsed questionId to the query helper', async () => {
     setupAuthenticatedUser()
-    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    mockFetchQuestionComments.mockResolvedValue({ data: [], error: null })
 
     await getComments({ questionId: QUESTION_ID })
 
-    expect(mockFrom).toHaveBeenCalledWith('question_comments')
+    expect(mockFetchQuestionComments).toHaveBeenCalledWith(expect.anything(), QUESTION_ID)
   })
 
   // ---- error handling ------------------------------------------------------
 
   it('returns a failure when the database query errors', async () => {
     setupAuthenticatedUser()
-    mockFrom.mockReturnValue(buildChain({ data: null, error: { message: 'connection timeout' } }))
+    mockFetchQuestionComments.mockResolvedValue({
+      data: [],
+      error: { message: 'connection timeout' },
+    })
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     const result = await getComments({ questionId: QUESTION_ID })

--- a/apps/web/app/app/quiz/actions/comments.ts
+++ b/apps/web/app/app/quiz/actions/comments.ts
@@ -2,6 +2,7 @@
 
 import { createServerSupabaseClient } from '@repo/db/server'
 import { z } from 'zod'
+import { COMMENT_SELECT, fetchQuestionComments } from './comment-queries'
 
 const GetCommentsSchema = z.object({ questionId: z.uuid() })
 const CreateCommentSchema = z.object({
@@ -9,8 +10,6 @@ const CreateCommentSchema = z.object({
   body: z.string().min(1).max(2000),
 })
 const DeleteCommentSchema = z.object({ commentId: z.uuid() })
-
-const COMMENT_SELECT = 'id, question_id, user_id, body, created_at, users(full_name, role)' as const
 
 export async function getComments(raw: unknown) {
   const supabase = await createServerSupabaseClient()
@@ -26,12 +25,7 @@ export async function getComments(raw: unknown) {
     return { success: false as const, error: 'Invalid input' }
   }
 
-  const { data, error } = await supabase
-    .from('question_comments')
-    .select(COMMENT_SELECT)
-    .eq('question_id', parsed.questionId)
-    .is('deleted_at', null)
-    .order('created_at', { ascending: true })
+  const { data, error } = await fetchQuestionComments(supabase, parsed.questionId)
 
   if (error) {
     console.error('[getComments]', error.message)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,7 +2,7 @@
 
 > This is the master plan. Start every new session by reading this file.
 > User writes zero code. Claude plans, builds, tests, reviews, documents.
-> Last updated: 2026-05-28 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) merged via #686 — completing all 12/12 P0 sites. Instance #6 (#678 + #679, filtered-question-pool RPCs — **P1** sites) merged via #691 (squash `67b9fcf9`); P1/P2 sites continue.
+> Last updated: 2026-05-29 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) merged via #686 — completing all 12/12 P0 sites. Instance #6 (#678 + #679, filtered-question-pool RPCs — **P1** sites) merged via #691 (squash `67b9fcf9`). Instance #7 (listOrgStudents + getComments — **P1** list reads, paginated via `fetchAllRows`) in progress on branch `fix/668-instance-7-p1-pagination`. P1/P2 sites continue.
 
 ---
 


### PR DESCRIPTION
## What & why
Umbrella **#668** instance #7 — the two remaining **P1** unbounded reads that silently cap at PostgREST's 1000-row limit:

- **`listOrgStudents`** (admin internal-exams org-student dropdown) — orgs with >1000 students lost entries for exam-code assignment.
- **`getComments`** (per-question comment thread) — threads past 1000 comments truncated.

Both now read via the established **`fetchAllRows`** helper (exact count → range-paged) with a deterministic **`id` tiebreaker** after the natural sort, so paging is stable. Each paginated read is extracted into a companion `-queries.ts` module (mirrors the GDPR `collect-user-data-queries.ts` precedent), which keeps the Server Action file under 100 lines and shrinks the already-over-limit `internal-exams/queries.ts`.

**Return contracts unchanged:** `OrgStudentOption[]` and `{ success, comments }`. No migration, no RPC, no RLS/auth change.

## Files
- **new** `quiz/actions/comment-queries.ts` — `COMMENT_SELECT` (FK-hinted `users!user_id(...)`) + `fetchQuestionComments`
- `quiz/actions/comments.ts` — delegates the read to the helper
- **new** `admin/internal-exams/students-queries.ts` — paginated `listOrgStudents` (extracted from `queries.ts`)
- `admin/internal-exams/queries.ts` — `listOrgStudents` removed
- `admin/internal-exams/_components/internal-exams-content.tsx` — import split
- new + updated co-located tests; `docs/plan.md` progress line

## Review trail
- Pre-commit: plan-critic + implementation-critic (clean)
- Post-commit: code-reviewer, semantic-reviewer (clean), doc-updater, test-writer, learner, **red-team** (pagination is authorization-transparent — no new vectors, `e2e:redteam` not required)
- **CodeRabbit local:** 4 rounds → 0 findings (applied: behavior-first test title, `users!user_id` FK-hint per code-style §5, dead spy removal, dropped 2 impl-coupled assertions per the PR#74 learning)
- `/fullpush`: lint, check-types, **3385 tests**, build — all green

## Follow-ups (deferred, tracked)
- #698 — split `internal-exams/queries.ts` under the 200-line limit (P2)
- #699 — promote "paginated fetch needs caller-level page-error test" to code-style §7 + sweep existing `fetchAllRows` call sites (P2)

Refs #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side student listing and centralized comment fetching to improve admin and quiz data retrieval.

* **Bug Fixes**
  * Admin pages and quiz comment sections now reliably load all records (handles >1000 rows/pagination).

* **Tests**
  * Added comprehensive tests covering student listing, comment retrieval, and error cases.

* **Documentation**
  * Updated project plan/status notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->