### PR TITLE
chore(dependabot): consolidate npm entries into one pnpm-workspace-aware root entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,7 +47,15 @@ updates:
     labels:
       - tech-debt
     groups:
+      # Low-risk: batch into one PR meant to merge quickly.
       npm-all-minor-patch:
         update-types:
           - minor
           - patch
+      # Higher-risk: batch majors into their own PR for deliberate review /
+      # migration, so they don't block the minor/patch batch above. Both
+      # groups are workspace-wide (no patterns), so every update lands in a
+      # grouped PR — never a per-package one.
+      npm-all-major:
+        update-types:
+          - major

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,11 +20,11 @@ updates:
   # npm — whole pnpm workspace, managed from the root.
   #
   # The root "/" entry is pnpm-workspace-aware: it updates the dependency
-  # manifests in apps/web, packages/db, packages/ui and
-  # packages/typescript-config AND the single shared root pnpm-lock.yaml
-  # together, in one PR. (Verified by PR #692, which bumped @sentry/nextjs +
-  # shadcn in apps/web and @supabase/supabase-js in BOTH apps/web and
-  # packages/db, with a synced lockfile, in one green PR.)
+  # manifests of all workspace members declared in pnpm-workspace.yaml AND
+  # the single shared root pnpm-lock.yaml together, in one PR. (Verified by
+  # PR #692, which bumped @sentry/nextjs + shadcn in apps/web and
+  # @supabase/supabase-js in BOTH apps/web and packages/db, with a synced
+  # lockfile, in one green PR.)
   #
   # Why this is a single entry (not one per package): per-directory npm
   # entries made dependabot open a SEPARATE PR per package for the same

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,26 @@ updates:
           - minor
           - patch
 
-  # npm — root
+  # npm — whole pnpm workspace, managed from the root.
+  #
+  # The root "/" entry is pnpm-workspace-aware: it updates the dependency
+  # manifests in apps/web, packages/db, packages/ui and
+  # packages/typescript-config AND the single shared root pnpm-lock.yaml
+  # together, in one PR. (Verified by PR #692, which bumped @sentry/nextjs +
+  # shadcn in apps/web and @supabase/supabase-js in BOTH apps/web and
+  # packages/db, with a synced lockfile, in one green PR.)
+  #
+  # Why this is a single entry (not one per package): per-directory npm
+  # entries made dependabot open a SEPARATE PR per package for the same
+  # shared dependency. One @supabase/supabase-js 2.106.1 -> 2.106.2 bump
+  # produced #669 (packages/db) and #670 (apps/web) as separate PRs — each
+  # touched only its own package.json and neither updated the shared root
+  # pnpm-lock.yaml. Result: `pnpm install --frozen-lockfile` failed in CI on
+  # both, and the half-applied bump left a workspace version skew that split
+  # SupabaseClient<Database> into two incompatible copies (TS2345). The same
+  # bump was ALSO carried by the root entry's #692, so it existed in three
+  # overlapping PRs at once. Consolidating to the root entry makes every
+  # workspace-wide dependency move atomically with a synced lockfile.
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -28,71 +47,7 @@ updates:
     labels:
       - tech-debt
     groups:
-      npm-root-minor-patch:
-        update-types:
-          - minor
-          - patch
-
-  # npm — apps/web
-  - package-ecosystem: npm
-    directory: /apps/web
-    schedule:
-      interval: weekly
-      day: monday
-    commit-message:
-      prefix: "chore"
-    labels:
-      - tech-debt
-    groups:
-      npm-web-minor-patch:
-        update-types:
-          - minor
-          - patch
-
-  # npm — packages/db
-  - package-ecosystem: npm
-    directory: /packages/db
-    schedule:
-      interval: weekly
-      day: monday
-    commit-message:
-      prefix: "chore"
-    labels:
-      - tech-debt
-    groups:
-      npm-db-minor-patch:
-        update-types:
-          - minor
-          - patch
-
-  # npm — packages/ui
-  - package-ecosystem: npm
-    directory: /packages/ui
-    schedule:
-      interval: weekly
-      day: monday
-    commit-message:
-      prefix: "chore"
-    labels:
-      - tech-debt
-    groups:
-      npm-ui-minor-patch:
-        update-types:
-          - minor
-          - patch
-
-  # npm — packages/typescript-config
-  - package-ecosystem: npm
-    directory: /packages/typescript-config
-    schedule:
-      interval: weekly
-      day: monday
-    commit-message:
-      prefix: "chore"
-    labels:
-      - tech-debt
-    groups:
-      npm-tsconfig-minor-patch:
+      npm-all-minor-patch:
         update-types:
           - minor
           - patch

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -131,7 +131,7 @@ Migrations 044–047. 1082 tests, all passing. Production Supabase email templat
 | 6 | #212 | Migrate Zod 3→4 (breaking API changes) | P0 | L | Done |
 
 **Scope:** 2S + 3M + 2L
-**Context:** Dependabot opened 16 PRs on first run. GH Actions PR #194 merged. Remaining 15 closed — Dependabot can't regenerate pnpm-lock.yaml for monorepos. All updates will be done manually.
+**Context:** Dependabot opened 16 PRs on first run. GH Actions PR #194 merged. Remaining 15 closed — at the time, the per-package npm entries couldn't keep the shared root `pnpm-lock.yaml` in sync, so those updates were done manually. **Correction (2026-05-31, #715):** the root `/` npm entry *is* pnpm-workspace-aware and regenerates the shared lockfile in one PR (proven by #692). The per-package entries were the problem (they caused the split lockfile failures in #669/#670) and were consolidated into the single root entry — Dependabot now syncs `pnpm-lock.yaml` automatically for workspace-wide bumps.
 
 **Tech Debt: Biome 1→2 Migration done (2026-03-16, commit a9930ac):**
 - Upgraded @biomejs/biome from ^1.9.0 to ^2.4.7
@@ -574,8 +574,8 @@ Migrations 044–047. 1082 tests, all passing. Production Supabase email templat
     - Audits homepage + forgot-password page
     - Artifacts uploaded to GitHub (14-day retention)
   - `codeql.yml` — weekly security scan (Monday 05:30 UTC) for JavaScript/TypeScript via GitHub CodeQL action, logs to Security tab
-  - `dependabot.yml` — automated dependency updates with auto-grouping by ecosystem/directory, weekly schedule, `tech-debt` label, commits with `ci` or `chore` prefix
-    - Scopes: GitHub Actions + npm root + apps/web + packages/{db,ui,typescript-config}
+  - `dependabot.yml` — automated dependency updates, weekly schedule, `tech-debt` label, commits with `ci` or `chore` prefix. npm updates are grouped into minor/patch + major batches via a single pnpm-workspace-aware root entry (consolidated in #715; per-directory entries previously caused lockfile-sync failures — see #669/#670)
+    - Scopes: GitHub Actions (`/`) + npm (whole pnpm workspace, via the root `/` entry)
   - `health-monitoring.yml` — weekly workflows: dependency audit, security audit, codeql scan (added 2026-03-15, moved to separate weekly schedule for visibility)
   - Local Supabase spun up in CI via `supabase/setup-cli` — runs all migrations automatically
   - `apps/web/scripts/seed-e2e.ts` — seeds org, users, question bank, and 20 questions for E2E (expanded from 5 to support review flow after quiz)


### PR DESCRIPTION
## Problem

pnpm uses **one shared root `pnpm-lock.yaml`**, but the old `dependabot.yml` had **5 separate npm `updates` entries** (one per directory: `/`, `/apps/web`, `/packages/db`, `/packages/ui`, `/packages/typescript-config`).

A dependency present in more than one package (e.g. `@supabase/supabase-js` in both `apps/web` and `packages/db`) therefore gets a **separate PR per directory**. Each such PR edits only *its own* `package.json` and **never updates the shared root lockfile** — so:

- `pnpm install --frozen-lockfile` fails in CI (cascading to every job), and
- the half-applied bump leaves a **workspace version skew** that splits `SupabaseClient<Database>` into two nominally-incompatible copies (`TS2345`).

This is exactly what happened on **2026-05-31**: one `@supabase/supabase-js` 2.106.1→2.106.2 bump produced **#669** (`packages/db`) and **#670** (`apps/web`) as separate, both-failing PRs — while the *same* bump also rode along in the root entry's **#692**. Three overlapping PRs for one dependency.

## Fix

Collapse the 5 npm entries into a **single root `/` entry** that covers the whole pnpm workspace.

The root `/` npm entry is **workspace-aware**: **PR #692** empirically updated `apps/web` *and* `packages/db` manifests **plus** the shared lockfile in **one green PR**. Consolidating means every workspace-wide dependency now moves **atomically with a synced lockfile**, in one grouped weekly PR.

## Diff

- Removes the 4 redundant per-package npm entries.
- Keeps the `github-actions` entry unchanged.
- Keeps one `npm` entry at `/` with the `npm-all-minor-patch` group (minor + patch).
- Adds an explanatory comment block documenting the rationale.

`−66 / +21` lines, one file.

## Trade-offs

- ✅ No more split/broken dependency PRs; the lockfile is always consistent.
- ✅ Mirrors how #692 already worked (proven behavior).
- ⚖️ One larger weekly npm PR instead of several small per-package ones — but for a single-lockfile workspace that per-package granularity was illusory (they share one lockfile).
- ⚠️ **Rollback:** relies on the root entry covering the whole workspace (demonstrated by #692). If any package stops receiving updates, re-add a targeted entry for it.

## Open decision (from semantic review) — major versions

The group covers `minor` + `patch` only, so **major** bumps still get individual per-package PRs (this behavior is unchanged from the old config — not a regression). Options, your call:
1. **Leave as-is** — keep seeing major bumps as individual PRs (rare, want manual review anyway).
2. **Group majors too** — add `major` to `update-types` (or a separate `npm-all-major` group) so majors also arrive as one workspace PR.
3. **Ignore majors** — add an `ignore` block to silence them entirely (least recommended — you'd stop hearing about major upgrades).

Happy to push a follow-up commit for (2) or (3) if you prefer.

## Validation

- `dependabot.yml` parses as valid YAML; dependabot v2 schema verified (2 entries: `github-actions /`, `npm /`).
- CI-config-only change — not consumed by build/test; GitHub will validate the schema live on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update behavior: workspace-wide updates now coordinate per-package manifests and the shared lockfile in a single PR, preventing lockfile sync failures and reducing per-package PR noise.
  * Renamed the minor/patch grouping and added a new major-update grouping to separate and batch update types.

* **Documentation**
  * Updated project plan docs to reflect the new workspace-wide dependency update process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->