### PR TITLE
fix(middleware): forward @supabase/ssr anti-cache headers + fix orphaned response (#446)

### DIFF
--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -68,6 +68,9 @@ function buildChain(returnValue: unknown) {
 describe('proxy', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset the shared mock's headers each test so a header set by one test can never
+    // leak into another (e.g. if a proxy() call throws before a try/finally cleanup runs).
+    MOCK_SESSION_RESPONSE.headers = new Headers()
   })
 
   it('redirects unauthenticated requests for /app/dashboard to /', async () => {

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -243,6 +243,62 @@ describe('proxy', () => {
     }
   })
 
+  it('forwards anti-cache headers from the session response onto a redirect', async () => {
+    // A token refresh that ends in a redirect carries a fresh Set-Cookie; the
+    // anti-cache headers must travel with it so a CDN cannot cache and replay it.
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    MOCK_SESSION_RESPONSE.headers.set(
+      'cache-control',
+      'private, no-cache, no-store, must-revalidate, max-age=0',
+    )
+    MOCK_SESSION_RESPONSE.headers.set('expires', '0')
+    MOCK_SESSION_RESPONSE.headers.set('pragma', 'no-cache')
+    try {
+      const response = await proxy(makeRequest('/app/dashboard'))
+
+      expect(response.status).toBe(307)
+      expect(response.headers.get('cache-control')).toBe(
+        'private, no-cache, no-store, must-revalidate, max-age=0',
+      )
+      expect(response.headers.get('expires')).toBe('0')
+      expect(response.headers.get('pragma')).toBe('no-cache')
+    } finally {
+      MOCK_SESSION_RESPONSE.headers.delete('cache-control')
+      MOCK_SESSION_RESPONSE.headers.delete('expires')
+      MOCK_SESSION_RESPONSE.headers.delete('pragma')
+    }
+  })
+
+  it('forwards anti-cache headers from the session response onto the 403 for a non-admin', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'student-1' } } })
+    mockFrom.mockReturnValue(buildChain({ data: { role: 'student' }, error: null }))
+    MOCK_SESSION_RESPONSE.headers.set('cache-control', 'private, no-store')
+    try {
+      const response = await proxy(makeConsentedRequest('/app/admin/syllabus'))
+
+      expect(response.status).toBe(403)
+      expect(response.headers.get('cache-control')).toBe('private, no-store')
+    } finally {
+      MOCK_SESSION_RESPONSE.headers.delete('cache-control')
+    }
+  })
+
+  it('forwards anti-cache headers from the session response onto the 503 when the admin role lookup fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(buildChain({ data: null, error: { message: 'connection reset' } }))
+    MOCK_SESSION_RESPONSE.headers.set('cache-control', 'private, no-store')
+    try {
+      const response = await proxy(makeConsentedRequest('/app/admin/syllabus'))
+
+      expect(response.status).toBe(503)
+      expect(response.headers.get('cache-control')).toBe('private, no-store')
+    } finally {
+      MOCK_SESSION_RESPONSE.headers.delete('cache-control')
+      consoleSpy.mockRestore()
+    }
+  })
+
   describe('__vdpl deployment pinning cookie', () => {
     const DEPLOYMENT_ID = 'dpl_test_abc123'
 

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -246,7 +246,7 @@ describe('proxy', () => {
     }
   })
 
-  it('forwards anti-cache headers from the session response onto a redirect', async () => {
+  it('preserves anti-cache headers on the login redirect', async () => {
     // A token refresh that ends in a redirect carries a fresh Set-Cookie; the
     // anti-cache headers must travel with it so a CDN cannot cache and replay it.
     mockGetUser.mockResolvedValue({ data: { user: null } })
@@ -272,7 +272,7 @@ describe('proxy', () => {
     }
   })
 
-  it('forwards anti-cache headers from the session response onto the 403 for a non-admin', async () => {
+  it('preserves anti-cache headers on the forbidden response', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'student-1' } } })
     mockFrom.mockReturnValue(buildChain({ data: { role: 'student' }, error: null }))
     MOCK_SESSION_RESPONSE.headers.set('cache-control', 'private, no-store')
@@ -286,7 +286,7 @@ describe('proxy', () => {
     }
   })
 
-  it('forwards anti-cache headers from the session response onto the 503 when the admin role lookup fails', async () => {
+  it('preserves anti-cache headers on the service-unavailable response', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockFrom.mockReturnValue(buildChain({ data: null, error: { message: 'connection reset' } }))

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -24,6 +24,18 @@ function applySecurityHeaders(res: NextResponse): void {
   res.headers.set('Content-Security-Policy', "default-src 'none'; frame-ancestors 'none'")
 }
 
+// @supabase/ssr writes anti-cache headers (Cache-Control/Expires/Pragma) onto the
+// pass-through response when it refreshes auth cookies. Redirect and error exits build
+// fresh NextResponse objects, so forward those headers too — otherwise a CDN/edge could
+// cache a Set-Cookie-bearing redirect and replay one user's session token to another.
+const ANTI_CACHE_HEADERS = ['cache-control', 'expires', 'pragma'] as const
+function forwardAntiCacheHeaders(source: NextResponse, target: NextResponse): void {
+  for (const name of ANTI_CACHE_HEADERS) {
+    const value = source.headers.get(name)
+    if (value !== null) target.headers.set(name, value)
+  }
+}
+
 export async function proxy(request: NextRequest): Promise<Response> {
   // Cast needed: @playwright/test causes a duplicate next.js install with incompatible internal types
   const { supabase, response } = createMiddlewareSupabaseClient(
@@ -47,6 +59,7 @@ export async function proxy(request: NextRequest): Promise<Response> {
     for (const cookie of response.cookies.getAll()) {
       redirect.cookies.set(cookie)
     }
+    forwardAntiCacheHeaders(response, redirect)
     applySecurityHeaders(redirect)
     return redirect
   }
@@ -86,6 +99,7 @@ export async function proxy(request: NextRequest): Promise<Response> {
       for (const cookie of response.cookies.getAll()) {
         unavailable.cookies.set(cookie)
       }
+      forwardAntiCacheHeaders(response, unavailable)
       applySecurityHeaders(unavailable)
       return unavailable
     }
@@ -95,6 +109,7 @@ export async function proxy(request: NextRequest): Promise<Response> {
       for (const cookie of response.cookies.getAll()) {
         forbidden.cookies.set(cookie)
       }
+      forwardAntiCacheHeaders(response, forbidden)
       applySecurityHeaders(forbidden)
       return forbidden
     }

--- a/packages/db/src/middleware.test.ts
+++ b/packages/db/src/middleware.test.ts
@@ -95,4 +95,42 @@ describe('createMiddlewareSupabaseClient', () => {
       cookiesConfig.setAll([{ name: 'sb-token', value: 'new-value', options: { httpOnly: true } }]),
     ).not.toThrow()
   })
+
+  it('forwards anti-cache headers onto the response the caller holds', () => {
+    // setAll fires lazily (during auth.getUser), after this function has returned —
+    // so the headers must land on the SAME reference returned here, not an orphan.
+    const { response } = createMiddlewareSupabaseClient(makeRequest())
+
+    const cookiesConfig = mockCreateServerClient.mock.calls[0]?.[2].cookies
+    cookiesConfig.setAll([{ name: 'sb-token', value: 'v', options: { httpOnly: true } }], {
+      'Cache-Control': 'private, no-cache, no-store, must-revalidate, max-age=0',
+      Expires: '0',
+      Pragma: 'no-cache',
+    })
+
+    expect(response.headers.get('Cache-Control')).toBe(
+      'private, no-cache, no-store, must-revalidate, max-age=0',
+    )
+    expect(response.headers.get('Expires')).toBe('0')
+    expect(response.headers.get('Pragma')).toBe('no-cache')
+  })
+
+  it('writes refreshed cookies onto the response the caller holds', () => {
+    // Regression guard: reassigning `response` inside setAll would orphan the cookie.
+    const { response } = createMiddlewareSupabaseClient(makeRequest())
+
+    const cookiesConfig = mockCreateServerClient.mock.calls[0]?.[2].cookies
+    cookiesConfig.setAll([{ name: 'sb-token', value: 'refreshed', options: { httpOnly: true } }])
+
+    expect(response.cookies.get('sb-token')?.value).toBe('refreshed')
+  })
+
+  it('does not throw when setAll is passed an empty headers object', () => {
+    createMiddlewareSupabaseClient(makeRequest())
+
+    const cookiesConfig = mockCreateServerClient.mock.calls[0]?.[2].cookies
+    expect(() =>
+      cookiesConfig.setAll([{ name: 'sb-token', value: 'v', options: { httpOnly: true } }], {}),
+    ).not.toThrow()
+  })
 })

--- a/packages/db/src/middleware.test.ts
+++ b/packages/db/src/middleware.test.ts
@@ -133,4 +133,20 @@ describe('createMiddlewareSupabaseClient', () => {
       cookiesConfig.setAll([{ name: 'sb-token', value: 'v', options: { httpOnly: true } }], {}),
     ).not.toThrow()
   })
+
+  it('writes all cookies in the array onto the response when setAll receives multiple cookies', () => {
+    // Covers the full iteration: the production loop runs for every element, not just the first.
+    const { response } = createMiddlewareSupabaseClient(makeRequest())
+
+    const cookiesConfig = mockCreateServerClient.mock.calls[0]?.[2].cookies
+    cookiesConfig.setAll([
+      { name: 'sb-access-token', value: 'access-val', options: { httpOnly: true } },
+      { name: 'sb-refresh-token', value: 'refresh-val', options: { httpOnly: true } },
+      { name: 'sb-provider-token', value: 'provider-val', options: { httpOnly: true } },
+    ])
+
+    expect(response.cookies.get('sb-access-token')?.value).toBe('access-val')
+    expect(response.cookies.get('sb-refresh-token')?.value).toBe('refresh-val')
+    expect(response.cookies.get('sb-provider-token')?.value).toBe('provider-val')
+  })
 })

--- a/packages/db/src/middleware.ts
+++ b/packages/db/src/middleware.ts
@@ -9,7 +9,7 @@ export function createMiddlewareSupabaseClient(request: NextRequest) {
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   if (!url || !key) throw new Error('Missing Supabase env vars')
 
-  let response = NextResponse.next({ request })
+  const response = NextResponse.next({ request })
 
   const supabase = createServerClient<Database>(url, key, {
     cookies: {
@@ -22,13 +22,24 @@ export function createMiddlewareSupabaseClient(request: NextRequest) {
           value: string
           options: CookieOptions
         }>,
+        // @supabase/ssr 0.10 passes anti-cache headers (Cache-Control/Expires/Pragma)
+        // alongside auth cookies — forwarding them stops a CDN/edge from caching a
+        // response that carries one user's session token and serving it to another.
+        headers?: Record<string, string>,
       ) {
+        // Write onto the SAME response object the caller already holds. setAll fires
+        // lazily during auth.getUser() — AFTER createMiddlewareSupabaseClient has
+        // returned — so reassigning `response` to a fresh NextResponse here would
+        // orphan it, silently dropping both the refreshed session cookies and the
+        // anti-cache headers below. Mutating in place keeps the reference live.
         for (const { name, value } of cookiesToSet) {
           request.cookies.set(name, value)
         }
-        response = NextResponse.next({ request })
         for (const { name, value, options } of cookiesToSet) {
           response.cookies.set(name, value, options)
+        }
+        for (const [key, value] of Object.entries(headers ?? {})) {
+          response.headers.set(key, value)
         }
       },
     },


### PR DESCRIPTION
## What & why
Closes #446.

`@supabase/ssr` 0.10 passes anti-cache headers (`Cache-Control: private, no-cache, no-store, must-revalidate, max-age=0`, `Expires: 0`, `Pragma: no-cache`) as a second arg to the `cookies.setAll` callback, alongside refreshed auth cookies. The middleware ignored them — so on a CDN/edge an auth-cookie-bearing response could be cached and replayed to another user.

## Notable discovery (scope beyond the issue's one-liner)
While wiring this up I found a **pre-existing latent bug**: `setAll` reassigned the local `response` to a fresh `NextResponse`, but `createMiddlewareSupabaseClient` returns the response reference **before** `setAll` fires (it runs lazily during `auth.getUser()` in `proxy.ts`). The reassigned object was **orphaned** — silently dropping both the forwarded headers *and* refreshed session cookies on token rotation (which could intermittently log users out).

Fix: mutate the response **in place** (`let`→`const`, drop the reassignment) so the caller's reference receives cookies + headers.

## Commits
1. `fix(middleware)` — forward headers + fix orphaned response (mutate in place) + tests.
2. `fix(proxy)` — semantic-reviewer caught that the redirect (`redirectWithCookies` ×4 branches), 503 and 403 exits build *fresh* responses and copied cookies but **not** the anti-cache headers. Added `forwardAntiCacheHeaders` at all three fresh-response sites + tests (redirect/403/503).
3. `test(proxy)` — reset shared mock `Headers` in `beforeEach` for hermiticity (PR-sweep suggestion).

## Trade-off
Removing the post-mutation `NextResponse.next({ request })` recreation means downstream same-request Server Components no longer get the just-mutated *request* cookies forwarded — but that benefit was already lost via the orphan, so this is strictly better. Browser still receives correct `Set-Cookie` + anti-cache headers on every exit (pass-through, redirect, 403, 503).

## Verification (no manual testing needed)
- `packages/db` middleware tests: assert headers + refreshed cookies land on the **returned** reference (fail against orphaned-response code); empty-headers + multi-cookie edge cases. 10 pass.
- `apps/web` proxy tests: assert all 3 anti-cache headers travel onto redirect, and onto 403/503. 23 pass.
- Pipeline: plan validation, implementation-critic (×2, approved), code-reviewer (clean), semantic-reviewer (per-commit + PR-level sweep, all clear), doc-updater (no drift), test-writer (+1 test), red-team (advisory — E2E gap filed as #781), CodeRabbit local (**No findings**).

## Follow-up
- #781 — red-team E2E (Vector CK2) for anti-cache headers on a token-refresh response (needs a test-infra seam; P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Anti-cache headers (Cache-Control, Expires, Pragma) are now consistently forwarded on redirects, error responses, and when updating cookies, preserving expected caching behavior.

* **Tests**
  * Added tests covering anti-cache header forwarding and cookie update behavior to prevent regressions and ensure headers and refreshed cookies appear on outgoing responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->