### PR TITLE
fix(reports): render hours tier in session duration formatting (#834)

### DIFF
--- a/apps/web/app/app/quiz/report/_components/result-summary.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/result-summary.test.tsx
@@ -101,6 +101,44 @@ describe('ResultSummary', () => {
       render(<ResultSummary summary={makeSummary({ endedAt: null })} />)
       expect(screen.getAllByText('—').length).toBeGreaterThan(0)
     })
+
+    it('keeps the minutes-and-seconds format just under one hour', () => {
+      // 59 min 59 s — boundary below the hours tier
+      render(
+        <ResultSummary
+          summary={makeSummary({
+            startedAt: '2026-03-12T10:00:00Z',
+            endedAt: '2026-03-12T10:59:59Z',
+          })}
+        />,
+      )
+      expect(screen.getAllByText('59m 59s').length).toBeGreaterThan(0)
+    })
+
+    it('shows the hours tier at exactly one hour', () => {
+      render(
+        <ResultSummary
+          summary={makeSummary({
+            startedAt: '2026-03-12T10:00:00Z',
+            endedAt: '2026-03-12T11:00:00Z',
+          })}
+        />,
+      )
+      expect(screen.getAllByText('1h 0m 0s').length).toBeGreaterThan(0)
+    })
+
+    it('renders multi-hour durations with an hours unit instead of raw minutes', () => {
+      // 27 h 9 m 43 s (the reported "1629m 43s" case)
+      render(
+        <ResultSummary
+          summary={makeSummary({
+            startedAt: '2026-03-12T10:00:00Z',
+            endedAt: '2026-03-13T13:09:43Z',
+          })}
+        />,
+      )
+      expect(screen.getAllByText('27h 9m 43s').length).toBeGreaterThan(0)
+    })
   })
 
   describe('date display', () => {

--- a/apps/web/app/app/quiz/report/_components/result-summary.tsx
+++ b/apps/web/app/app/quiz/report/_components/result-summary.tsx
@@ -7,8 +7,10 @@ function formatDuration(startedAt: string, endedAt: string | null): string {
   const ms = new Date(endedAt).getTime() - new Date(startedAt).getTime()
   if (ms < 0) return '—'
   const totalSeconds = Math.round(ms / 1000)
-  const minutes = Math.floor(totalSeconds / 60)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
   const seconds = totalSeconds % 60
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`
   if (minutes === 0) return `${seconds}s`
   return `${minutes}m ${seconds}s`
 }

--- a/apps/web/app/app/reports/_components/reports-utils.test.ts
+++ b/apps/web/app/app/reports/_components/reports-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatDate, MODE_LABELS } from './reports-utils'
+import { formatDate, formatDurationMinutes, MODE_LABELS } from './reports-utils'
 
 describe('formatDate', () => {
   it('formats an ISO date string as "D Mon YYYY" in en-GB locale', () => {
@@ -14,6 +14,29 @@ describe('formatDate', () => {
   it('formats a date at the end of the year correctly', () => {
     // Use midday UTC to avoid date rolling over in any local timezone
     expect(formatDate('2025-12-31T12:00:00Z')).toBe('31 Dec 2025')
+  })
+})
+
+describe('formatDurationMinutes', () => {
+  it('renders minutes only when under an hour', () => {
+    expect(formatDurationMinutes(45)).toBe('45m')
+  })
+
+  it('renders a zero-minute session as "0m"', () => {
+    expect(formatDurationMinutes(0)).toBe('0m')
+  })
+
+  it('keeps the minutes-only format at the last minute below an hour', () => {
+    expect(formatDurationMinutes(59)).toBe('59m')
+  })
+
+  it('switches to the hours tier at exactly one hour', () => {
+    expect(formatDurationMinutes(60)).toBe('1h 0m')
+  })
+
+  it('renders long sessions with an hours unit instead of raw minutes', () => {
+    // 1629 min = 27 h 9 m — the reported raw-minutes case
+    expect(formatDurationMinutes(1629)).toBe('27h 9m')
   })
 })
 

--- a/apps/web/app/app/reports/_components/reports-utils.ts
+++ b/apps/web/app/app/reports/_components/reports-utils.ts
@@ -16,8 +16,8 @@ export function formatDate(iso: string) {
 // Renders a pre-computed minute count as `Xm` under an hour and `Xh Ym` at or above it,
 // so long sessions read as "27h 9m" instead of a raw "1629m".
 // Sibling duration formatters, kept separate by granularity on purpose:
-//   - quiz/exam report card (second-level, "Xh Ym Zs"): formatDuration in quiz/report/_components/result-summary.tsx
-//   - admin student detail table (minute-level, "<1m"/"Xh Ym"): formatDuration in admin/dashboard/students/[id]/_components/session-table-helpers.tsx
+//   - quiz/exam report card (second-level: "Xs" / "Xm Ys" / "Xh Ym Zs"): formatDuration in quiz/report/_components/result-summary.tsx
+//   - admin student detail table (minute-level: "<1m" / "Xm" / "Xh Ym"): formatDuration in admin/dashboard/students/[id]/_components/session-table-helpers.tsx
 export function formatDurationMinutes(mins: number): string {
   if (mins < 60) return `${mins}m`
   return `${Math.floor(mins / 60)}h ${mins % 60}m`

--- a/apps/web/app/app/reports/_components/reports-utils.ts
+++ b/apps/web/app/app/reports/_components/reports-utils.ts
@@ -12,3 +12,10 @@ export function formatDate(iso: string) {
     year: 'numeric',
   })
 }
+
+// Renders a pre-computed minute count as `Xm` under an hour and `Xh Ym` at or above it,
+// so long sessions read as "27h 9m" instead of a raw "1629m".
+export function formatDurationMinutes(mins: number): string {
+  if (mins < 60) return `${mins}m`
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`
+}

--- a/apps/web/app/app/reports/_components/reports-utils.ts
+++ b/apps/web/app/app/reports/_components/reports-utils.ts
@@ -15,6 +15,9 @@ export function formatDate(iso: string) {
 
 // Renders a pre-computed minute count as `Xm` under an hour and `Xh Ym` at or above it,
 // so long sessions read as "27h 9m" instead of a raw "1629m".
+// Sibling duration formatters, kept separate by granularity on purpose:
+//   - quiz/exam report card (second-level, "Xh Ym Zs"): formatDuration in quiz/report/_components/result-summary.tsx
+//   - admin student detail table (minute-level, "<1m"/"Xh Ym"): formatDuration in admin/dashboard/students/[id]/_components/session-table-helpers.tsx
 export function formatDurationMinutes(mins: number): string {
   if (mins < 60) return `${mins}m`
   return `${Math.floor(mins / 60)}h ${mins % 60}m`

--- a/apps/web/app/app/reports/_components/session-card.test.tsx
+++ b/apps/web/app/app/reports/_components/session-card.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { SessionReport } from '@/lib/queries/reports'
+import { SessionCard } from './session-card'
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string
+    children: React.ReactNode
+    className?: string
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+function makeSession(overrides: Partial<SessionReport> = {}): SessionReport {
+  return {
+    id: 'sess-1',
+    mode: 'quick_quiz',
+    subjectName: 'Navigation',
+    totalQuestions: 10,
+    correctCount: 8,
+    scorePercentage: 80,
+    startedAt: '2026-03-10T10:00:00Z',
+    endedAt: '2026-03-10T10:15:00Z',
+    durationMinutes: 15,
+    ...overrides,
+  }
+}
+
+describe('SessionCard', () => {
+  it('links to the quiz report page for the session', () => {
+    render(<SessionCard session={makeSession({ id: 'abc-123' })} />)
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/app/quiz/report?session=abc-123')
+  })
+
+  it('displays the subject name', () => {
+    render(<SessionCard session={makeSession({ subjectName: 'Meteorology' })} />)
+    expect(screen.getByText('Meteorology')).toBeInTheDocument()
+  })
+
+  it('displays em dash when subjectName is null', () => {
+    render(<SessionCard session={makeSession({ subjectName: null })} />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('displays score percentage rounded to nearest integer', () => {
+    render(<SessionCard session={makeSession({ scorePercentage: 66.7 })} />)
+    expect(screen.getByText('67%')).toBeInTheDocument()
+  })
+
+  it('displays em dash when scorePercentage is null', () => {
+    render(<SessionCard session={makeSession({ scorePercentage: null })} />)
+    // The subject-name em dash and the score em dash — at least one must be present
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  })
+
+  it('renders the correct/total question counts', () => {
+    render(<SessionCard session={makeSession({ correctCount: 7, totalQuestions: 10 })} />)
+    expect(screen.getByText(/7 \/ 10/)).toBeInTheDocument()
+  })
+
+  it('displays duration in minutes when under one hour', () => {
+    render(<SessionCard session={makeSession({ durationMinutes: 15 })} />)
+    expect(screen.getByText(/Time: 15m/)).toBeInTheDocument()
+  })
+
+  it('displays duration with an hours unit when at or above one hour', () => {
+    render(<SessionCard session={makeSession({ durationMinutes: 1629 })} />)
+    expect(screen.getByText(/Time: 27h 9m/)).toBeInTheDocument()
+  })
+
+  it('displays duration at exactly one hour as "1h 0m"', () => {
+    render(<SessionCard session={makeSession({ durationMinutes: 60 })} />)
+    expect(screen.getByText(/Time: 1h 0m/)).toBeInTheDocument()
+  })
+
+  it('renders a Practice Exam badge for mock_exam mode', () => {
+    render(<SessionCard session={makeSession({ mode: 'mock_exam' })} />)
+    expect(screen.getByText('Practice Exam')).toBeInTheDocument()
+  })
+
+  it('renders an Internal Exam badge for internal_exam mode', () => {
+    render(<SessionCard session={makeSession({ mode: 'internal_exam' })} />)
+    expect(screen.getByText('Internal Exam')).toBeInTheDocument()
+  })
+
+  it('renders the mode label for non-exam modes', () => {
+    render(<SessionCard session={makeSession({ mode: 'quick_quiz' })} />)
+    expect(screen.getByText('Study')).toBeInTheDocument()
+  })
+
+  it('falls back to raw mode string for unknown modes', () => {
+    render(<SessionCard session={makeSession({ mode: 'custom_mode' })} />)
+    expect(screen.getByText('custom_mode')).toBeInTheDocument()
+  })
+})

--- a/apps/web/app/app/reports/_components/session-card.test.tsx
+++ b/apps/web/app/app/reports/_components/session-card.test.tsx
@@ -57,8 +57,7 @@ describe('SessionCard', () => {
 
   it('displays em dash when scorePercentage is null', () => {
     render(<SessionCard session={makeSession({ scorePercentage: null })} />)
-    // The subject-name em dash and the score em dash — at least one must be present
-    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+    expect(screen.getByText('—')).toBeInTheDocument()
   })
 
   it('renders the correct/total question counts', () => {

--- a/apps/web/app/app/reports/_components/session-card.tsx
+++ b/apps/web/app/app/reports/_components/session-card.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { isExamMode } from '@/lib/constants/exam-modes'
 import type { SessionReport } from '@/lib/queries/reports'
 import { scoreColor } from '@/lib/utils/score-color'
-import { formatDate, MODE_LABELS } from './reports-utils'
+import { formatDate, formatDurationMinutes, MODE_LABELS } from './reports-utils'
 
 export function SessionCard({ session: s }: Readonly<{ session: SessionReport }>) {
   const exam = isExamMode(s.mode)
@@ -33,7 +33,7 @@ export function SessionCard({ session: s }: Readonly<{ session: SessionReport }>
         <span className="ml-3">
           Correct: {s.correctCount} / {s.totalQuestions}
         </span>
-        <span className="ml-3">Time: {s.durationMinutes}m</span>
+        <span className="ml-3">Time: {formatDurationMinutes(s.durationMinutes)}</span>
       </p>
     </Link>
   )

--- a/apps/web/app/app/reports/_components/session-table.test.tsx
+++ b/apps/web/app/app/reports/_components/session-table.test.tsx
@@ -74,9 +74,14 @@ describe('SessionTable', () => {
     expect(screen.getByText(/7 \/ 10/)).toBeInTheDocument()
   })
 
-  it('displays duration in minutes', () => {
+  it('displays duration in minutes when under one hour', () => {
     render(<SessionTable {...SORT_PROPS} sessions={[makeSession({ durationMinutes: 20 })]} />)
     expect(screen.getByText('20m')).toBeInTheDocument()
+  })
+
+  it('displays duration with an hours unit when at or above one hour', () => {
+    render(<SessionTable {...SORT_PROPS} sessions={[makeSession({ durationMinutes: 1629 })]} />)
+    expect(screen.getByText('27h 9m')).toBeInTheDocument()
   })
 
   it('displays score percentage rounded to nearest integer', () => {

--- a/apps/web/app/app/reports/_components/session-table.tsx
+++ b/apps/web/app/app/reports/_components/session-table.tsx
@@ -6,7 +6,7 @@ import { SortableTableHead } from '@/components/sortable-table-head'
 import { isExamMode } from '@/lib/constants/exam-modes'
 import type { SessionReport, SortDir, SortKey } from '@/lib/queries/reports'
 import { scoreColor } from '@/lib/utils/score-color'
-import { formatDate, MODE_LABELS } from './reports-utils'
+import { formatDate, formatDurationMinutes, MODE_LABELS } from './reports-utils'
 
 type Props = Readonly<{
   sessions: SessionReport[]
@@ -95,7 +95,9 @@ function SessionRow({ session: s }: Readonly<{ session: SessionReport }>) {
       <td className="px-4 py-3 tabular-nums">
         {s.correctCount} / {s.totalQuestions}
       </td>
-      <td className="px-4 py-3 text-muted-foreground">{s.durationMinutes}m</td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {formatDurationMinutes(s.durationMinutes)}
+      </td>
       <td className="px-4 py-3 text-right font-semibold tabular-nums" style={{ color }}>
         {score}
       </td>


### PR DESCRIPTION
## What

Long session durations rendered in raw minutes with no hours unit — e.g. a 27-hour session showed `1629m 43s` (report card) and `1629m` (reports list). This adds an hours tier to both duration paths.

## Changes

- **`result-summary.tsx` `formatDuration`** — adds an hours tier, keeping seconds, so ≥1h renders as `Xh Ym Zs` (e.g. `27h 9m 43s`). Sub-1h output (`Ym Zs`, `Zs`, `—`) is unchanged. This single function feeds **6 surfaces** via the shared `ResultSummary`: quiz report, mock-exam report, internal-exam report (student + admin), and admin session-detail report.
- **`reports-utils.ts` — new `formatDurationMinutes(mins)`** — renders the pre-computed `durationMinutes` integer as `Xm` under an hour, `Xh Ym` at/above. Wired into `session-card.tsx` and `session-table.tsx`, which previously interpolated the raw `{durationMinutes}m`. (No seconds tier here — the reports list only carries minute granularity.)
- A cross-reference comment documents the three sibling formatters (report card / reports list / admin table) and their intentionally different granularities.

## Scope notes

- **VFR RT report** — not built yet (Phase B), nothing to change.
- **Admin student session-history table** (`session-table-helpers.tsx`) — already hours-aware; untouched.
- The helper is co-located in `reports-utils.ts` rather than extracted, because the three formatters have different output contracts (with-seconds / `<1m` floor / neither); a shared util would mean refactoring two unrelated working formatters.

## Tests

- `result-summary.test.tsx` — boundary cases: 59m59s (unchanged), exactly 1h → `1h 0m 0s`, the reported `27h 9m 43s`.
- `reports-utils.test.ts` — `formatDurationMinutes`: 0→`0m`, 45→`45m`, 59→`59m`, 60→`1h 0m`, 1629→`27h 9m`.
- `session-table.test.tsx` — added an hours-tier render case.
- `session-card.test.tsx` — new co-located suite (13 tests; the card was previously untested).

Full web suite green (3598 tests), type-check clean.

## Manual eval

Worth a quick click-through of a completed long session on the quiz/exam report card and the reports list to confirm the rendered strings, since this is a user-facing display change.

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Duration display in quiz reports and session cards now formats durations to show hours for sessions lasting one hour or longer (e.g., "27h 9m" instead of minutes only), improving readability for longer study sessions.

* **Tests**
  * Added comprehensive test coverage for duration formatting, including edge cases at key time boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->