### PR TITLE
fix(profile): aggregate averageScore via get_student_profile_stats RPC (#668 instance #8)

### DIFF
--- a/apps/web/lib/queries/profile.test.ts
+++ b/apps/web/lib/queries/profile.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks ----------------------------------------------------------------
 
-const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+const { mockGetUser, mockFrom, mockRpc } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockFrom: vi.fn(),
+  mockRpc: vi.fn(),
 }))
 
 vi.mock('@repo/db/server', () => ({
@@ -12,6 +13,10 @@ vi.mock('@repo/db/server', () => ({
     auth: { getUser: mockGetUser },
     from: mockFrom,
   }),
+}))
+
+vi.mock('@/lib/supabase-rpc', () => ({
+  rpc: (...args: unknown[]) => mockRpc(...args),
 }))
 
 // ---- Subject under test ---------------------------------------------------
@@ -41,17 +46,20 @@ function buildChain(returnValue: unknown) {
   })
 }
 
+type StatsRow = { total_sessions: number | string; avg_score: number | string | null }
+
 type FromSetup = {
   profileError?: { message: string } | null
   profileData?: Record<string, unknown> | null
   orgData?: Record<string, unknown> | null
-  sessions?: { score_percentage: number | null }[]
+  statsRow?: StatsRow | null
   answeredCount?: number | null
 }
 
 /**
- * Sets up mockFrom to respond per table name.
- * Call order: users (profile), organizations, quiz_sessions, student_responses.
+ * Sets up the mocked Supabase client.
+ * `from` responds per table name (users -> profile, organizations, student_responses);
+ * profile stats come from the mocked `get_student_profile_stats` RPC (mockRpc).
  */
 function setupMocks({
   profileError = null,
@@ -62,7 +70,7 @@ function setupMocks({
     organization_id: ORG_ID,
   },
   orgData = { name: 'Sky Academy' },
-  sessions = [{ score_percentage: 80 }, { score_percentage: 60 }],
+  statsRow = { total_sessions: 2, avg_score: 70 },
   answeredCount = 42,
 }: FromSetup = {}) {
   mockFrom.mockImplementation((table: string) => {
@@ -72,14 +80,12 @@ function setupMocks({
     if (table === 'organizations') {
       return buildChain({ data: orgData, error: null })
     }
-    if (table === 'quiz_sessions') {
-      return buildChain({ data: sessions, error: null })
-    }
     if (table === 'student_responses') {
       return buildChain({ count: answeredCount, data: null })
     }
     return buildChain({ data: null, error: null })
   })
+  mockRpc.mockResolvedValue({ data: statsRow === null ? null : [statsRow], error: null })
 }
 
 // ---- Tests ----------------------------------------------------------------
@@ -119,24 +125,23 @@ describe('getProfileData', () => {
       expect(result.memberSince).toBe('2026-01-01T00:00:00Z')
     })
 
-    it('computes averageScore as the rounded mean of completed session scores', async () => {
+    it('returns the rounded average score reported by the stats RPC', async () => {
       mockAuthenticatedUser()
-      setupMocks({ sessions: [{ score_percentage: 80 }, { score_percentage: 60 }] })
+      setupMocks({ statsRow: { total_sessions: 2, avg_score: 85.5 } })
 
       const result = await getProfileData()
 
-      // (80 + 60) / 2 = 70
-      expect(result.stats.averageScore).toBe(70)
+      // 85.5 rounds to 86
+      expect(result.stats.averageScore).toBe(86)
     })
 
-    it('counts only sessions with a non-null score_percentage as completed', async () => {
+    it('returns totalSessions reported by the stats RPC', async () => {
       mockAuthenticatedUser()
-      setupMocks({ sessions: [{ score_percentage: 90 }, { score_percentage: null }] })
+      setupMocks({ statsRow: { total_sessions: 7, avg_score: 70 } })
 
       const result = await getProfileData()
 
-      expect(result.stats.totalSessions).toBe(1)
-      expect(result.stats.averageScore).toBe(90)
+      expect(result.stats.totalSessions).toBe(7)
     })
 
     it('returns totalAnswered from the student_responses count', async () => {
@@ -150,9 +155,9 @@ describe('getProfileData', () => {
   })
 
   describe('stats edge cases', () => {
-    it('returns averageScore of 0 when there are no completed sessions', async () => {
+    it('returns averageScore of 0 when the RPC reports no completed sessions', async () => {
       mockAuthenticatedUser()
-      setupMocks({ sessions: [] })
+      setupMocks({ statsRow: { total_sessions: 0, avg_score: null } })
 
       const result = await getProfileData()
 
@@ -160,14 +165,34 @@ describe('getProfileData', () => {
       expect(result.stats.averageScore).toBe(0)
     })
 
-    it('returns averageScore of 0 when all session scores are null', async () => {
+    it('coerces a string avg_score from PostgREST into a rounded number', async () => {
       mockAuthenticatedUser()
-      setupMocks({ sessions: [{ score_percentage: null }, { score_percentage: null }] })
+      // Postgres numeric AVG / bigint COUNT serialize as JSON strings.
+      setupMocks({ statsRow: { total_sessions: '2', avg_score: '85.5' } })
+
+      const result = await getProfileData()
+
+      expect(result.stats.totalSessions).toBe(2)
+      expect(result.stats.averageScore).toBe(86)
+    })
+
+    it('returns totalSessions 0 and averageScore 0 when the RPC payload is not an array', async () => {
+      mockAuthenticatedUser()
+      setupMocks()
+      mockRpc.mockResolvedValue({ data: { total_sessions: 3, avg_score: 50 }, error: null })
 
       const result = await getProfileData()
 
       expect(result.stats.totalSessions).toBe(0)
       expect(result.stats.averageScore).toBe(0)
+    })
+
+    it('throws when the stats RPC returns an error', async () => {
+      mockAuthenticatedUser()
+      setupMocks()
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'rpc boom' } })
+
+      await expect(getProfileData()).rejects.toThrow('Failed to fetch profile stats: rpc boom')
     })
 
     it('returns totalAnswered of 0 when count is null', async () => {
@@ -177,16 +202,6 @@ describe('getProfileData', () => {
       const result = await getProfileData()
 
       expect(result.stats.totalAnswered).toBe(0)
-    })
-
-    it('returns averageScore rounded to the nearest integer', async () => {
-      mockAuthenticatedUser()
-      setupMocks({ sessions: [{ score_percentage: 85 }, { score_percentage: 86 }] })
-
-      const result = await getProfileData()
-
-      // (85 + 86) / 2 = 85.5 → rounds to 86
-      expect(result.stats.averageScore).toBe(86)
     })
   })
 

--- a/apps/web/lib/queries/profile.test.ts
+++ b/apps/web/lib/queries/profile.test.ts
@@ -187,6 +187,29 @@ describe('getProfileData', () => {
       expect(result.stats.averageScore).toBe(0)
     })
 
+    it('returns totalSessions 0 and averageScore 0 when the RPC returns an empty array', async () => {
+      mockAuthenticatedUser()
+      setupMocks()
+      // Empty array: row is undefined, both values fall back to 0.
+      mockRpc.mockResolvedValue({ data: [], error: null })
+
+      const result = await getProfileData()
+
+      expect(result.stats.totalSessions).toBe(0)
+      expect(result.stats.averageScore).toBe(0)
+    })
+
+    it('returns averageScore of 0 when sessions exist but avg_score is null', async () => {
+      mockAuthenticatedUser()
+      // total_sessions > 0 but avg_score is null — the score guard short-circuits to 0.
+      setupMocks({ statsRow: { total_sessions: 5, avg_score: null } })
+
+      const result = await getProfileData()
+
+      expect(result.stats.totalSessions).toBe(5)
+      expect(result.stats.averageScore).toBe(0)
+    })
+
     it('throws when the stats RPC returns an error', async () => {
       mockAuthenticatedUser()
       setupMocks()

--- a/apps/web/lib/queries/profile.ts
+++ b/apps/web/lib/queries/profile.ts
@@ -97,6 +97,8 @@ async function getProfileStats(supabase: SupabaseClient, userId: string): Promis
   const averageScore =
     totalSessions > 0 && row?.avg_score != null ? Math.round(Number(row.avg_score)) : 0
 
+  // `userId` is only needed here: the head-count of answered questions is a safe
+  // count (no truncation). The stats RPC above takes no args and self-scopes via auth.uid().
   const { count } = await supabase
     .from('student_responses')
     .select('*', { count: 'exact', head: true })

--- a/apps/web/lib/queries/profile.ts
+++ b/apps/web/lib/queries/profile.ts
@@ -1,4 +1,5 @@
 import { createServerSupabaseClient } from '@repo/db/server'
+import { rpc } from '@/lib/supabase-rpc'
 
 export type ProfileData = {
   fullName: string | null
@@ -72,23 +73,29 @@ async function getProfile(supabase: SupabaseClient, userId: string) {
   }
 }
 
-type SessionRow = { score_percentage: number | null }
+// Postgres serializes numeric AVG (and bigint COUNT) as JSON strings, so accept both.
+type ProfileStatsRow = { total_sessions: number | string; avg_score: number | string | null }
 
 async function getProfileStats(supabase: SupabaseClient, userId: string): Promise<ProfileStats> {
-  const { data: sessions } = await supabase
-    .from('quiz_sessions')
-    .select('score_percentage')
-    .eq('student_id', userId)
-    .not('ended_at', 'is', null)
-    .is('deleted_at', null)
+  // Completed-session count + average score aggregated in Postgres (#668 P2): the prior
+  // client read fetched every session's score_percentage and counted/averaged in JS, which
+  // truncated at the PostgREST 1000-row cap for high-volume students. The RPC self-scopes to
+  // the caller (quiz_sessions is multi-permissive, security.md §11).
+  const { data: statsData, error: statsError } = await rpc<ProfileStatsRow[]>(
+    supabase,
+    'get_student_profile_stats',
+    {},
+  )
+  if (statsError) {
+    throw new Error(`Failed to fetch profile stats: ${statsError.message}`)
+  }
 
-  const completed = ((sessions ?? []) as SessionRow[]).filter((s) => s.score_percentage !== null)
-
-  const totalSessions = completed.length
+  // rpc() casts the payload without validating shape — guard the array per code-style §5.
+  const row = Array.isArray(statsData) ? statsData[0] : undefined
+  const totalSessions = Number(row?.total_sessions ?? 0)
+  // avg_score is the raw numeric mean; Math.round stays here to preserve the legacy rounding.
   const averageScore =
-    totalSessions > 0
-      ? Math.round(completed.reduce((sum, s) => sum + (s.score_percentage ?? 0), 0) / totalSessions)
-      : 0
+    totalSessions > 0 && row?.avg_score != null ? Math.round(Number(row.avg_score)) : 0
 
   const { count } = await supabase
     .from('student_responses')

--- a/docs/database.md
+++ b/docs/database.md
@@ -663,6 +663,7 @@ verb_noun pattern:
   get_student_mastery_stats  ← read, student: per-(subject) and per-(subject,topic) mastery counts (total=active questions, correct=distinct correct to non-deleted any-status questions); replaces client-side aggregation that truncated at the PostgREST 1000-row cap (#540, umbrella #668)
   get_student_streak         ← read, student: current + best daily-practice streak (all-time), computed in Postgres via gaps-and-islands over DISTINCT UTC response dates; replaces client-side computeStreaks over a .limit(10000) read that truncated at the 1000-row cap (#668)
   get_student_last_practiced ← read, student: most recent response timestamp per subject (all responses); retires the client-side questionSubjectMap + truncated questions read (#668)
+  get_student_profile_stats  ← read, student: completed-session count + average score (single-row COUNT + AVG over own non-deleted, ended, non-null-score quiz_sessions); replaces the client-side count/average that truncated at the PostgREST 1000-row cap (#668 P2, profile.ts)
 ```
 
 ### Security Model
@@ -2156,6 +2157,24 @@ Returns one row per subject the caller has answered, with the most recent respon
 **Migration:** `20260521000006_dashboard_secondary_stats_rpcs.sql`
 
 **Rationale:** Replaces client-side last-practiced attribution over a `.limit(5000)` read (ignored above the 1000-row cap) that falsely NULLed `lastPracticedAt` for subjects answered outside the most-recent ~1000 responses, and retires the coupled truncated `questions` read (the `questionSubjectMap`) deferred from PR #674 (#668).
+
+---
+
+#### `get_student_profile_stats` — completed-session count + average score for the calling student
+
+Returns a single aggregate row with the caller's completed-session count and average score, computed in Postgres via `COUNT(*)` + `AVG(score_percentage)`. Used by the settings/profile page (`lib/queries/profile.ts` → `getProfileStats`).
+
+**Security:** `SECURITY INVOKER`. `quiz_sessions` has MORE THAN ONE permissive SELECT policy (`students_select_sessions` = `student_id = auth.uid()`, and `instructors_read_sessions` = org + instructor/admin role), so RLS alone would let an instructor/admin caller average org-wide. The query self-scopes with an explicit `qs.student_id = auth.uid()` (load-bearing per security.md §3 (Multiple Permissive SELECT Policies), same multi-policy reason as `get_student_mastery_stats`). Unauthenticated caller → `auth.uid()` NULL → zero rows → `{0, NULL}`.
+
+**Parameters:** none (caller is always self).
+
+**Returns:** `TABLE(total_sessions BIGINT, avg_score NUMERIC)` — a no-`GROUP BY` aggregate always yields exactly one row.
+- `total_sessions` — `COUNT(*)` of the caller's `quiz_sessions` with `ended_at IS NOT NULL`, `deleted_at IS NULL`, and `score_percentage IS NOT NULL`. The non-null-score predicate makes the count match the legacy `.filter(s => s.score_percentage !== null)` set.
+- `avg_score` — raw `AVG(score_percentage)` over the same filtered set (`NULL` when none). `Math.round()` and the `totalSessions > 0 ? .. : 0` guard stay in TypeScript, which consumes the raw value (`avg_score` arrives as a JSON string because `score_percentage` is `NUMERIC(5,2)`; the caller coerces with `Number()`).
+
+**Migration:** `20260529000001_student_profile_stats_rpc.sql`
+
+**Rationale:** Replaces a client-side count/average over an unpaginated `quiz_sessions` read that silently truncated at the PostgREST 1000-row cap, skewing `totalSessions` and `averageScore` for high-volume students (#668 P2, profile.ts).
 
 ---
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,7 +2,7 @@
 
 > This is the master plan. Start every new session by reading this file.
 > User writes zero code. Claude plans, builds, tests, reviews, documents.
-> Last updated: 2026-05-29 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) merged via #686 — completing all 12/12 P0 sites. Instance #6 (#678 + #679, filtered-question-pool RPCs — **P1** sites) merged via #691 (squash `67b9fcf9`). Instance #7 (listOrgStudents + getComments — **P1** list reads, paginated via `fetchAllRows`) in progress on branch `fix/668-instance-7-p1-pagination`. P1/P2 sites continue.
+> Last updated: 2026-05-29 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) merged via #686 — completing all 12/12 P0 sites. Instance #6 (#678 + #679, filtered-question-pool RPCs — **P1** sites) merged via #691 (squash `67b9fcf9`). Instance #7 (listOrgStudents + getComments — **P1** list reads, paginated via `fetchAllRows`) merged via #700 (squash `0187d483`) — completing the P1 tier. Instance #8 (profile.ts averageScore → `get_student_profile_stats` aggregation RPC — first **P2** site) in PR (branch `fix/668-instance-8-profile-stats-rpc`). Remaining P2: 3 practically-bounded sites (active mock/internal exam lookups, drafts) deferred to a tracked follow-up.
 
 ---
 

--- a/supabase/migrations/20260529000001_student_profile_stats_rpc.sql
+++ b/supabase/migrations/20260529000001_student_profile_stats_rpc.sql
@@ -1,0 +1,53 @@
+-- Completed-session count + average score for the calling student (umbrella #668, P2).
+--
+-- Replaces the unpaginated quiz_sessions read in lib/queries/profile.ts:getProfileStats that
+-- fetched every completed session's score_percentage as a raw, unpaginated row set to count
+-- and average them in JavaScript. PostgREST silently truncates any unpaginated read at the
+-- 1000-row cap, so a high-volume student (the #540 profile: thousands of sessions) had both
+-- totalSessions and averageScore computed from an arbitrary first-1000-session subset.
+-- Aggregation now runs inside Postgres (COUNT + AVG -> a single row, never truncated).
+--
+-- SECURITY INVOKER + RLS, same model as get_student_mastery_stats (#540): the explicit
+-- `qs.student_id = auth.uid()` is REQUIRED, not redundant. quiz_sessions has MORE THAN ONE
+-- permissive SELECT policy (a student-own policy AND an instructor/admin org-read policy),
+-- which Postgres ORs together, so RLS alone would let an instructor/admin aggregate org-wide.
+-- The self-scope keeps the result per-caller for every role (matching the legacy read's
+-- .eq('student_id', userId)). See security.md §11 / docs/security.md §3 (Multiple Permissive
+-- SELECT Policies). No auth preamble is needed: an unauthenticated caller resolves auth.uid()
+-- to NULL, the filter matches zero rows, and the aggregate returns total_sessions 0 / avg_score NULL.
+--
+-- Behaviour-preserving TS->SQL move: the legacy code filtered completed sessions to those with
+-- a non-null score_percentage BEFORE counting (totalSessions = completed.length) and averaging.
+-- The `score_percentage IS NOT NULL` predicate reproduces that exactly, so COUNT(*) and AVG()
+-- operate on the identical filtered set. avg_score stays a raw numeric; the Math.round() and the
+-- `totalSessions > 0 ? .. : 0` guard remain in TypeScript, which still consumes the raw values.
+-- A no-GROUP-BY aggregate always returns exactly one row (NULL avg_score when no rows match).
+
+CREATE OR REPLACE FUNCTION public.get_student_profile_stats()
+RETURNS TABLE (
+  total_sessions bigint,
+  avg_score      numeric
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+SET search_path = public
+AS $$
+  SELECT
+    COUNT(*)::bigint          AS total_sessions,
+    AVG(qs.score_percentage)  AS avg_score
+  FROM quiz_sessions qs
+  WHERE qs.student_id = auth.uid()
+    AND qs.ended_at IS NOT NULL
+    AND qs.deleted_at IS NULL
+    AND qs.score_percentage IS NOT NULL;
+$$;
+
+-- Grants EXECUTE only to `authenticated` (same as get_student_mastery_stats / get_question_counts).
+-- Supabase platform defaults also implicitly grant EXECUTE to `anon`; that is safe to leave —
+-- an anon caller resolves auth.uid() to NULL and the filter yields zero rows. RLS + the
+-- auth.uid() self-scope, not the EXECUTE grant, are the access boundary here.
+GRANT EXECUTE ON FUNCTION public.get_student_profile_stats() TO authenticated;
+
+COMMENT ON FUNCTION public.get_student_profile_stats() IS
+  'Completed-session count (total_sessions) and average score (avg_score, raw numeric) for the calling student. Counts only sessions with ended_at IS NOT NULL, deleted_at IS NULL, and score_percentage IS NOT NULL (single-row aggregate; avg_score NULL when none). SECURITY INVOKER + explicit student_id = auth.uid() self-scope (quiz_sessions is multi-permissive, security.md §11). Replaces a client-side read that truncated at the PostgREST 1000-row cap (#668 P2, profile.ts).';


### PR DESCRIPTION
## What & why

First **P2** instance of umbrella #668 (PostgREST `max_rows=1000` silent truncation). `lib/queries/profile.ts:getProfileStats` fetched every completed session's `score_percentage` as a raw, unpaginated `quiz_sessions` row set and counted/averaged in JS — so a high-volume student (the #540 profile: hundreds–thousands of sessions) had `totalSessions` and `averageScore` computed from an arbitrary first-1000-session subset.

The aggregation now runs in Postgres via a new `SECURITY INVOKER` RPC `get_student_profile_stats()` (single-row `COUNT(*) + AVG(score_percentage)`), mirroring the established `get_student_mastery_stats` pattern.

## Changes
- **New migration `20260529000001_student_profile_stats_rpc.sql`** — `get_student_profile_stats()`: `SECURITY INVOKER`, `STABLE`, `SET search_path = public`, `GRANT EXECUTE TO authenticated`. Aggregates over the caller's own sessions: `WHERE student_id = auth.uid() AND ended_at IS NOT NULL AND deleted_at IS NULL AND score_percentage IS NOT NULL`.
- **`profile.ts`** — consume via `rpc<ProfileStatsRow[]>` with an `Array.isArray` guard (code-style §5), `Number()` coercion (`score_percentage` is `NUMERIC(5,2)` → PostgREST serializes AVG as a JSON string), `Math.round` + the `totalSessions>0` guard preserved in TS, sanitized throw on RPC error. The safe `student_responses` head-count (`totalAnswered`) is unchanged.
- **`profile.test.ts`** — RPC-mocked; 16 tests (rounding, string coercion, empty-array, non-array payload, null avg, error-throw, totalAnswered).
- **Docs** — `database.md` RPC summary + detail section; `plan.md` #668 progress line.

## Security — `docs/security.md` §3 / security.md §11 (Multiple Permissive SELECT Policies)
`quiz_sessions` has two permissive SELECT policies (`students_select_sessions` + `instructors_read_sessions`), which Postgres ORs together. The explicit `student_id = auth.uid()` self-scope is **load-bearing** — without it an instructor/admin caller would aggregate org-wide.

## Behaviour preservation
`score_percentage IS NOT NULL` reproduces the legacy `.filter(s => s.score_percentage !== null)` set exactly, so `COUNT(*)` matches `completed.length` and `AVG()` matches the JS mean. `Math.round` location unchanged.

## Verification
- **Local DB probe** (spoofed `request.jwt.claims`): student with {ended, non-null}×2 (80, 60) + null-score + soft-deleted + not-ended → **2 / 70** ✓; cross-student isolation holds; **instructor with no own sessions → 0 / NULL** (proves the §11 self-scope — org-wide would be 3 / 50) ✓; unauthenticated → 0 / NULL ✓.
- Migration applies cleanly (verified `SECURITY INVOKER` / `STABLE` / `search_path=public`). ⚠️ Full `supabase db reset` not run locally (CLI not installed) — CI's clean-reset migration job is the authoritative ordering check.
- `pnpm lint` / `check-types` / **3388 unit+integration tests** / `build` all green. CR-local: 0 findings.

## Pipeline
plan-critic ✓, impl-critic ✓ (0 findings), 4 post-commit agents + PR-level semantic sweep ✓ (0 CRITICAL/0 ISSUE), red-team ✓ (vectors CD1/CD2/CD3 absorbed into #673; `e2e:redteam` not required), learner ✓ (no new rules).

## Scope / follow-ups
- Completes the first P2 site. The 3 remaining P2 sites (active mock/internal-exam session lookups, draft loader) are **practically bounded by business invariants today** and deferred to **#701** (P2/M).
- Part of umbrella **#668**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where student profile statistics (total sessions and average score) were truncated for students with more than 1,000 sessions. Statistics are now computed server-side for improved accuracy and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->