### PR TITLE
fix(mcp): use npx (not npx.cmd) and pin spec-workflow@2.2.5

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "supabase": {
-      "command": "npx.cmd",
+      "command": "npx",
       "args": [
         "-y",
         "@supabase/mcp-server-supabase@0.7.0",
@@ -12,16 +12,16 @@
       ]
     },
     "context7": {
-      "command": "npx.cmd",
+      "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@2.1.4"]
     },
     "shadcn": {
-      "command": "npx.cmd",
+      "command": "npx",
       "args": ["-y", "shadcn@4.1.0", "mcp"]
     },
     "spec-workflow": {
-      "command": "npx.cmd",
-      "args": ["-y", "@pimzino/spec-workflow-mcp@latest", "."]
+      "command": "npx",
+      "args": ["-y", "@pimzino/spec-workflow-mcp@2.2.5", "."]
     },
     "sonarqube": {
       "command": "docker",


### PR DESCRIPTION
Closes #695, closes #464.

## #695 — `.mcp.json` used `npx.cmd` (Windows-only) → MCP servers fail on Linux
The `supabase`, `context7`, `shadcn`, and `spec-workflow` servers invoked `npx.cmd`, which doesn't exist on Linux, so all four silently failed to start. Switched to `npx` (cross-platform — works on Windows too). `sonarqube` is unchanged (uses `docker`).

## #464 — pin spec-workflow MCP to an explicit version
`@latest` → `@2.2.5` (verified current latest published version), matching how the other servers are pinned and preventing a surprise break on an upstream release.

## Validation
Config-only change. `/fullpush`: lint ✅, types ✅, 3499 unit/integration ✅, build ✅. CR-local: **no findings**. JSON validated. No code/test/security surface touched (redteam/migration gates N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server configurations with pinned dependency versions for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->