### PR TITLE
fix(agents): bump learner model haiku→sonnet (#756)

### DIFF
--- a/.claude/agents/learner.md
+++ b/.claude/agents/learner.md
@@ -1,7 +1,7 @@
 ---
 name: learner
 description: Learns from post-commit agent findings, identifies recurring patterns, and updates project rules/memory to prevent repeat mistakes. Runs after code-reviewer, doc-updater, and test-writer report back.
-model: claude-haiku-4-5-20251001
+model: claude-sonnet-4-6
 memory: project
 ---
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -554,7 +554,7 @@ Migrations 044–047. 1082 tests, all passing. Production Supabase email templat
   - code-reviewer (sonnet) — reviews diff for code style violations
   - doc-updater (haiku) — checks if docs need updates
   - test-writer (sonnet) — writes missing tests, runs them
-  - learner (haiku) — analyzes findings, detects patterns, updates rules/memory
+  - learner (sonnet) — analyzes findings, detects patterns, updates rules/memory
   - coderabbit-sync (haiku) — keeps .coderabbit.yaml aligned when rules change
 - **CodeRabbit** (GitHub PR review):
   - `.coderabbit.yaml` — assertive profile, path-specific rules mirroring code-style.md + security.md


### PR DESCRIPTION
## Summary
The `learner` agent's frontmatter declared `claude-haiku-4-5-20251001`, but every doc/rule specifies **sonnet** (`agent-learner.md` header, `CLAUDE.md:166`, `agent-workflow.md:190`, `plan.md:924`). Since the learner runs via the Agent tool (no hook), the **frontmatter governs** — so it was silently running on haiku, the weaker tier for its reasoning-heavy cross-session pattern-synthesis job.

## Evidence it mattered
During the #750/#753 review cycle the learner **conflated patterns from unrelated PRs** (#736, #256, #570, #611) and **re-proposed an already-promoted rule** — consistent with the underpowered model.

## Changes
- `.claude/agents/learner.md` — frontmatter `model:` → `claude-sonnet-4-6`
- `docs/plan.md:557` — lone stray `learner (haiku)` label → `(sonnet)`

Every learner reference now agrees on sonnet. Takes effect on the next Claude Code restart (agent defs snapshot at session start).

Closes #756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the learner agent with an improved model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->