### PR TITLE
test: behavior-first titles for void-code + useExamPipeline tests (#581, #600)

### DIFF
--- a/apps/web/app/app/admin/internal-exams/actions/void-code.test.ts
+++ b/apps/web/app/app/admin/internal-exams/actions/void-code.test.ts
@@ -148,7 +148,7 @@ describe('voidInternalExamCode', () => {
   })
 
   describe('error code mapping', () => {
-    it('surfaces a final-record error when voiding a finished attempt', async () => {
+    it('surfaces "Cannot void a finished attempt" when voiding after submission', async () => {
       mockAdmin()
       mockRpc.mockResolvedValue({
         data: null,

--- a/apps/web/app/app/admin/internal-exams/actions/void-code.test.ts
+++ b/apps/web/app/app/admin/internal-exams/actions/void-code.test.ts
@@ -148,7 +148,7 @@ describe('voidInternalExamCode', () => {
   })
 
   describe('error code mapping', () => {
-    it('maps cannot_void_finished_attempt', async () => {
+    it('surfaces a final-record error when voiding a finished attempt', async () => {
       mockAdmin()
       mockRpc.mockResolvedValue({
         data: null,
@@ -161,7 +161,7 @@ describe('voidInternalExamCode', () => {
       }
     })
 
-    it('maps code_not_found', async () => {
+    it('surfaces "Code not found" when the code does not exist', async () => {
       mockAdmin()
       mockRpc.mockResolvedValue({ data: null, error: { message: 'code_not_found' } })
       const result = await voidInternalExamCode(VALID_INPUT)
@@ -169,7 +169,7 @@ describe('voidInternalExamCode', () => {
       if (!result.success) expect(result.error).toBe('Code not found')
     })
 
-    it('maps not_admin', async () => {
+    it('surfaces an admin-permission error when the RPC rejects the caller', async () => {
       mockAdmin()
       mockRpc.mockResolvedValue({ data: null, error: { message: 'not_admin' } })
       const result = await voidInternalExamCode(VALID_INPUT)
@@ -177,7 +177,7 @@ describe('voidInternalExamCode', () => {
       if (!result.success) expect(result.error).toBe('Admin permission required')
     })
 
-    it('maps invalid_reason', async () => {
+    it('surfaces a blank-reason error when the reason is whitespace-only', async () => {
       mockAdmin()
       mockRpc.mockResolvedValue({ data: null, error: { message: 'invalid_reason' } })
       const result = await voidInternalExamCode(VALID_INPUT)
@@ -185,7 +185,7 @@ describe('voidInternalExamCode', () => {
       if (!result.success) expect(result.error).toBe('Reason cannot be blank or whitespace-only')
     })
 
-    it('maps session_state_changed', async () => {
+    it('surfaces a refresh-and-retry error when the session changed concurrently', async () => {
       mockAdmin()
       mockRpc.mockResolvedValue({ data: null, error: { message: 'session_state_changed' } })
       const result = await voidInternalExamCode(VALID_INPUT)

--- a/apps/web/app/app/quiz/session/_hooks/use-exam-state.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-exam-state.test.ts
@@ -259,27 +259,27 @@ describe('useExamPipeline — submit state surfacing', () => {
     expect(result.current.showFinishDialog).toBe(true)
   })
 
-  it('returns the submit handler to the consumer', () => {
+  it('exposes the submit handler that triggers exam submission', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.handleSubmit).toBe(mockHandleSubmit)
   })
 
-  it('returns the save handler to the consumer', () => {
+  it('exposes the save-and-exit handler', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.handleSave).toBe(mockHandleSave)
   })
 
-  it('returns the discard handler to the consumer', () => {
+  it('exposes the discard handler that abandons the session', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.handleDiscard).toBe(mockHandleDiscard)
   })
 
-  it('returns the finish-dialog setter to the consumer', () => {
+  it('exposes the setter that controls finish-dialog visibility', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.setShowFinishDialog).toBe(mockSetShowFinishDialog)
   })
 
-  it('returns the submitted ref to the consumer', () => {
+  it('exposes the submitted ref that tracks whether the exam was submitted', () => {
     const { result } = renderHook(() => useExamPipeline(makeOpts()))
     expect(result.current.submitted).toBe(mockSubmitted)
   })


### PR DESCRIPTION
## Summary

Test-title cleanup from the overnight batch (PR-2). Pure `it(...)` description renames per **code-style.md §7** (describe behaviour, not implementation) — no logic or assertion changes.

- **Closes #581** — `void-code.test.ts`: five `maps <rpc_error_token>` titles → `surfaces ...` descriptions of the user-visible error for each condition. The finished-attempt case quotes the literal asserted message (matching the `code_not_found` style) after semantic-review.
- **Closes #600** — `use-exam-state.test.ts`: five `returns the X to the consumer` titles → `exposes ...` descriptions framed from the hook's public contract, matching the file's existing `exposes ...` convention on the navigation tests. The `formatExpiry` NaN-guard branch flagged in the issue is already covered by `format-expiry.test.ts:17`, so nothing is added there.

#574 (raw-JSON test-rot) was found **already resolved** on master (both target tests use `makeSession`) and closed separately.

## Review trail
- code-reviewer: all 10 new titles comply with §7 (no disallowed pattern). Clean.
- semantic-reviewer: 1 ISSUE — one title used an invented paraphrase; fixed to quote the literal message.
- CR-local: round 1 no findings; round 2 (after the fix) no findings.

Closes #581
Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for exam code voiding error messages and scenarios
  * Restructured exam submission state handler tests for improved organization and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->