### PR TITLE
docs(plan): reconcile #668 instances #7 + #8 in umbrella section

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1227,12 +1227,34 @@ Pattern hit count=2 (`admin-students.spec.ts` precedent + `admin-questions.spec.
 - **No migration.** `audit_events` read-only (immutability preserved); no correct-answer exposure. `flagged_questions` narrowed via a runtime type-guard filter that logs any dropped rows.
 - Covers the #668 P0 GDPR-export reads. `fetchAllRows` is the reusable pagination primitive for future #668 list/export fixes.
 
+### Instance #7: listOrgStudents + getComments — P1 list reads (merged via PR #700)
+
+**Commit:** `0187d483` (squash-merged via PR #700, 2026-05-29)
+
+- Two unpaginated **P1** list reads routed through `fetchAllRows`:
+  - `listOrgStudents` (admin service-role) extracted into `students-queries.ts`, removed from `queries.ts`, caller updated.
+  - `fetchQuestionComments` extracted into `comment-queries.ts` (paginated, `COMMENT_SELECT` with `users!user_id` FK-hint per code-style §5); `getComments` delegates to it.
+- **No migration** — pagination-only fix reusing the `fetchAllRows` primitive from instance #4.
+- Co-located tests incl. caller-level page-error coverage; behavior-first titles; partial `vi.importActual` mock keeps `COMMENT_SELECT` in sync.
+- Completes the **P1 tier**. Does not close #698 (`queries.ts` still >200 lines) or #699 (rule promotion + `fetchAllRows` sweep) — deferred follow-ups.
+
+### Instance #8: profile.ts averageScore → get_student_profile_stats — first P2 site (merged via PR #702)
+
+**Commit:** `49491481` (squash-merged via PR #702, 2026-05-29)
+
+- New RPC `get_student_profile_stats()` (mig `20260529000001`) — `COUNT + AVG` over the caller's own non-deleted, ended, non-null-score `quiz_sessions`. Replaces the unpaginated `getProfileStats` read that computed `totalSessions` + `averageScore` from an arbitrary first-1000-session subset for high-volume students (the #540 profile).
+- Security: `SECURITY INVOKER` + explicit `student_id = auth.uid()` self-scope — LOAD-BEARING per the Multiple Permissive RLS SELECT Policies rule (`docs/security.md §3`): `quiz_sessions` has two permissive SELECT policies (`students_select_sessions` + `instructors_read_sessions`), so RLS alone would let an instructor/admin caller average org-wide. Verified on local DB with a spoofed JWT (instructor with no own sessions → 0/NULL, not org-wide).
+- Behaviour-preserving: the `score_percentage IS NOT NULL` predicate reproduces the legacy `.filter(non-null)` set; `Math.round` + `totalSessions>0` guard stay in TS; `avg_score` arrives as a JSON string (NUMERIC(5,2)) coerced via `Number()`. The safe `student_responses` head-count (`totalAnswered`) is unchanged. `userId` arg now scopes only that head-count (RPC self-scopes via `auth.uid()`).
+- First **P2** site. The 3 practically-bounded P2 sites (active mock/internal exam lookups, drafts) are deferred to **#701**.
+
 ### Status
 
-- **Merged to master:** instance #1 (`get_student_mastery_stats`, `ae087c76`), instance #2 (`get_student_streak` + `get_student_last_practiced`, `9f40caae`), instance #3 (quiz.ts counts via `get_question_counts`, `8b134663`), instance #4 (GDPR export pagination, `4538c649`), instance #5 (admin roster → `get_admin_dashboard_students`, PR #686), and instance #6 (filtered-question-pool RPCs `get_random_question_ids` + `get_filtered_question_counts`, `67b9fcf9`, PR #691).
+- **Merged to master:** instance #1 (`get_student_mastery_stats`, `ae087c76`), instance #2 (`get_student_streak` + `get_student_last_practiced`, `9f40caae`), instance #3 (quiz.ts counts via `get_question_counts`, `8b134663`), instance #4 (GDPR export pagination, `4538c649`), instance #5 (admin roster → `get_admin_dashboard_students`, PR #686), instance #6 (filtered-question-pool RPCs `get_random_question_ids` + `get_filtered_question_counts`, `67b9fcf9`, PR #691), instance #7 (`listOrgStudents` + `getComments` paginated, `0187d483`, PR #700), and instance #8 (`get_student_profile_stats`, `49491481`, PR #702).
 - **P0 progress:** 12 of 12 P0 sites fixed and merged — 10 across instances #1–#4, 2 in **#682** (admin roster + `get_admin_student_stats` → new `get_admin_dashboard_students`, PR #686).
+- **P1 progress:** complete — instances #3 (quiz.ts counts) + #6 (filtered-pool RPCs) + #7 (`listOrgStudents` + `getComments` list reads).
+- **P2 progress:** instance #8 (profile stats RPC) merged — first P2 site. 3 practically-bounded P2 sites (active mock/internal exam lookups, drafts) tracked in **#701**.
 - **Instance #5 (#682):** replaces the admin-roster fetch-all-merge-sort-slice and the `get_admin_student_stats` RPC with one `SECURITY DEFINER` RPC (`get_admin_dashboard_students`) that joins + filters + sorts + paginates + counts in Postgres; old RPC dropped. Validated on a clean `db reset`; merged via PR #686.
 - **Pending:** prod verification via synthetic + real student probes (instances #1–#2).
 - **Note:** #668 was briefly auto-closed on 2026-05-26 by a `fix #668` token in a PR #676 commit title, then reopened — the umbrella stays open until all P0/P1/P2 sites land.
 
-*Last updated: 2026-05-28 — Instance #6 (#678 + #679) merged via PR #691 (squash `67b9fcf9`). 12/12 P0 merged.*
+*Last updated: 2026-05-29 — Instances #7 (`0187d483`, PR #700) + #8 (`49491481`, PR #702) merged. 12/12 P0 + full P1 tier merged; first P2 site (#8) done; P2 tail tracked in #701.*

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,7 +2,7 @@
 
 > This is the master plan. Start every new session by reading this file.
 > User writes zero code. Claude plans, builds, tests, reviews, documents.
-> Last updated: 2026-05-29 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) merged via #686 — completing all 12/12 P0 sites. Instance #6 (#678 + #679, filtered-question-pool RPCs — **P1** sites) merged via #691 (squash `67b9fcf9`). Instance #7 (listOrgStudents + getComments — **P1** list reads, paginated via `fetchAllRows`) merged via #700 (squash `0187d483`) — completing the P1 tier. Instance #8 (profile.ts averageScore → `get_student_profile_stats` aggregation RPC — first **P2** site) in PR (branch `fix/668-instance-8-profile-stats-rpc`). Remaining P2: 3 practically-bounded sites (active mock/internal exam lookups, drafts) deferred to a tracked follow-up.
+> Last updated: 2026-05-29 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) merged via #686 — completing all 12/12 P0 sites. Instance #6 (#678 + #679, filtered-question-pool RPCs — **P1** sites) merged via #691 (squash `67b9fcf9`). Instance #7 (listOrgStudents + getComments — **P1** list reads, paginated via `fetchAllRows`) merged via #700 (squash `0187d483`) — completing the P1 tier. Instance #8 (profile.ts averageScore → `get_student_profile_stats` aggregation RPC — first **P2** site) merged via #702 (squash `49491481`). Remaining P2: 3 practically-bounded sites (active mock/internal exam lookups, drafts) deferred to a tracked follow-up (#701).
 
 ---
 


### PR DESCRIPTION
Docs-only reconciliation of the #668 umbrella tracking in `docs/plan.md` for the two instances that merged on 2026-05-29. Mirrors prior reconciliation PRs (#683/#687/#693).

## What changed (`docs/plan.md`, +25/-3)
- **Header status line** — instance #8 flipped from "in PR (branch `fix/668-instance-8-profile-stats-rpc`)" to "merged via #702 (squash `49491481`)"; P2 tail now points at the tracked follow-up #701.
- **New detail sections** for instance #7 (`listOrgStudents` + `getComments` paginated via `fetchAllRows`, PR #700, `0187d483`) and instance #8 (`get_student_profile_stats` RPC, PR #702, `49491481`).
- **Status block** — added P1-progress (complete) and P2-progress (first site done) lines; extended the merged-to-master list with #7 + #8.

## Scope
- Pure documentation. No code, schema, or migration changes.
- **Does not close #668** — the umbrella stays open until the remaining P2 tail (#701: 3 practically-bounded reads) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning documentation to reflect milestone completions and current development progress status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->