### PR TITLE
ci: migrate to SonarSource/sonarqube-scan-action (deprecation fix)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -50,10 +50,14 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
 
-      - name: SonarCloud Scan
+      - name: SonarQube Cloud Scan
         if: env.SONAR_TOKEN != ''
-        uses: sonarsource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5
+        # Migrated from the deprecated sonarcloud-github-action. SONAR_TOKEN is
+        # inherited from the job-level env; org/project keys live in
+        # sonar-project.properties; SONAR_HOST_URL is not needed for SonarQube Cloud.
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         env:
+          # Forwarded to the Sonar Scanner CLI for PR decoration — keep it.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Skip notice


### PR DESCRIPTION
## What

Swaps the **deprecated** `sonarsource/sonarcloud-github-action@v5` for the unified, supported `SonarSource/sonarqube-scan-action@v8.1.0` (SHA-pinned per repo convention) in `.github/workflows/sonarcloud.yml`.

Fixes the CI deprecation warning:
> This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.

## Why it's a safe drop-in

- **Only `SONAR_TOKEN` is required** for SonarQube Cloud — already set at job level (`env.SONAR_TOKEN`) and inherited by the step.
- **`SONAR_HOST_URL` intentionally omitted** — not needed for SonarQube Cloud (routes to `sonarcloud.io` by default).
- **Org/project keys unchanged** — they live in `sonar-project.properties` (`sonar.organization=okpilot`, `sonar.projectKey=okpilot_lmsplus_v2`); `projectBaseDir` defaults to repo root.
- **`GITHUB_TOKEN` kept** — the new action forwards it to the Sonar Scanner CLI for PR decoration (verified against the action source); a comment documents why so it isn't removed as "unused".
- **Required-check identity preserved** — the job display name `SonarCloud Analysis` is unchanged (branch protection matches on job name, not step name). Only the *step* name changed.

## Verification

- v8.1.0 lightweight tag → commit `7006c4492b2e0ee0f816d36501671557c97f5995` (confirmed via `gh api`; no mutable-tag risk).
- YAML parses cleanly; graceful-skip guards (`if: env.SONAR_TOKEN != ''`) intact across all steps.
- impl-critic APPROVED; post-commit agents clean (code-reviewer, semantic-reviewer 0 ISSUE / 1 applied cosmetic suggestion, doc-updater no drift, test-writer N/A).

## Context

Unrelated to the transient SonarCloud failure seen on #744 (a one-off JRE-metadata fetch blip that passed on re-run) — this PR only addresses the deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)