### PR TITLE
fix(reads): bound 3 practically-bounded P2 reads with explicit .limit() (#668 instance #9)

### DIFF
--- a/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts
+++ b/apps/web/app/app/internal-exam/actions/get-active-internal-exam-session.ts
@@ -5,6 +5,7 @@ import {
   extractPassMark,
   extractQuestionIds,
   isExamOverdue,
+  MAX_ACTIVE_EXAM_SESSIONS,
 } from '@/app/app/quiz/actions/_overdue-helpers'
 import { rpc } from '@/lib/supabase-rpc'
 
@@ -57,6 +58,8 @@ export async function getActiveInternalExamSession(): Promise<GetActiveInternalE
       .is('deleted_at', null)
       .eq('mode', 'internal_exam')
       .order('started_at', { ascending: false })
+      // Deliberate bound — active sessions are structurally ~0–2; see MAX_ACTIVE_EXAM_SESSIONS.
+      .limit(MAX_ACTIVE_EXAM_SESSIONS)
 
     if (error) {
       console.error('[getActiveInternalExamSession] Query error:', error.message)

--- a/apps/web/app/app/quiz/actions/_overdue-helpers.ts
+++ b/apps/web/app/app/quiz/actions/_overdue-helpers.ts
@@ -1,5 +1,14 @@
-// Helpers for getActiveExamSession. Extracted so the action stays under the
-// 100-line cap from .claude/rules/code-style.md §1 after Layer 1 partitioning.
+// Helpers and bounds for the active-exam-session reads (mock_exam +
+// internal_exam). Extracted so the actions stay under the 100-line cap from
+// .claude/rules/code-style.md §1 after Layer 1 partitioning.
+
+// Deliberate read bound for getActiveExamSession / getActiveInternalExamSession
+// (#668 instance #9). Active (ended_at IS NULL) exam sessions per student are
+// structurally ~0–2; >this signals data corruption, not normal usage. The cap
+// makes the bound explicit instead of relying on PostgREST's implicit max_rows
+// (1000) silent truncation, and bounds the per-row complete_overdue_exam_session
+// RPC loop in both readers. 50 ≫ any real count, ≪ 1000.
+export const MAX_ACTIVE_EXAM_SESSIONS = 50
 
 export function extractQuestionIds(config: unknown): string[] | null {
   if (typeof config !== 'object' || config === null) return null

--- a/apps/web/app/app/quiz/actions/draft-helpers.ts
+++ b/apps/web/app/app/quiz/actions/draft-helpers.ts
@@ -24,6 +24,11 @@ type SaveDraftParsed = {
   subjectCode?: string
 }
 
+// Single source of truth for the saved-draft cap. Enforced at THREE points that
+// must stay in sync: (1) insertNewDraft below (TS count gate), (2) the
+// enforce_draft_limit DB trigger (mig 20260430000011, advisory-locked — hardcodes
+// 20), and (3) the loadDrafts read bound (load-draft.ts: `.limit(MAX_DRAFTS)`).
+// If this value changes, update the trigger migration's hardcoded 20 as well.
 export const MAX_DRAFTS = 20
 
 function sessionConfig(i: SaveDraftParsed) {

--- a/apps/web/app/app/quiz/actions/get-active-exam-session.ts
+++ b/apps/web/app/app/quiz/actions/get-active-exam-session.ts
@@ -2,7 +2,12 @@
 
 import { createServerSupabaseClient } from '@repo/db/server'
 import { rpc } from '@/lib/supabase-rpc'
-import { extractPassMark, extractQuestionIds, isExamOverdue } from './_overdue-helpers'
+import {
+  extractPassMark,
+  extractQuestionIds,
+  isExamOverdue,
+  MAX_ACTIVE_EXAM_SESSIONS,
+} from './_overdue-helpers'
 
 export type ActiveExamSession = {
   sessionId: string
@@ -41,6 +46,8 @@ export async function getActiveExamSession(): Promise<GetActiveExamSessionResult
       .is('deleted_at', null)
       .eq('mode', 'mock_exam')
       .order('started_at', { ascending: false })
+      // Deliberate bound — active sessions are structurally ~0–2; see MAX_ACTIVE_EXAM_SESSIONS.
+      .limit(MAX_ACTIVE_EXAM_SESSIONS)
 
     if (error) {
       console.error('[getActiveExamSession] Query error:', error.message)

--- a/apps/web/app/app/quiz/actions/load-draft.test.ts
+++ b/apps/web/app/app/quiz/actions/load-draft.test.ts
@@ -16,6 +16,7 @@ vi.mock('@repo/db/server', () => ({
 
 // ---- Subject under test ---------------------------------------------------
 
+import { MAX_DRAFTS } from './draft-helpers'
 import { loadDrafts } from './load-draft'
 
 // ---- Fixtures -------------------------------------------------------------
@@ -111,6 +112,16 @@ describe('loadDrafts', () => {
       subjectCode: 'MET',
       createdAt: '2026-03-12T10:00:00Z',
     })
+  })
+
+  it('bounds the read to the MAX_DRAFTS cap', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const chain = buildSelectChain({ data: [buildDraftRow()], error: null })
+    mockFrom.mockReturnValue(chain)
+
+    await loadDrafts()
+
+    expect(chain.limit).toHaveBeenCalledWith(MAX_DRAFTS)
   })
 
   it('maps feedback column to DraftData.feedback when present', async () => {

--- a/apps/web/app/app/quiz/actions/load-draft.test.ts
+++ b/apps/web/app/app/quiz/actions/load-draft.test.ts
@@ -38,10 +38,13 @@ function buildDraftRow(overrides: Record<string, unknown> = {}) {
 }
 
 function buildSelectChain(result: { data: unknown; error: unknown }) {
+  // loadDrafts now awaits after `.limit(MAX_DRAFTS)`, so `.order()` chains and
+  // `.limit()` is the terminal that resolves the result.
   return {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
-    order: vi.fn().mockResolvedValue(result),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(result),
   }
 }
 

--- a/apps/web/app/app/quiz/actions/load-draft.ts
+++ b/apps/web/app/app/quiz/actions/load-draft.ts
@@ -3,6 +3,7 @@
 import { createServerSupabaseClient } from '@repo/db/server'
 import type { Database } from '@repo/db/types'
 import type { AnswerFeedback, DraftData, LoadDraftsResult } from '../types'
+import { MAX_DRAFTS } from './draft-helpers'
 
 type QuizDraftRow = Database['public']['Tables']['quiz_drafts']['Row']
 type SessionConfig = { sessionId: string; subjectName?: string; subjectCode?: string }
@@ -72,6 +73,10 @@ export async function loadDrafts(): Promise<LoadDraftsResult> {
       .select('*')
       .eq('student_id', user.id)
       .order('updated_at', { ascending: false })
+      // Deliberate bound matching the insert-time cap enforced in insertNewDraft
+      // (draft-helpers.ts: rejects count >= MAX_DRAFTS). Makes the read bound
+      // explicit instead of relying on PostgREST's implicit max_rows truncation.
+      .limit(MAX_DRAFTS)
 
     if (error) {
       console.error('[loadDrafts] Query error:', error.message)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,7 +2,7 @@
 
 > This is the master plan. Start every new session by reading this file.
 > User writes zero code. Claude plans, builds, tests, reviews, documents.
-> Last updated: 2026-05-29 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) merged via #686 — completing all 12/12 P0 sites. Instance #6 (#678 + #679, filtered-question-pool RPCs — **P1** sites) merged via #691 (squash `67b9fcf9`). Instance #7 (listOrgStudents + getComments — **P1** list reads, paginated via `fetchAllRows`) merged via #700 (squash `0187d483`) — completing the P1 tier. Instance #8 (profile.ts averageScore → `get_student_profile_stats` aggregation RPC — first **P2** site) merged via #702 (squash `49491481`). Remaining P2: 3 practically-bounded sites (active mock/internal exam lookups, drafts) deferred to a tracked follow-up (#701).
+> Last updated: 2026-05-30 — Umbrella #668: PostgREST 1000-row truncation fixes. Instances #1–#4 merged (10 P0 sites); instance #5 (#682, admin roster → get_admin_dashboard_students) merged via #686 — completing all 12/12 P0 sites. Instance #6 (#678 + #679, filtered-question-pool RPCs — **P1** sites) merged via #691 (squash `67b9fcf9`). Instance #7 (listOrgStudents + getComments — **P1** list reads, paginated via `fetchAllRows`) merged via #700 (squash `0187d483`) — completing the P1 tier. Instance #8 (profile.ts averageScore → `get_student_profile_stats` aggregation RPC — first **P2** site) merged via #702 (squash `49491481`). Instance #9 (#701, the 3 practically-bounded P2 sites — active mock/internal exam lookups + drafts — given explicit `.limit()` bounds) implemented and in review on `fix/668-instance-9-bounded-reads`, completing the P2 tier on merge.
 
 ---
 
@@ -1245,16 +1245,26 @@ Pattern hit count=2 (`admin-students.spec.ts` precedent + `admin-questions.spec.
 - New RPC `get_student_profile_stats()` (mig `20260529000001`) — `COUNT + AVG` over the caller's own non-deleted, ended, non-null-score `quiz_sessions`. Replaces the unpaginated `getProfileStats` read that computed `totalSessions` + `averageScore` from an arbitrary first-1000-session subset for high-volume students (the #540 profile).
 - Security: `SECURITY INVOKER` + explicit `student_id = auth.uid()` self-scope — LOAD-BEARING per the Multiple Permissive RLS SELECT Policies rule (`docs/security.md §3`): `quiz_sessions` has two permissive SELECT policies (`students_select_sessions` + `instructors_read_sessions`), so RLS alone would let an instructor/admin caller average org-wide. Verified on local DB with a spoofed JWT (instructor with no own sessions → 0/NULL, not org-wide).
 - Behaviour-preserving: the `score_percentage IS NOT NULL` predicate reproduces the legacy `.filter(non-null)` set; `Math.round` + `totalSessions>0` guard stay in TS; `avg_score` arrives as a JSON string (NUMERIC(5,2)) coerced via `Number()`. The safe `student_responses` head-count (`totalAnswered`) is unchanged. `userId` arg now scopes only that head-count (RPC self-scopes via `auth.uid()`).
-- First **P2** site. The 3 practically-bounded P2 sites (active mock/internal exam lookups, drafts) are deferred to **#701**.
+- First **P2** site. The 3 practically-bounded P2 sites (active mock/internal exam lookups, drafts) are deferred to **#701** (instance #9 below).
+
+### Instance #9: active-exam + active-internal-exam + load-draft read bounds — P2 tail (#701, in review)
+
+**Commits:** `cd0add36` + `a6272d61` (branch `fix/668-instance-9-bounded-reads`)
+
+- The 3 remaining **P2** sites — all bounded by business invariants but querying unbounded, so silently relying on PostgREST's implicit `max_rows=1000` cap. Each gets an explicit, documented `.limit()` so the bound is deliberate (chosen over `fetchAllRows`: these are structurally tiny reads on hot page-load paths, and a count round-trip would defend a scenario the invariants already prevent):
+  - `get-active-exam-session.ts` + `get-active-internal-exam-session.ts`: `.limit(MAX_ACTIVE_EXAM_SESSIONS)` (=50, exported from `_overdue-helpers.ts`). Active (`ended_at IS NULL`) sessions per student are ~0–2; 50 ≫ realistic, ≪ 1000. Also bounds the per-row `complete_overdue_exam_session` RPC loop in both readers.
+  - `load-draft.ts`: `.limit(MAX_DRAFTS)` (=20), aligned with the insert-time `insertNewDraft` count gate and the advisory-locked `enforce_draft_limit` DB trigger (mig `20260430000011`). `MAX_DRAFTS` doc-comment now records all three sync points.
+- **No migration** — application-layer read bounding only. No behavior change for in-range data. `load-draft.test.ts` mock chain updated for the new `.limit()` terminal + an assertion that the cap is applied.
+- Closes **#701**. Completes the P2 tier — once merged, all P0/P1/P2 sites of umbrella #668 are addressed (`get_question_counts()` was already aggregated/bounded; no action).
 
 ### Status
 
 - **Merged to master:** instance #1 (`get_student_mastery_stats`, `ae087c76`), instance #2 (`get_student_streak` + `get_student_last_practiced`, `9f40caae`), instance #3 (quiz.ts counts via `get_question_counts`, `8b134663`), instance #4 (GDPR export pagination, `4538c649`), instance #5 (admin roster → `get_admin_dashboard_students`, PR #686), instance #6 (filtered-question-pool RPCs `get_random_question_ids` + `get_filtered_question_counts`, `67b9fcf9`, PR #691), instance #7 (`listOrgStudents` + `getComments` paginated, `0187d483`, PR #700), and instance #8 (`get_student_profile_stats`, `49491481`, PR #702).
 - **P0 progress:** 12 of 12 P0 sites fixed and merged — 10 across instances #1–#4, 2 in **#682** (admin roster + `get_admin_student_stats` → new `get_admin_dashboard_students`, PR #686).
 - **P1 progress:** complete — instances #3 (quiz.ts counts) + #6 (filtered-pool RPCs) + #7 (`listOrgStudents` + `getComments` list reads).
-- **P2 progress:** instance #8 (profile stats RPC) merged — first P2 site. 3 practically-bounded P2 sites (active mock/internal exam lookups, drafts) tracked in **#701**.
+- **P2 progress:** instance #8 (profile stats RPC) merged — first P2 site. Instance #9 (#701 — `.limit()` read bounds on active mock/internal exam lookups + drafts) implemented and in review on `fix/668-instance-9-bounded-reads`; completes the P2 tier on merge.
 - **Instance #5 (#682):** replaces the admin-roster fetch-all-merge-sort-slice and the `get_admin_student_stats` RPC with one `SECURITY DEFINER` RPC (`get_admin_dashboard_students`) that joins + filters + sorts + paginates + counts in Postgres; old RPC dropped. Validated on a clean `db reset`; merged via PR #686.
 - **Pending:** prod verification via synthetic + real student probes (instances #1–#2).
 - **Note:** #668 was briefly auto-closed on 2026-05-26 by a `fix #668` token in a PR #676 commit title, then reopened — the umbrella stays open until all P0/P1/P2 sites land.
 
-*Last updated: 2026-05-29 — Instances #7 (`0187d483`, PR #700) + #8 (`49491481`, PR #702) merged. 12/12 P0 + full P1 tier merged; first P2 site (#8) done; P2 tail tracked in #701.*
+*Last updated: 2026-05-30 — Instance #9 (#701, `.limit()` read bounds) implemented + in review on `fix/668-instance-9-bounded-reads`. 12/12 P0 + full P1 tier merged; P2 = #8 merged + #9 in review (completes the tier on merge).*


### PR DESCRIPTION
## What

Tail of umbrella #668 (PostgREST `max_rows=1000` silent-truncation audit). The three remaining P2 sites are bounded by business invariants but query unbounded, so they silently relied on the implicit 1000-row cap. Each now gets an **explicit, documented `.limit()`** so the bound is deliberate.

| Site | Bound | Invariant |
|---|---|---|
| `get-active-exam-session.ts` | `.limit(MAX_ACTIVE_EXAM_SESSIONS)` = 50 | active (`ended_at IS NULL`) sessions per student are ~0–2 |
| `get-active-internal-exam-session.ts` | `.limit(MAX_ACTIVE_EXAM_SESSIONS)` = 50 | same; also bounds the per-row `complete_overdue_exam_session` loop |
| `load-draft.ts` | `.limit(MAX_DRAFTS)` = 20 | matches the insert-time gate + advisory-locked `enforce_draft_limit` DB trigger |

## Why `.limit()` and not `fetchAllRows`

These are structurally tiny reads on hot page-load paths. `fetchAllRows` would add a `count` round-trip to defend a scenario the invariants already prevent. A code-level `.limit()` makes the bound deliberate (vs. the implicit 1000 cap) and also caps the per-row auto-complete RPC loop in the two exam-session readers. (Per #701 acceptance criteria, option 2.)

## Notes

- **No migration** — application-layer read bounding only. No behavior change for in-range data.
- `MAX_ACTIVE_EXAM_SESSIONS` added to `_overdue-helpers.ts` (shared by both exam readers).
- `MAX_DRAFTS` doc-comment now records its three sync points (TS count gate, DB trigger, read `.limit`).
- `load-draft.test.ts` mock chain updated for the new `.limit()` terminal + an assertion that the cap is applied.
- `docs/plan.md` records instance #9 (completes the P2 tier; `get_question_counts()` was already aggregated/bounded).

## Review

Per-commit + PR-level semantic review, plan/impl critics, code-reviewer, doc-updater, test-writer, red-team, security-auditor — all clear. 3404 unit tests + type-check + biome pass.

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added explicit limits to prevent silent data truncation when loading active exam sessions and draft exams, ensuring consistent behavior across the application.

* **Tests**
  * Updated test coverage to verify that query limits are properly applied.

* **Documentation**
  * Updated project documentation to reflect completion progress on data-bound optimization work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okpilot/lmsplus_v2/pull/705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->