### PR TITLE
test(redteam): batch_submit_quiz time-limit enforcement + sessionId null-guard sweep (#546, #636)

### DIFF
--- a/apps/web/e2e/redteam/audit-completeness.spec.ts
+++ b/apps/web/e2e/redteam/audit-completeness.spec.ts
@@ -274,22 +274,22 @@ test.describe('Red Team: Audit Event Completeness', () => {
       p_question_ids: questionIds,
     })
     expect(startErr).toBeNull()
-    expect(typeof sessionId).toBe('string')
-    createdSessionIds.add(sessionId as string)
+    // Explicit guard over a bare `as string` cast — narrows sessionId for both the
+    // cleanup-set add and the answer build, and fails loudly with a diagnostic if
+    // the RPC ever returns a non-string. (#636)
+    if (!sessionId || typeof sessionId !== 'string') {
+      throw new Error(`start_quiz_session returned non-string sessionId: ${typeof sessionId}`)
+    }
+    createdSessionIds.add(sessionId)
 
-    const answers = await buildAnswersForSession(sessionId as string)
+    const answers = await buildAnswersForSession(sessionId)
     const { error: submitErr } = await studentClient.rpc('batch_submit_quiz', {
       p_session_id: sessionId,
       p_answers: answers,
     })
     expect(submitErr).toBeNull()
 
-    await expectAuditRow(
-      'quiz_session.batch_submitted',
-      studentUserId,
-      testStart,
-      sessionId as string,
-    )
+    await expectAuditRow('quiz_session.batch_submitted', studentUserId, testStart, sessionId)
   })
 
   test('writes exam.started when start_exam_session runs', async () => {

--- a/apps/web/e2e/redteam/batch-submit-time-limit.spec.ts
+++ b/apps/web/e2e/redteam/batch-submit-time-limit.spec.ts
@@ -144,7 +144,10 @@ test.describe('Red Team: batch_submit_quiz time-limit enforcement', () => {
       .single()
     expect(rowErr).toBeNull()
     expect(row?.ended_at).not.toBeNull()
-    expect(row?.score_percentage).toEqual(0)
+    // score_percentage is NUMERIC(5,2): PostgREST serializes fractional NUMERIC as a
+    // string (code-style.md §5). Coerce so a future non-integer score can't slip past;
+    // `?? -1` keeps a NULL from masquerading as 0.
+    expect(Number(row?.score_percentage ?? -1)).toEqual(0)
 
     // No answers were recorded — the submission was rejected at the deadline gate
     // before any scoring/insert.

--- a/apps/web/e2e/redteam/batch-submit-time-limit.spec.ts
+++ b/apps/web/e2e/redteam/batch-submit-time-limit.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Red Team Spec — Vector AI (MEDIUM): batch_submit_quiz server-side time-limit
+ *
+ * Attack: submit an exam after its deadline has passed, relying on a tampered or
+ * absent client timer to sneak answers in past expiry.
+ * Defense: batch_submit_quiz independently enforces
+ *   now() > started_at + (time_limit_seconds + 30s grace)
+ * and, when breached, force-ends the session with a zeroed result
+ * (`expired: true`, score 0, no answers scored) regardless of the payload.
+ *
+ * The check (mig 20260601000001, lines 99-125) fires AFTER auth/ownership but
+ * BEFORE answer/config validation, so an overdue submission is zeroed no matter
+ * what answers are sent. The branch is reachable only for exam-mode sessions —
+ * quick_quiz leaves `time_limit_seconds` NULL, so this spec seeds a mock_exam
+ * session directly (admin client) with a backdated started_at, mirroring the
+ * rpc-complete-overdue-exam.spec.ts seed pattern.
+ */
+
+import { expect, test } from '@playwright/test'
+import { getAdminClient } from '../helpers/supabase'
+import { createAuthenticatedClient } from './helpers/redteam-client'
+import {
+  ATTACKER_EMAIL,
+  ATTACKER_PASSWORD,
+  pickSubjectWithQuestions,
+  seedRedTeamUsers,
+} from './helpers/seed'
+
+test.describe('Red Team: batch_submit_quiz time-limit enforcement', () => {
+  let admin: ReturnType<typeof getAdminClient>
+  let attackerClient: Awaited<ReturnType<typeof createAuthenticatedClient>>
+  let attackerUserId: string
+  let orgId: string
+  let subjectId: string
+  let questionId: string
+  let answers: { question_id: string; selected_option: string; response_time_ms: number }[]
+
+  const createdSessionIds = new Set<string>()
+
+  test.beforeAll(async () => {
+    admin = getAdminClient()
+    const seed = await seedRedTeamUsers()
+    attackerUserId = seed.attackerUserId
+    orgId = seed.orgId
+    attackerClient = await createAuthenticatedClient(ATTACKER_EMAIL, ATTACKER_PASSWORD)
+
+    const picked = await pickSubjectWithQuestions(admin, { orgId })
+    subjectId = picked.subjectId
+
+    const { data: q, error: qErr } = await admin
+      .from('questions')
+      .select('id, options')
+      .eq('organization_id', orgId)
+      .eq('subject_id', subjectId)
+      .eq('status', 'active')
+      .is('deleted_at', null)
+      .order('id', { ascending: true })
+      .limit(1)
+      .single()
+    if (qErr || !q) throw new Error(`time-limit seed: no active question found: ${qErr?.message}`)
+    questionId = q.id
+    // options is JSONB — narrow to an array before indexing (code-style.md §5).
+    const opts = Array.isArray(q.options) ? (q.options as { id: string }[]) : []
+    const firstOption = opts[0]?.id
+    if (!firstOption) throw new Error('time-limit seed: question has no options to answer with')
+    answers = [{ question_id: questionId, selected_option: firstOption, response_time_ms: 2000 }]
+  })
+
+  // Seed an attacker-owned mock_exam session with a 60s limit. `overdue` backdates
+  // started_at past the 60s + 30s grace window; otherwise it is well within it.
+  const seedExamSession = async (overdue: boolean): Promise<string> => {
+    const { data, error } = await admin
+      .from('quiz_sessions')
+      .insert({
+        organization_id: orgId,
+        student_id: attackerUserId,
+        mode: 'mock_exam',
+        subject_id: subjectId,
+        config: { question_ids: [questionId], pass_mark: 75 },
+        total_questions: 1,
+        time_limit_seconds: 60,
+        started_at: new Date(Date.now() - (overdue ? 120_000 : 5_000)).toISOString(),
+      })
+      .select('id')
+      .single()
+    if (error || !data) throw new Error(`seed exam session: ${error?.message}`)
+    createdSessionIds.add(data.id)
+    return data.id
+  }
+
+  test.afterEach(async () => {
+    if (createdSessionIds.size === 0) return
+    try {
+      const { data, error } = await admin
+        .from('quiz_sessions')
+        .update({ deleted_at: new Date().toISOString() })
+        .in('id', Array.from(createdSessionIds))
+        .is('deleted_at', null)
+        .select('id')
+      if (error) {
+        console.error('[batch-time-limit afterEach] soft-delete failed:', error.message)
+        throw new Error(`afterEach soft-delete: ${error.message}`)
+      }
+      if ((data?.length ?? 0) > 0) {
+        console.log(`[batch-time-limit] soft-deleted ${data?.length} session(s)`)
+      }
+    } finally {
+      createdSessionIds.clear()
+    }
+  })
+
+  test('AI: an overdue exam submission is force-expired and scored zero (server-enforced deadline)', async () => {
+    const sid = await seedExamSession(true)
+
+    const { data, error } = await attackerClient.rpc('batch_submit_quiz', {
+      p_session_id: sid,
+      p_answers: answers,
+    })
+
+    // The RPC does not raise — it returns a zeroed, expired result.
+    expect(error).toBeNull()
+    const d = data as {
+      expired?: boolean
+      answered_count?: number
+      correct_count?: number
+      score_percentage?: number
+      passed?: boolean
+      results?: unknown[]
+    }
+    // `expired: true` is emitted ONLY by the past-grace branch — asserting it pins
+    // that the deadline check (not some other rejection) is what zeroed the score.
+    expect(d?.expired).toBe(true)
+    expect(d?.answered_count).toBe(0)
+    expect(d?.correct_count).toBe(0)
+    expect(d?.score_percentage).toBe(0)
+    expect(d?.passed).toBe(false)
+    expect(Array.isArray(d?.results) ? d?.results?.length : -1).toBe(0)
+
+    // Server force-ended the session despite the in-time-looking payload.
+    const { data: row, error: rowErr } = await admin
+      .from('quiz_sessions')
+      .select('ended_at, score_percentage')
+      .eq('id', sid)
+      .single()
+    expect(rowErr).toBeNull()
+    expect(row?.ended_at).not.toBeNull()
+    expect(row?.score_percentage).toEqual(0)
+
+    // No answers were recorded — the submission was rejected at the deadline gate
+    // before any scoring/insert.
+    const { count, error: countErr } = await admin
+      .from('quiz_session_answers')
+      .select('id', { count: 'exact', head: true })
+      .eq('session_id', sid)
+    expect(countErr).toBeNull()
+    expect(count).toBe(0)
+  })
+
+  test('AI control: an in-time exam submission scores normally (proves expiry is the cause)', async () => {
+    // Non-vacuity: the same payload on a non-overdue session is actually scored,
+    // so the overdue test above zeroes BECAUSE of the deadline, not because the
+    // session/answer shape is universally rejected.
+    const sid = await seedExamSession(false)
+
+    const { data, error } = await attackerClient.rpc('batch_submit_quiz', {
+      p_session_id: sid,
+      p_answers: answers,
+    })
+
+    expect(error).toBeNull()
+    const d = data as { expired?: boolean; answered_count?: number; total_questions?: number }
+    expect(d?.expired).toBeUndefined()
+    expect(d?.answered_count).toBe(1)
+    expect(d?.total_questions).toBe(1)
+
+    const { count, error: countErr } = await admin
+      .from('quiz_session_answers')
+      .select('id', { count: 'exact', head: true })
+      .eq('session_id', sid)
+    expect(countErr).toBeNull()
+    expect(count).toBe(1)
+  })
+})

--- a/apps/web/e2e/redteam/batch-submit-time-limit.spec.ts
+++ b/apps/web/e2e/redteam/batch-submit-time-limit.spec.ts
@@ -123,7 +123,8 @@ test.describe('Red Team: batch_submit_quiz time-limit enforcement', () => {
       expired?: boolean
       answered_count?: number
       correct_count?: number
-      score_percentage?: number
+      // NUMERIC over the wire is a JSON string, not a number (code-style.md §5).
+      score_percentage?: number | string
       passed?: boolean
       results?: unknown[]
     }
@@ -132,7 +133,7 @@ test.describe('Red Team: batch_submit_quiz time-limit enforcement', () => {
     expect(d?.expired).toBe(true)
     expect(d?.answered_count).toBe(0)
     expect(d?.correct_count).toBe(0)
-    expect(d?.score_percentage).toBe(0)
+    expect(Number(d?.score_percentage ?? -1)).toBe(0)
     expect(d?.passed).toBe(false)
     expect(Array.isArray(d?.results) ? d?.results?.length : -1).toBe(0)
 

--- a/apps/web/e2e/redteam/injection-xss.spec.ts
+++ b/apps/web/e2e/redteam/injection-xss.spec.ts
@@ -167,8 +167,16 @@ async function startStudentSessionFor(
     p_question_ids: [qid],
   })
   expect(error).toBeNull()
-  expect(typeof sessionId).toBe('string')
-  return { sessionId: sessionId as string, questionIds: [qid] }
+  // Explicit guard, not a bare `as string` cast: if a future change weakens the
+  // expect above, a null/non-string sessionId would otherwise propagate silently
+  // into seedSessionHandoff and surface as a misleading redirect-to-/app/quiz
+  // (looks like a UI bug, not a missing-RPC-return bug). (#636)
+  if (!sessionId || typeof sessionId !== 'string') {
+    throw new Error(
+      `startStudentSessionFor: start_quiz_session returned non-string sessionId: ${typeof sessionId}`,
+    )
+  }
+  return { sessionId, questionIds: [qid] }
 }
 
 // The /app/quiz/session page reads its session from sessionStorage (handoff


### PR DESCRIPTION
## Summary

Two Group-4 red-team items, both spec-only (no runtime/migration changes):

### #546 — Vector AI: `batch_submit_quiz` server-side time-limit enforcement
New `apps/web/e2e/redteam/batch-submit-time-limit.spec.ts`. Proves the RPC enforces the deadline independently of the client timer:

- **Overdue test** — seeds an attacker-owned `mock_exam` session (quick_quiz has NULL `time_limit_seconds`, so the branch is unreachable there) with `started_at` backdated 120s past the 60s+30s grace. Asserts `batch_submit_quiz` returns the zeroed `{ expired: true, answered_count: 0, score_percentage: 0, passed: false, results: [] }`, force-ends the session (`ended_at` set), and records **zero** answer rows.
- **In-time control** — same payload on a 5s-old session scores normally (`answered_count: 1`, no `expired` key). This is the non-vacuity proof that expiry — not a universal rejection — is what zeroed the overdue case.

`expired: true` is emitted **only** by the past-grace branch (mig `20260601000001` L99-125), so the assertion uniquely pins that code path. Hermetic: `afterEach` soft-deletes created sessions (try/finally + zero-row observability), mirroring `rpc-complete-overdue-exam.spec.ts`.

### #636 — explicit null guard in session helpers
Replaced `expect(typeof sessionId).toBe('string')` + `sessionId as string` casts with an explicit `if (!sessionId || typeof sessionId !== 'string') throw` guard in `injection-xss.spec.ts` and `audit-completeness.spec.ts` (3 cast sites swept). A non-string RPC return now fails loudly with a diagnostic at the source instead of propagating `null` into downstream handoff/audit reads.

## Pipeline
impl-critic APPROVED (2 SUGGESTIONs applied) · code-reviewer clean · semantic-reviewer clean (1 SUGGESTION applied — NUMERIC coercion) · red-team COVERED (Vector AI) · learner: no promotions.

Closes #546
Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test reliability through improved runtime validation for session initialization across test scenarios.
  * Expanded end-to-end test coverage to verify server-side time-limit enforcement for quiz batch submissions, including validation of behavior for expired sessions, grace period handling, and session termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->