### PR TITLE
feat(gdpr): machine-readable warnings field for failed export sub-reads (#684)

### DIFF
--- a/apps/web/app/app/admin/students/_components/export-student-dialog.test.tsx
+++ b/apps/web/app/app/admin/students/_components/export-student-dialog.test.tsx
@@ -4,16 +4,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks ----------------------------------------------------------------
 
-const { mockExportStudentData, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
-  mockExportStudentData: vi.fn(),
-  mockToastSuccess: vi.fn(),
-  mockToastError: vi.fn(),
-}))
+const { mockExportStudentData, mockToastSuccess, mockToastError, mockToastWarning } = vi.hoisted(
+  () => ({
+    mockExportStudentData: vi.fn(),
+    mockToastSuccess: vi.fn(),
+    mockToastError: vi.fn(),
+    mockToastWarning: vi.fn(),
+  }),
+)
 
 vi.mock('../actions/export-student-data', () => ({
   exportStudentData: mockExportStudentData,
 }))
-vi.mock('sonner', () => ({ toast: { success: mockToastSuccess, error: mockToastError } }))
+vi.mock('sonner', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError, warning: mockToastWarning },
+}))
 
 // jsdom does not implement URL.createObjectURL / URL.revokeObjectURL
 vi.stubGlobal('URL', {
@@ -41,6 +46,7 @@ const MOCK_STUDENT: StudentRow = {
 
 const MOCK_PAYLOAD = {
   exported_at: '2026-03-27T10:00:00.000Z',
+  warnings: [],
   user: {
     id: MOCK_STUDENT.id,
     email: MOCK_STUDENT.email,
@@ -106,6 +112,27 @@ describe('ExportStudentDialog', () => {
         expect(mockToastSuccess).toHaveBeenCalledWith('Student data exported')
         expect(mockOnOpenChange).toHaveBeenCalledWith(false)
       })
+    })
+
+    it('shows a warning toast (not success) but still closes when the export is incomplete', async () => {
+      mockExportStudentData.mockResolvedValue({
+        success: true,
+        data: { ...MOCK_PAYLOAD, warnings: [{ section: 'audit_events', message: 'incomplete' }] },
+      })
+      const mockOnOpenChange = vi.fn()
+
+      const user = userEvent.setup()
+      render(
+        <ExportStudentDialog student={MOCK_STUDENT} open={true} onOpenChange={mockOnOpenChange} />,
+      )
+
+      await user.click(screen.getByRole('button', { name: /^export$/i }))
+
+      await waitFor(() => {
+        expect(mockToastWarning).toHaveBeenCalledWith(expect.stringContaining('incomplete'))
+        expect(mockOnOpenChange).toHaveBeenCalledWith(false)
+      })
+      expect(mockToastSuccess).not.toHaveBeenCalled()
     })
 
     it('calls exportStudentData with the student userId', async () => {

--- a/apps/web/app/app/admin/students/_components/export-student-dialog.tsx
+++ b/apps/web/app/app/admin/students/_components/export-student-dialog.tsx
@@ -44,7 +44,15 @@ export function ExportStudentDialog({ student, open, onOpenChange }: Readonly<Pr
           `student-export-${safePrefix}-${new Date().toISOString().slice(0, 10)}.json`,
         )
 
-        toast.success('Student data exported')
+        // Download still proceeds on a partial failure, but flag incompleteness rather
+        // than reporting plain success so the admin knows to retry before relying on it.
+        if (result.data.warnings.length > 0) {
+          toast.warning(
+            'Export downloaded, but some sections could not be loaded and may be incomplete. Please try again.',
+          )
+        } else {
+          toast.success('Student data exported')
+        }
         onOpenChange(false)
       } catch {
         toast.error('Failed to export student data')

--- a/apps/web/app/app/settings/_components/data-export-card.test.tsx
+++ b/apps/web/app/app/settings/_components/data-export-card.test.tsx
@@ -55,6 +55,22 @@ beforeEach(() => {
   vi.resetAllMocks()
 })
 
+/**
+ * Stub document.createElement so the anchor's .click() is a no-op (jsdom does not
+ * implement navigation). Returns the spy so the caller can restore it in a finally
+ * block — beforeEach uses resetAllMocks, which does NOT reinstate the original impl.
+ */
+function stubLinkClick() {
+  const originalCreateElement = document.createElement.bind(document)
+  return vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    const el = originalCreateElement(tag)
+    if (tag === 'a') {
+      Object.defineProperty(el, 'click', { value: vi.fn(), writable: true })
+    }
+    return el
+  })
+}
+
 describe('DataExportCard', () => {
   describe('rendering', () => {
     it('renders the card heading', () => {
@@ -76,27 +92,19 @@ describe('DataExportCard', () => {
   describe('happy path', () => {
     it('shows success toast when export succeeds', async () => {
       mockExportMyData.mockResolvedValue({ success: true, data: MOCK_PAYLOAD })
+      const createElementSpy = stubLinkClick()
+      try {
+        const user = userEvent.setup()
+        render(<DataExportCard />)
 
-      // Stub link.click() so jsdom does not attempt navigation
-      const originalCreateElement = document.createElement.bind(document)
-      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-        const el = originalCreateElement(tag)
-        if (tag === 'a') {
-          Object.defineProperty(el, 'click', { value: vi.fn(), writable: true })
-        }
-        return el
-      })
+        await user.click(screen.getByRole('button', { name: /export my data/i }))
 
-      const user = userEvent.setup()
-      render(<DataExportCard />)
-
-      await user.click(screen.getByRole('button', { name: /export my data/i }))
-
-      await waitFor(() => {
-        expect(mockToastSuccess).toHaveBeenCalledWith('Data exported successfully')
-      })
-
-      vi.restoreAllMocks()
+        await waitFor(() => {
+          expect(mockToastSuccess).toHaveBeenCalledWith('Data exported successfully')
+        })
+      } finally {
+        createElementSpy.mockRestore()
+      }
     })
 
     it('shows a warning toast (not success) when the export has incomplete sections', async () => {
@@ -104,27 +112,20 @@ describe('DataExportCard', () => {
         success: true,
         data: { ...MOCK_PAYLOAD, warnings: [{ section: 'quiz_sessions', message: 'incomplete' }] },
       })
+      const createElementSpy = stubLinkClick()
+      try {
+        const user = userEvent.setup()
+        render(<DataExportCard />)
 
-      const originalCreateElement = document.createElement.bind(document)
-      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-        const el = originalCreateElement(tag)
-        if (tag === 'a') {
-          Object.defineProperty(el, 'click', { value: vi.fn(), writable: true })
-        }
-        return el
-      })
+        await user.click(screen.getByRole('button', { name: /export my data/i }))
 
-      const user = userEvent.setup()
-      render(<DataExportCard />)
-
-      await user.click(screen.getByRole('button', { name: /export my data/i }))
-
-      await waitFor(() => {
-        expect(mockToastWarning).toHaveBeenCalledWith(expect.stringContaining('incomplete'))
-      })
-      expect(mockToastSuccess).not.toHaveBeenCalled()
-
-      vi.restoreAllMocks()
+        await waitFor(() => {
+          expect(mockToastWarning).toHaveBeenCalledWith(expect.stringContaining('incomplete'))
+        })
+        expect(mockToastSuccess).not.toHaveBeenCalled()
+      } finally {
+        createElementSpy.mockRestore()
+      }
     })
   })
 

--- a/apps/web/app/app/settings/_components/data-export-card.test.tsx
+++ b/apps/web/app/app/settings/_components/data-export-card.test.tsx
@@ -4,14 +4,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks ----------------------------------------------------------------
 
-const { mockExportMyData, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+const { mockExportMyData, mockToastSuccess, mockToastError, mockToastWarning } = vi.hoisted(() => ({
   mockExportMyData: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
+  mockToastWarning: vi.fn(),
 }))
 
 vi.mock('../gdpr-actions', () => ({ exportMyData: mockExportMyData }))
-vi.mock('sonner', () => ({ toast: { success: mockToastSuccess, error: mockToastError } }))
+vi.mock('sonner', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError, warning: mockToastWarning },
+}))
 
 // jsdom does not implement URL.createObjectURL / URL.revokeObjectURL
 vi.stubGlobal('URL', {
@@ -27,6 +30,7 @@ import { DataExportCard } from './data-export-card'
 
 const MOCK_PAYLOAD = {
   exported_at: '2026-03-27T10:00:00.000Z',
+  warnings: [],
   user: {
     id: 'u-1',
     email: 'student@example.com',
@@ -91,6 +95,34 @@ describe('DataExportCard', () => {
       await waitFor(() => {
         expect(mockToastSuccess).toHaveBeenCalledWith('Data exported successfully')
       })
+
+      vi.restoreAllMocks()
+    })
+
+    it('shows a warning toast (not success) when the export has incomplete sections', async () => {
+      mockExportMyData.mockResolvedValue({
+        success: true,
+        data: { ...MOCK_PAYLOAD, warnings: [{ section: 'quiz_sessions', message: 'incomplete' }] },
+      })
+
+      const originalCreateElement = document.createElement.bind(document)
+      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        const el = originalCreateElement(tag)
+        if (tag === 'a') {
+          Object.defineProperty(el, 'click', { value: vi.fn(), writable: true })
+        }
+        return el
+      })
+
+      const user = userEvent.setup()
+      render(<DataExportCard />)
+
+      await user.click(screen.getByRole('button', { name: /export my data/i }))
+
+      await waitFor(() => {
+        expect(mockToastWarning).toHaveBeenCalledWith(expect.stringContaining('incomplete'))
+      })
+      expect(mockToastSuccess).not.toHaveBeenCalled()
 
       vi.restoreAllMocks()
     })

--- a/apps/web/app/app/settings/_components/data-export-card.tsx
+++ b/apps/web/app/app/settings/_components/data-export-card.tsx
@@ -25,7 +25,15 @@ export function DataExportCard() {
           `lmsplus-data-export-${new Date().toISOString().slice(0, 10)}.json`,
         )
 
-        toast.success('Data exported successfully')
+        // The export still downloads on a partial failure (right of access is never denied),
+        // but the requester must be told it may be incomplete rather than seeing plain success.
+        if (result.data.warnings.length > 0) {
+          toast.warning(
+            'Export downloaded, but some sections could not be loaded and may be incomplete. Please try again.',
+          )
+        } else {
+          toast.success('Data exported successfully')
+        }
       } catch {
         toast.error('Failed to export data')
       }

--- a/apps/web/lib/gdpr/collect-user-data.test.ts
+++ b/apps/web/lib/gdpr/collect-user-data.test.ts
@@ -79,6 +79,31 @@ function makeChain(rows: unknown, error: unknown) {
 }
 
 /**
+ * Chain where the count (head) call succeeds with a non-zero total but the page (range)
+ * call errors — the fetchAllRows "page error after count success" path. fetchAllRows then
+ * discards partial pages and returns { data: [], error }, so the caller sees an errored read.
+ */
+function makePageErrorChain(count: number, pageError: { message: string }) {
+  const state = { head: false }
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(target, prop) {
+      if (prop === 'then') {
+        return (resolve: (v: unknown) => void) =>
+          resolve(state.head ? { count, error: null } : { data: null, error: pageError })
+      }
+      if (prop === 'select') {
+        return (_col: unknown, opts?: { head?: boolean; count?: string }) => {
+          state.head = Boolean(opts?.head) // reset per select: count select is head, page select is not
+          return new Proxy(target, handler)
+        }
+      }
+      return () => new Proxy(target, handler)
+    },
+  }
+  return new Proxy({} as Record<string, unknown>, handler)
+}
+
+/**
  * Build a fake Supabase client that returns pre-configured data for each table.
  * Each call to `.from(tableName)` returns a chain that resolves to the supplied value.
  */
@@ -440,6 +465,68 @@ describe('collectUserData', () => {
       expect(result.flagged_questions).toHaveLength(2)
       // No rows dropped → no drop log (guards against a `<` → `>=` regression).
       expect(consoleSpy).not.toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('warnings (machine-readable incompleteness)', () => {
+    it('returns an empty warnings array when every section exports cleanly', async () => {
+      const supabase = buildSupabaseClient()
+      const result = await collectUserData(supabase, USER_ID)
+
+      expect(result.warnings).toEqual([])
+    })
+
+    it('records a warning for each failed sub-read, keyed by section', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const supabase = buildSupabaseClientWithErrors({
+        sessionsError: { message: 'timeout' },
+        flagsError: { message: 'connection lost' },
+      })
+      const result = await collectUserData(supabase, USER_ID)
+
+      const sections = result.warnings.map((w) => w.section)
+      expect(sections).toContain('quiz_sessions')
+      expect(sections).toContain('flagged_questions')
+      expect(sections).toHaveLength(2)
+      // Message is the user-safe constant — never the raw DB error string.
+      for (const warning of result.warnings) {
+        expect(warning.message).not.toContain('timeout')
+        expect(warning.message).not.toContain('connection lost')
+        expect(warning.message.length).toBeGreaterThan(0)
+      }
+      consoleSpy.mockRestore()
+    })
+
+    it('records a quiz_answers warning when the phase-2 answers read fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      // Sessions succeed (phase-2 fires), but the answers read errors.
+      const supabase = buildSupabaseClientWithErrors({
+        answersError: { message: 'answers timeout' },
+      })
+      const result = await collectUserData(supabase, USER_ID)
+
+      expect(result.warnings.map((w) => w.section)).toContain('quiz_answers')
+      consoleSpy.mockRestore()
+    })
+
+    it('records a warning when a page fetch fails after the count succeeds', async () => {
+      // fetchAllRows page-error path: count returns a non-zero total, then the page read
+      // errors and fetchAllRows discards partial pages, yielding { data: [], error }. The
+      // export must surface this — a silently truncated legal export is the #668 failure mode.
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const base = buildSupabaseClient()
+      const supabase = {
+        from: (table: string) =>
+          table === 'quiz_sessions'
+            ? makePageErrorChain(5, { message: 'page fetch failed' })
+            : (base as unknown as { from: (t: string) => unknown }).from(table),
+      } as unknown as SupabaseClient<Database>
+
+      const result = await collectUserData(supabase, USER_ID)
+
+      expect(result.quiz_sessions).toHaveLength(0) // partial pages discarded
+      expect(result.warnings.map((w) => w.section)).toContain('quiz_sessions')
       consoleSpy.mockRestore()
     })
   })

--- a/apps/web/lib/gdpr/collect-user-data.test.ts
+++ b/apps/web/lib/gdpr/collect-user-data.test.ts
@@ -82,6 +82,8 @@ function makeChain(rows: unknown, error: unknown) {
  * Chain where the count (head) call succeeds with a non-zero total but the page (range)
  * call errors — the fetchAllRows "page error after count success" path. fetchAllRows then
  * discards partial pages and returns { data: [], error }, so the caller sees an errored read.
+ * NB: `state` is per-`from()`-call; each logical fetchAllRows chain must originate from a fresh
+ * `from()` so the head/page flag doesn't carry over (one count + one page call per invocation).
  */
 function makePageErrorChain(count: number, pageError: { message: string }) {
   const state = { head: false }
@@ -510,6 +512,22 @@ describe('collectUserData', () => {
       consoleSpy.mockRestore()
     })
 
+    it('skips phase-2 and leaves quiz_answers empty when the sessions read fails', async () => {
+      // Sessions errored → fetchAllRows returns { data: [], error }; phase-2 must not run
+      // (and the explicit error guard protects .map if a future refactor returns null data).
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const supabase = buildSupabaseClientWithErrors({
+        sessionsError: { message: 'sessions down' },
+      })
+      const result = await collectUserData(supabase, USER_ID)
+
+      expect(result.quiz_answers).toEqual([])
+      expect(result.warnings.map((w) => w.section)).toContain('quiz_sessions')
+      // sessions failed, so the answers section is not separately warned (phase-2 skipped)
+      expect(result.warnings.map((w) => w.section)).not.toContain('quiz_answers')
+      consoleSpy.mockRestore()
+    })
+
     it('records a warning when a page fetch fails after the count succeeds', async () => {
       // fetchAllRows page-error path: count returns a non-zero total, then the page read
       // errors and fetchAllRows discards partial pages, yielding { data: [], error }. The
@@ -527,6 +545,91 @@ describe('collectUserData', () => {
 
       expect(result.quiz_sessions).toHaveLength(0) // partial pages discarded
       expect(result.warnings.map((w) => w.section)).toContain('quiz_sessions')
+      consoleSpy.mockRestore()
+    })
+
+    it('records exactly one warning per failed section — no duplicates', async () => {
+      // Regression guard: collectSectionWarnings must push exactly one entry per failing
+      // section, not two (e.g. if the loop iterated the same result twice).
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const supabase = buildSupabaseClientWithErrors({
+        responsesError: { message: 'db error' },
+        commentsError: { message: 'db error' },
+      })
+      const result = await collectUserData(supabase, USER_ID)
+
+      const failedSections = result.warnings.map((w) => w.section)
+      // Exactly two sections failed — no duplicates.
+      expect(failedSections).toHaveLength(2)
+      expect(new Set(failedSections).size).toBe(2)
+      consoleSpy.mockRestore()
+    })
+
+    it('omits successful sections from warnings even when other sections fail', async () => {
+      // Guards against an unconditional push regression: a section that exported cleanly
+      // must never appear in warnings regardless of how many other sections fail.
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const supabase = buildSupabaseClientWithErrors({
+        sessionsError: { message: 'timeout' },
+        fsrsError: { message: 'timeout' },
+      })
+      const result = await collectUserData(supabase, USER_ID)
+
+      const warnedSections = new Set(result.warnings.map((w) => w.section))
+      // Failed sections must be present.
+      expect(warnedSections.has('quiz_sessions')).toBe(true)
+      expect(warnedSections.has('fsrs_cards')).toBe(true)
+      // Successful phase-1 sections must be absent.
+      for (const ok of [
+        'student_responses',
+        'flagged_questions',
+        'question_comments',
+        'user_consents',
+        'audit_events',
+      ]) {
+        expect(warnedSections.has(ok)).toBe(false)
+      }
+      // Phase-2 succeeded (sessions errored, so no sessionIds → no phase-2 call → no answers warning).
+      expect(warnedSections.has('quiz_answers')).toBe(false)
+      consoleSpy.mockRestore()
+    })
+
+    it('produces warnings in section-iteration order when all phase-1 sections fail', async () => {
+      // collectSectionWarnings iterates queryResults in declaration order. The warnings array
+      // must reflect that stable order — downstream consumers (e.g. UI rendering) rely on it.
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const supabase = buildSupabaseClientWithErrors({
+        sessionsError: { message: 'e' },
+        responsesError: { message: 'e' },
+        fsrsError: { message: 'e' },
+        flagsError: { message: 'e' },
+        commentsError: { message: 'e' },
+        consentsError: { message: 'e' },
+        auditError: { message: 'e' },
+      })
+      const result = await collectUserData(supabase, USER_ID)
+
+      // All 7 phase-1 sections fail → 7 warnings (no quiz_answers warning because sessions
+      // returned empty data, so phase-2 never fires).
+      expect(result.warnings).toHaveLength(7)
+
+      // Verify stable declaration order (see `queryResults` array in collect-user-data.ts).
+      const expectedOrder = [
+        'quiz_sessions',
+        'student_responses',
+        'fsrs_cards',
+        'flagged_questions',
+        'question_comments',
+        'user_consents',
+        'audit_events',
+      ]
+      expect(result.warnings.map((w) => w.section)).toEqual(expectedOrder)
+
+      // Every warning carries the user-safe message, not any raw error string.
+      for (const warning of result.warnings) {
+        expect(warning.message).not.toBe('e')
+        expect(warning.message.length).toBeGreaterThan(0)
+      }
       consoleSpy.mockRestore()
     })
   })

--- a/apps/web/lib/gdpr/collect-user-data.ts
+++ b/apps/web/lib/gdpr/collect-user-data.ts
@@ -87,8 +87,10 @@ export async function collectUserData(
   ] as const
   const warnings = collectSectionWarnings(queryResults)
 
-  // Phase 2: fetch quiz answers using session IDs from phase 1
-  const sessionIds = sessionsResult.data.map((s) => s.id)
+  // Phase 2: fetch quiz answers using session IDs from phase 1. Skip when the sessions
+  // read failed — we can't resolve answer session IDs from a partial/empty set, and the
+  // explicit error guard also protects .map() if a future refactor returns data: null.
+  const sessionIds = sessionsResult.error ? [] : sessionsResult.data.map((s) => s.id)
   let answers: GdprExportPayload['quiz_answers'] = []
   let answersError: { message: string } | null = null
 

--- a/apps/web/lib/gdpr/collect-user-data.ts
+++ b/apps/web/lib/gdpr/collect-user-data.ts
@@ -10,7 +10,31 @@ import {
   fetchUserSessionAnswers,
   fetchUserSessions,
 } from './collect-user-data-queries'
-import type { GdprExportPayload } from './types'
+import type { GdprExportPayload, GdprExportWarning } from './types'
+
+// User-safe wording for a failed section — surfaced in the export's `warnings`. The raw
+// DB error is logged server-side only (see callers), never returned to the data subject.
+const SECTION_FAILED_MESSAGE =
+  'This section could not be exported in full and may be incomplete. Please retry the export or contact support.'
+
+/**
+ * Logs each failed sub-read server-side and returns a machine-readable warning per
+ * failure. A failed read yields an EMPTY section (fetchAllRows discards partial pages on
+ * error), so without a warning the export would look complete while silently missing a
+ * section — the #668 failure mode, which for a legal GDPR export is unacceptable.
+ */
+function collectSectionWarnings(
+  results: ReadonlyArray<readonly [string, { error: { message: string } | null }]>,
+): GdprExportWarning[] {
+  const warnings: GdprExportWarning[] = []
+  for (const [section, result] of results) {
+    if (result.error) {
+      console.error(`[collectUserData] ${section} query failed:`, result.error.message)
+      warnings.push({ section, message: SECTION_FAILED_MESSAGE })
+    }
+  }
+  return warnings
+}
 
 /**
  * Collects all data associated with a user for GDPR export.
@@ -48,9 +72,10 @@ export async function collectUserData(
     throw new Error('User not found')
   }
 
-  // A failed read returns an EMPTY section (fetchAllRows discards partial pages on error) and is
-  // logged here; the export still returns rather than hard-failing. The #668 failure mode we must
-  // avoid is a silently TRUNCATED section that looks complete — an empty + logged section does not.
+  // A failed read returns an EMPTY section (fetchAllRows discards partial pages on error); the
+  // export still returns rather than hard-failing so a transient outage never denies the data
+  // subject access. Each failure is logged AND recorded in `warnings` so the incompleteness is
+  // visible/machine-readable rather than a silently TRUNCATED section that looks complete (#668).
   const queryResults = [
     ['quiz_sessions', sessionsResult],
     ['student_responses', responsesResult],
@@ -60,11 +85,7 @@ export async function collectUserData(
     ['user_consents', consentsResult],
     ['audit_events', auditResult],
   ] as const
-  for (const [table, result] of queryResults) {
-    if (result.error) {
-      console.error(`[collectUserData] ${table} query failed:`, result.error.message)
-    }
-  }
+  const warnings = collectSectionWarnings(queryResults)
 
   // Phase 2: fetch quiz answers using session IDs from phase 1
   const sessionIds = sessionsResult.data.map((s) => s.id)
@@ -79,6 +100,7 @@ export async function collectUserData(
 
   if (answersError) {
     console.error('[collectUserData] quiz_session_answers query failed:', answersError.message)
+    warnings.push({ section: 'quiz_answers', message: SECTION_FAILED_MESSAGE })
   }
 
   // View columns are typed nullable (Postgres view artifact); the backing table enforces NOT NULL,
@@ -97,6 +119,7 @@ export async function collectUserData(
 
   return {
     exported_at: new Date().toISOString(),
+    warnings,
     user: userResult.data,
     quiz_sessions: sessionsResult.data,
     quiz_answers: answers,

--- a/apps/web/lib/gdpr/types.ts
+++ b/apps/web/lib/gdpr/types.ts
@@ -1,6 +1,20 @@
+/**
+ * A section of the export that could not be read in full. The export is still
+ * returned (so the data subject is never denied access by a transient outage),
+ * but this list makes the incompleteness machine-readable so the caller can warn
+ * the requester or retry. `section` matches a payload key; `message` is user-safe
+ * (the raw DB error is logged server-side only, never surfaced here).
+ */
+export type GdprExportWarning = {
+  section: string
+  message: string
+}
+
 /** GDPR data export payload — Articles 15 (access) and 20 (portability). */
 export type GdprExportPayload = {
   exported_at: string
+  /** Empty when every section exported cleanly; one entry per failed sub-read. */
+  warnings: GdprExportWarning[]
   user: {
     id: string
     email: string

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -664,6 +664,22 @@ Full audit completed — 46 files reviewed. Score: 9.5/10. Full report: `docs/se
 
 **Implementation**: Round-2 fix commits `e3a7a0b` + `7082d77` + `787b5f0` (PR #590, merged 2026-04-30 → `1eeeda6`). New helper `restoreSeededQuestionsState()` in `apps/web/e2e/helpers/supabase.ts`. Marker constant `E2E_ADMIN_Q_MARKER` exported from same module. 7 unit tests for the helper.
 
+### Decision 39: GDPR export sub-read failure → machine-readable `warnings` field (not silent empty, not hard-fail) (2026-06-06)
+
+**Date**: 2026-06-06
+
+**Context**: Issue #684 (spun out of #668/#681). `collectUserData()` fetches each export section independently. When a sub-read fails, `fetchAllRows` discards partial pages and returns `{ data: [], error }`, so the section comes back empty. The prior behaviour logged the failure server-side and returned the export anyway. For a **legal** GDPR data-subject export this is risky: a transient outage could hand the requester an export that *looks* whole while silently missing a section — the server log is the only signal.
+
+**Decision**: Add a machine-readable `warnings: GdprExportWarning[]` field to `GdprExportPayload`. Each failed sub-read appends `{ section, message }` (section = payload key; message = a fixed user-safe string — the raw DB error is logged server-side only, never surfaced to the data subject per `docs/security.md` error-sanitisation). The export is still **returned** rather than hard-failing, so a transient outage never denies the data subject their right of access (Art. 15); the warnings make any incompleteness explicit so the caller/UI can warn or retry.
+
+- Rejected **hard-fail-and-retry**: a single section outage would block the entire export, denying access for a transient cause.
+- Rejected **keep-as-is (empty + log only)**: incompleteness was invisible to the requester — unacceptable for a legal export.
+- The user record itself remains a **hard fail** (`throw 'User not found'`) — without identity the export is meaningless.
+
+**Rationale**: Preserves the right of access while making partial failure auditable and actionable, at app-layer cost only (no migration). Empty array when every section exports cleanly.
+
+**Implementation**: `GdprExportWarning` type + `warnings` field in `apps/web/lib/gdpr/types.ts`; `collectSectionWarnings()` helper in `collect-user-data.ts`; warnings asserted in `collect-user-data.test.ts` (incl. the mandatory `fetchAllRows` page-error-after-count-success path). Both Server Action callers (`exportMyData`, `exportStudentData`) pass the payload — and its `warnings` — through unchanged.
+
 ---
 
-*Last updated: 2026-04-30 — Decision 38: E2E Spec Hermiticity rule promotion (count=2)*
+*Last updated: 2026-06-06 — Decision 39: GDPR export `warnings` field (#684)*


### PR DESCRIPTION
## What & why
Closes #684. Decision recorded as **Decision 39** in `docs/decisions.md`.

A GDPR export fetches each section independently. When a sub-read fails, `fetchAllRows` discards partial pages and the section comes back **empty**. Previously this was logged server-side only — a transient outage could hand the data subject an export that *looks* complete while silently missing a section (the #668 failure mode). For a legal Art. 15 export that's unacceptable.

## Approach (option 3 of the issue)
Add a machine-readable `warnings: GdprExportWarning[]` field to `GdprExportPayload`:
- Each failed sub-read (7 parallel reads + the phase-2 `quiz_answers` read) appends `{ section, message }` — `section` = payload key, `message` = a fixed **user-safe** string. The raw DB error is `console.error`'d server-side only, never surfaced (security.md error sanitisation).
- The export **still returns** rather than hard-failing, so a transient outage never denies right-of-access. The **user record** stays a hard-fail (no identity ⇒ meaningless export).
- Rejected: hard-fail-and-retry (one section outage blocks the whole export) and keep-as-is (incompleteness invisible).

## UI follow-through
Both callers (`DataExportCard`, `ExportStudentDialog`) now show `toast.warning` — not `toast.success` — when `warnings` is non-empty. The file still downloads (access never denied); the requester is told it may be incomplete and to retry.

## Hardening
Phase-2 answers read is now explicitly skipped when the sessions read errored (`sessionsResult.error ? [] : …`), which also guards `.map()` against a future refactor returning `null`.

## Verification (no manual testing needed)
- `collect-user-data` tests: empty warnings on success; one warning per failed section (asserting **no raw-error leak**); phase-2 answers warning; phase-2 **skip** on sessions error; the mandatory `fetchAllRows` page-error-after-count-success path; duplicate/omission/ordering guards.
- Both component tests assert `toast.warning` fires and `toast.success` does not when warnings present.
- Pipeline: plan validation, impl-critic (×2, approved), code-reviewer (clean; 1 watch: test file length — relaxed for tests), semantic-reviewer (per-commit + PR-level sweep — 1 ISSUE validated as a **false positive**: `fetchAllRows` normalises `data` to `[]` on every path, so `sessionsResult.data` is never null; existing null/error tests prove it), doc-updater (no further drift), test-writer (+4 tests), CodeRabbit local (2 trivial nits — both applied: `stubLinkClick` helper + try/finally spy restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GDPR data export now reports which sections failed to export completely, rather than silently omitting them.
  * Export dialogs display warning notifications when the downloaded data is incomplete, with the option to retry.

* **Documentation**
  * Added decision record for partial export handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->