### PR TITLE
feat(reports): show all options by default + render question image (#835)

### DIFF
--- a/apps/web/app/app/quiz/report/_components/options-list.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/options-list.test.tsx
@@ -1,10 +1,6 @@
 import { render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { OptionsList } from './options-list'
-
-beforeEach(() => {
-  vi.resetAllMocks()
-})
 
 const baseOptions = [
   { id: 'opt-a', text: 'Upward force' },
@@ -72,8 +68,6 @@ describe('OptionsList', () => {
 
   it('shows no markers on neutral options', () => {
     render(<OptionsList options={baseOptions} correctOptionId="opt-a" selectedOptionId="opt-b" />)
-    // opt-c and opt-d are neither correct nor selected — no Correct/Your answer on them
-    // The Correct label appears exactly once (for opt-a), Your answer exactly once (for opt-b)
     expect(screen.getAllByText('Correct')).toHaveLength(1)
     expect(screen.getAllByText('Your answer')).toHaveLength(1)
   })

--- a/apps/web/app/app/quiz/report/_components/options-list.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/options-list.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OptionsList } from './options-list'
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+const baseOptions = [
+  { id: 'opt-a', text: 'Upward force' },
+  { id: 'opt-b', text: 'Downward force' },
+  { id: 'opt-c', text: 'Sideways force' },
+  { id: 'opt-d', text: 'No force' },
+]
+
+describe('OptionsList', () => {
+  it('renders nothing when options array is empty', () => {
+    const { container } = render(
+      <OptionsList options={[]} correctOptionId="opt-a" selectedOptionId="opt-a" />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders all option texts', () => {
+    render(<OptionsList options={baseOptions} correctOptionId="opt-a" selectedOptionId="opt-b" />)
+    expect(screen.getByText('Upward force')).toBeInTheDocument()
+    expect(screen.getByText('Downward force')).toBeInTheDocument()
+    expect(screen.getByText('Sideways force')).toBeInTheDocument()
+    expect(screen.getByText('No force')).toBeInTheDocument()
+  })
+
+  it('assigns letters A/B/C/D by index order', () => {
+    render(<OptionsList options={baseOptions} correctOptionId="opt-a" selectedOptionId="opt-a" />)
+    const letters = screen.getAllByText(/^[A-D]$/)
+    expect(letters.map((el) => el.textContent)).toEqual(['A', 'B', 'C', 'D'])
+  })
+
+  it('marks the correct option with a "Correct" label', () => {
+    render(<OptionsList options={baseOptions} correctOptionId="opt-a" selectedOptionId="opt-b" />)
+    expect(screen.getByText('Correct')).toBeInTheDocument()
+  })
+
+  it('marks the selected-wrong option with "Your answer" label', () => {
+    render(<OptionsList options={baseOptions} correctOptionId="opt-a" selectedOptionId="opt-b" />)
+    expect(screen.getByText('Your answer')).toBeInTheDocument()
+  })
+
+  it('shows both "Correct" and "Your answer" markers when selected option is correct', () => {
+    render(<OptionsList options={baseOptions} correctOptionId="opt-a" selectedOptionId="opt-a" />)
+    expect(screen.getByText('Correct')).toBeInTheDocument()
+    expect(screen.getByText('· Your answer')).toBeInTheDocument()
+  })
+
+  it('shows no "Your answer" marker when selectedOptionId matches no option', () => {
+    render(
+      <OptionsList
+        options={baseOptions}
+        correctOptionId="opt-a"
+        selectedOptionId="opt-nonexistent"
+      />,
+    )
+    expect(screen.queryByText('Your answer')).not.toBeInTheDocument()
+    expect(screen.queryByText('· Your answer')).not.toBeInTheDocument()
+  })
+
+  it('shows no markers on neutral options', () => {
+    render(<OptionsList options={baseOptions} correctOptionId="opt-a" selectedOptionId="opt-b" />)
+    // opt-c and opt-d are neither correct nor selected — no Correct/Your answer on them
+    // The Correct label appears exactly once (for opt-a), Your answer exactly once (for opt-b)
+    expect(screen.getAllByText('Correct')).toHaveLength(1)
+    expect(screen.getAllByText('Your answer')).toHaveLength(1)
+  })
+})

--- a/apps/web/app/app/quiz/report/_components/options-list.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/options-list.test.tsx
@@ -63,6 +63,13 @@ describe('OptionsList', () => {
     expect(screen.queryByText('· Your answer')).not.toBeInTheDocument()
   })
 
+  it('shows the correct marker but no "Your answer" when selectedOptionId is null (text-answer row)', () => {
+    // VFR RT text-answer rows carry selected_option_id = NULL (mig 095)
+    render(<OptionsList options={baseOptions} correctOptionId="opt-a" selectedOptionId={null} />)
+    expect(screen.getByText('Correct')).toBeInTheDocument()
+    expect(screen.queryByText('Your answer')).not.toBeInTheDocument()
+  })
+
   it('shows no markers on neutral options', () => {
     render(<OptionsList options={baseOptions} correctOptionId="opt-a" selectedOptionId="opt-b" />)
     // opt-c and opt-d are neither correct nor selected — no Correct/Your answer on them

--- a/apps/web/app/app/quiz/report/_components/options-list.tsx
+++ b/apps/web/app/app/quiz/report/_components/options-list.tsx
@@ -1,0 +1,48 @@
+import { Check, X } from 'lucide-react'
+
+type Option = { id: string; text: string }
+
+type OptionsListProps = {
+  options: Option[]
+  correctOptionId: string
+  selectedOptionId: string
+}
+
+export function OptionsList({ options, correctOptionId, selectedOptionId }: OptionsListProps) {
+  if (options.length === 0) return null
+
+  return (
+    <ul className="mt-1 space-y-0.5">
+      {options.map((option, i) => {
+        const letter = String.fromCodePoint(65 + i)
+        const isCorrect = option.id === correctOptionId
+        const isSelected = option.id === selectedOptionId
+
+        let rowClass = 'text-xs text-muted-foreground'
+        if (isCorrect) rowClass = 'text-xs text-green-600'
+        else if (isSelected) rowClass = 'text-xs text-destructive'
+
+        return (
+          <li key={option.id} className={`flex items-center gap-1 ${rowClass}`}>
+            <span className="font-medium">{letter}</span>
+            <span>—</span>
+            <span>{option.text}</span>
+            {isCorrect && (
+              <>
+                <Check size={12} aria-hidden className="ml-1 flex-shrink-0" />
+                <span>Correct</span>
+              </>
+            )}
+            {isSelected && !isCorrect && (
+              <>
+                <X size={12} aria-hidden className="ml-1 flex-shrink-0" />
+                <span>Your answer</span>
+              </>
+            )}
+            {isCorrect && isSelected && <span>· Your answer</span>}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/apps/web/app/app/quiz/report/_components/options-list.tsx
+++ b/apps/web/app/app/quiz/report/_components/options-list.tsx
@@ -5,7 +5,7 @@ type Option = { id: string; text: string }
 type OptionsListProps = {
   options: Option[]
   correctOptionId: string
-  selectedOptionId: string
+  selectedOptionId: string | null
 }
 
 export function OptionsList({ options, correctOptionId, selectedOptionId }: OptionsListProps) {

--- a/apps/web/app/app/quiz/report/_components/question-breakdown.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/question-breakdown.test.tsx
@@ -42,6 +42,7 @@ function makeQuestion(id: string, text: string): QuizReportQuestion {
     options: [{ id: 'opt-a', text: 'Answer A' }],
     explanationText: null,
     explanationImageUrl: null,
+    questionImageUrl: null,
     responseTimeMs: 2000,
   }
 }

--- a/apps/web/app/app/quiz/report/_components/report-card.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-card.test.tsx
@@ -41,6 +41,7 @@ const mockQuestions: QuizReportQuestion[] = [
     ],
     explanationText: 'Lift acts perpendicular to the relative wind.',
     explanationImageUrl: null,
+    questionImageUrl: null,
     responseTimeMs: 3000,
   },
   {
@@ -56,6 +57,7 @@ const mockQuestions: QuizReportQuestion[] = [
     ],
     explanationText: null,
     explanationImageUrl: null,
+    questionImageUrl: null,
     responseTimeMs: 5000,
   },
   {
@@ -71,6 +73,7 @@ const mockQuestions: QuizReportQuestion[] = [
     ],
     explanationText: null,
     explanationImageUrl: null,
+    questionImageUrl: null,
     responseTimeMs: 2500,
   },
 ]

--- a/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
@@ -15,9 +15,11 @@ vi.mock('@/app/app/_components/markdown-text', () => ({
 
 vi.mock('@/app/app/_components/zoomable-image', () => ({
   ZoomableImage: ({ src, alt }: { src: string; alt: string }) => (
-    <span data-testid="zoomable-image" data-src={src} role="img" aria-label={alt} />
+    <img data-testid="zoomable-image" src={src} alt={alt} />
   ),
 }))
+
+// OptionsList is a real component — no mock; its rendering is part of the contract
 
 beforeEach(() => {
   vi.resetAllMocks()
@@ -39,6 +41,7 @@ function makeQuestion(overrides: Partial<QuizReportQuestion> = {}): QuizReportQu
     ],
     explanationText: null,
     explanationImageUrl: null,
+    questionImageUrl: null,
     responseTimeMs: 3000,
     ...overrides,
   }
@@ -61,30 +64,47 @@ describe('ReportQuestionRow', () => {
     })
   })
 
-  describe('correct answer', () => {
-    it('renders question text for a correct answer', () => {
-      render(<ReportQuestionRow question={makeQuestion({ isCorrect: true })} index={0} />)
+  describe('question text', () => {
+    it('renders question text', () => {
+      render(<ReportQuestionRow question={makeQuestion()} index={0} />)
       expect(screen.getByText('What is lift?')).toBeInTheDocument()
-    })
-
-    it('shows the selected answer with letter prefix for a correct answer', () => {
-      render(
-        <ReportQuestionRow
-          question={makeQuestion({ isCorrect: true, selectedOptionId: 'opt-a' })}
-          index={0}
-        />,
-      )
-      expect(screen.getByText(/A — Upward force/)).toBeInTheDocument()
-    })
-
-    it('does not show the correct answer row when the answer is correct', () => {
-      render(<ReportQuestionRow question={makeQuestion({ isCorrect: true })} index={0} />)
-      expect(screen.queryByText(/Correct answer:/)).not.toBeInTheDocument()
     })
   })
 
-  describe('incorrect answer', () => {
-    it('shows the selected (wrong) answer with letter prefix', () => {
+  describe('options list', () => {
+    it('renders all option texts', () => {
+      render(
+        <ReportQuestionRow
+          question={makeQuestion({
+            options: [
+              { id: 'opt-a', text: 'Upward force' },
+              { id: 'opt-b', text: 'Downward force' },
+            ],
+            selectedOptionId: 'opt-a',
+            correctOptionId: 'opt-a',
+          })}
+          index={0}
+        />,
+      )
+      expect(screen.getByText('Upward force')).toBeInTheDocument()
+      expect(screen.getByText('Downward force')).toBeInTheDocument()
+    })
+
+    it('marks the correct option with "Correct" label', () => {
+      render(
+        <ReportQuestionRow
+          question={makeQuestion({
+            isCorrect: true,
+            selectedOptionId: 'opt-a',
+            correctOptionId: 'opt-a',
+          })}
+          index={0}
+        />,
+      )
+      expect(screen.getByText('Correct')).toBeInTheDocument()
+    })
+
+    it('marks the selected-wrong option with "Your answer" label', () => {
       render(
         <ReportQuestionRow
           question={makeQuestion({
@@ -95,24 +115,38 @@ describe('ReportQuestionRow', () => {
           index={0}
         />,
       )
-      expect(screen.getByText(/B — Downward force/)).toBeInTheDocument()
+      expect(screen.getByText('Your answer')).toBeInTheDocument()
     })
 
-    it('shows the correct answer row when the answer is incorrect', () => {
+    it('shows both "Correct" and "Your answer" when the selected option is correct', () => {
       render(
         <ReportQuestionRow
           question={makeQuestion({
-            isCorrect: false,
-            selectedOptionId: 'opt-b',
+            isCorrect: true,
+            selectedOptionId: 'opt-a',
             correctOptionId: 'opt-a',
           })}
           index={0}
         />,
       )
-      expect(screen.getByText(/Correct answer:/)).toBeInTheDocument()
-      expect(screen.getByText(/A — Upward force/)).toBeInTheDocument()
+      expect(screen.getByText('Correct')).toBeInTheDocument()
+      expect(screen.getByText('· Your answer')).toBeInTheDocument()
     })
+  })
 
+  describe('no answer fallback', () => {
+    it('shows "Not answered" when selectedOptionId matches no option', () => {
+      render(
+        <ReportQuestionRow
+          question={makeQuestion({ selectedOptionId: 'opt-nonexistent' })}
+          index={0}
+        />,
+      )
+      expect(screen.getByText('Not answered')).toBeInTheDocument()
+    })
+  })
+
+  describe('background tint', () => {
     it('applies pink tint background on incorrect rows', () => {
       const { container } = render(
         <ReportQuestionRow question={makeQuestion({ isCorrect: false })} index={0} />,
@@ -128,31 +162,25 @@ describe('ReportQuestionRow', () => {
       const row = container.firstElementChild as HTMLElement
       expect(row.className).not.toContain('bg-red-50')
     })
-
-    it('hides the correct answer row when correctOption is not found in options', () => {
-      render(
-        <ReportQuestionRow
-          question={makeQuestion({
-            isCorrect: false,
-            selectedOptionId: 'opt-b',
-            correctOptionId: 'opt-unknown',
-          })}
-          index={0}
-        />,
-      )
-      expect(screen.queryByText(/Correct answer:/)).not.toBeInTheDocument()
-    })
   })
 
-  describe('no answer fallback', () => {
-    it('shows "No answer" when selectedOptionId matches no option', () => {
+  describe('question image', () => {
+    it('renders question image when questionImageUrl is set', () => {
       render(
         <ReportQuestionRow
-          question={makeQuestion({ selectedOptionId: 'opt-nonexistent' })}
+          question={makeQuestion({ questionImageUrl: 'https://example.com/q-img.png' })}
           index={0}
         />,
       )
-      expect(screen.getByText(/No answer/)).toBeInTheDocument()
+      const imgs = screen.getAllByRole('img', { name: 'Question illustration' })
+      expect(imgs.length).toBeGreaterThan(0)
+      expect(imgs[0]).toHaveAttribute('src', 'https://example.com/q-img.png')
+    })
+
+    it('does not render question image when questionImageUrl is null', () => {
+      render(<ReportQuestionRow question={makeQuestion({ questionImageUrl: null })} index={0} />)
+      const imgs = screen.queryAllByRole('img', { name: 'Question illustration' })
+      expect(imgs).toHaveLength(0)
     })
   })
 
@@ -221,8 +249,12 @@ describe('ReportQuestionRow', () => {
         />,
       )
       fireEvent.click(screen.getByText('Show explanation'))
-      const img = screen.getByTestId('zoomable-image')
-      expect(img).toHaveAttribute('data-src', 'https://example.com/diagram.png')
+      const imgs = screen.getAllByTestId('zoomable-image')
+      const explanationImg = imgs.find(
+        (el) => el.getAttribute('alt') === 'Explanation illustration',
+      )
+      expect(explanationImg).toBeDefined()
+      expect(explanationImg).toHaveAttribute('src', 'https://example.com/diagram.png')
     })
 
     it('hides explanation when toggle is clicked again', () => {

--- a/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@/app/app/_components/markdown-text', () => ({
 
 vi.mock('@/app/app/_components/zoomable-image', () => ({
   ZoomableImage: ({ src, alt }: { src: string; alt: string }) => (
+    // biome-ignore lint/performance/noImgElement: test mock — no Next.js Image needed
     <img data-testid="zoomable-image" src={src} alt={alt} />
   ),
 }))
@@ -61,6 +62,23 @@ describe('ReportQuestionRow', () => {
     it('falls back to Q{index+1} when questionNumber is null', () => {
       render(<ReportQuestionRow question={makeQuestion({ questionNumber: null })} index={2} />)
       expect(screen.getByText('Q3')).toBeInTheDocument()
+    })
+  })
+
+  describe('status icon', () => {
+    it('shows the Correct icon when the answer is correct', () => {
+      render(<ReportQuestionRow question={makeQuestion({ isCorrect: true })} index={0} />)
+      expect(screen.getByRole('img', { name: 'Correct' })).toBeInTheDocument()
+    })
+
+    it('shows the Incorrect icon when the answer is wrong', () => {
+      render(
+        <ReportQuestionRow
+          question={makeQuestion({ isCorrect: false, selectedOptionId: 'opt-b' })}
+          index={0}
+        />,
+      )
+      expect(screen.getByRole('img', { name: 'Incorrect' })).toBeInTheDocument()
     })
   })
 
@@ -172,9 +190,8 @@ describe('ReportQuestionRow', () => {
           index={0}
         />,
       )
-      const imgs = screen.getAllByRole('img', { name: 'Question illustration' })
-      expect(imgs.length).toBeGreaterThan(0)
-      expect(imgs[0]).toHaveAttribute('src', 'https://example.com/q-img.png')
+      const img = screen.getByRole('img', { name: 'Question illustration' })
+      expect(img).toHaveAttribute('src', 'https://example.com/q-img.png')
     })
 
     it('does not render question image when questionImageUrl is null', () => {

--- a/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
@@ -162,6 +162,11 @@ describe('ReportQuestionRow', () => {
       )
       expect(screen.getByText('Not answered')).toBeInTheDocument()
     })
+
+    it('shows "Not answered" when selectedOptionId is null (VFR RT text-answer row)', () => {
+      render(<ReportQuestionRow question={makeQuestion({ selectedOptionId: null })} index={0} />)
+      expect(screen.getByText('Not answered')).toBeInTheDocument()
+    })
   })
 
   describe('background tint', () => {

--- a/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
@@ -271,11 +271,7 @@ describe('ReportQuestionRow', () => {
         />,
       )
       fireEvent.click(screen.getByText('Show explanation'))
-      const imgs = screen.getAllByTestId('zoomable-image')
-      const explanationImg = imgs.find(
-        (el) => el.getAttribute('alt') === 'Explanation illustration',
-      )
-      expect(explanationImg).toBeDefined()
+      const explanationImg = screen.getByRole('img', { name: 'Explanation illustration' })
       expect(explanationImg).toHaveAttribute('src', 'https://example.com/diagram.png')
     })
 

--- a/apps/web/app/app/quiz/report/_components/report-question-row.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.tsx
@@ -5,15 +5,10 @@ import { useState } from 'react'
 import { MarkdownText } from '@/app/app/_components/markdown-text'
 import { ZoomableImage } from '@/app/app/_components/zoomable-image'
 import type { QuizReportQuestion } from '@/lib/queries/quiz-report'
+import { OptionsList } from './options-list'
 
 function formatResponseTime(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`
-}
-
-function optionLetter(options: { id: string; text: string }[], optionId: string): string {
-  const idx = options.findIndex((o) => o.id === optionId)
-  if (idx === -1) return ''
-  return String.fromCodePoint(65 + idx)
 }
 
 export function ReportQuestionRow({
@@ -25,17 +20,9 @@ export function ReportQuestionRow({
 }) {
   const [expanded, setExpanded] = useState(false)
 
-  const selectedOption = question.options.find((o) => o.id === question.selectedOptionId)
-  const correctOption = question.options.find((o) => o.id === question.correctOptionId)
   const label = question.questionNumber ?? `Q${index + 1}`
-  const selectedLetter = question.selectedOptionId
-    ? optionLetter(question.options, question.selectedOptionId)
-    : ''
-  const correctLetter = question.correctOptionId
-    ? optionLetter(question.options, question.correctOptionId)
-    : ''
-
   const hasExplanation = Boolean(question.explanationText || question.explanationImageUrl)
+  const isAnswered = question.options.some((o) => o.id === question.selectedOptionId)
 
   return (
     <div className={`px-4 py-3 ${question.isCorrect ? '' : 'bg-red-50 dark:bg-red-950/20'}`}>
@@ -69,17 +56,21 @@ export function ReportQuestionRow({
             </span>
           </div>
 
-          <div className="mt-1 space-y-0.5 text-xs">
-            <p className={question.isCorrect ? 'text-green-600' : 'text-destructive'}>
-              Your answer:{' '}
-              {selectedLetter ? `${selectedLetter} — ${selectedOption?.text ?? ''}` : 'No answer'}
-            </p>
-            {!question.isCorrect && correctOption && (
-              <p className="text-green-600">
-                Correct answer: {correctLetter} — {correctOption.text}
-              </p>
-            )}
-          </div>
+          {question.questionImageUrl && (
+            <ZoomableImage
+              src={question.questionImageUrl}
+              alt="Question illustration"
+              className="max-h-64"
+            />
+          )}
+
+          {!isAnswered && <p className="mt-1 text-xs text-muted-foreground">Not answered</p>}
+
+          <OptionsList
+            options={question.options}
+            correctOptionId={question.correctOptionId}
+            selectedOptionId={question.selectedOptionId}
+          />
 
           {hasExplanation && (
             <div className="mt-2">

--- a/apps/web/app/app/quiz/report/_components/report-question-row.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.tsx
@@ -57,11 +57,13 @@ export function ReportQuestionRow({
           </div>
 
           {question.questionImageUrl && (
-            <ZoomableImage
-              src={question.questionImageUrl}
-              alt="Question illustration"
-              className="max-h-64"
-            />
+            <div className="mt-2">
+              <ZoomableImage
+                src={question.questionImageUrl}
+                alt="Question illustration"
+                className="max-h-64"
+              />
+            </div>
           )}
 
           {!isAnswered && <p className="mt-1 text-xs text-muted-foreground">Not answered</p>}

--- a/apps/web/lib/queries/admin-quiz-report.test.ts
+++ b/apps/web/lib/queries/admin-quiz-report.test.ts
@@ -86,6 +86,7 @@ const questionsData = [
     ],
     explanation_text: 'Lift acts upward.',
     explanation_image_url: null,
+    question_image_url: null,
   },
   {
     id: 'q2',
@@ -97,6 +98,7 @@ const questionsData = [
     ],
     explanation_text: null,
     explanation_image_url: null,
+    question_image_url: null,
   },
 ]
 

--- a/apps/web/lib/queries/admin-quiz-report.ts
+++ b/apps/web/lib/queries/admin-quiz-report.ts
@@ -171,7 +171,9 @@ export async function getAdminQuizReportQuestions(opts: {
   // Omits deleted_at intentionally — historical record for completed sessions.
   const { data: questionsData, error: questionsError } = await adminClient
     .from('questions')
-    .select('id, question_text, question_number, options, explanation_text, explanation_image_url')
+    .select(
+      'id, question_text, question_number, options, explanation_text, explanation_image_url, question_image_url',
+    )
     .in('id', questionIds)
 
   if (questionsError) {

--- a/apps/web/lib/queries/quiz-report-questions.test.ts
+++ b/apps/web/lib/queries/quiz-report-questions.test.ts
@@ -86,6 +86,7 @@ const questionsData = [
       { id: 'opt-b', text: 'Downward force' },
     ],
     explanation_text: 'Lift acts upward.',
+    question_image_url: null,
   },
   {
     id: 'q2',
@@ -96,6 +97,7 @@ const questionsData = [
       { id: 'opt-d', text: 'Opposing force' },
     ],
     explanation_text: null,
+    question_image_url: null,
   },
 ]
 

--- a/apps/web/lib/queries/quiz-report-questions.ts
+++ b/apps/web/lib/queries/quiz-report-questions.ts
@@ -87,7 +87,9 @@ export async function getQuizReportQuestions(opts: {
   // are shown even if subsequently soft-deleted (historical record).
   const { data: questionsData, error: questionsError } = await supabase
     .from('questions')
-    .select('id, question_text, question_number, options, explanation_text, explanation_image_url')
+    .select(
+      'id, question_text, question_number, options, explanation_text, explanation_image_url, question_image_url',
+    )
     .in('id', questionIds)
 
   if (questionsError) {

--- a/apps/web/lib/queries/quiz-report.ts
+++ b/apps/web/lib/queries/quiz-report.ts
@@ -10,6 +10,7 @@ export type QuizReportQuestion = {
   options: { id: string; text: string }[]
   explanationText: string | null
   explanationImageUrl: string | null
+  questionImageUrl: string | null
   responseTimeMs: number
 }
 

--- a/apps/web/lib/queries/quiz-report.ts
+++ b/apps/web/lib/queries/quiz-report.ts
@@ -5,7 +5,8 @@ export type QuizReportQuestion = {
   questionText: string
   questionNumber: string | null
   isCorrect: boolean
-  selectedOptionId: string
+  // Null for text-answer (VFR RT) rows — see AnswerRow in report-question-builder.ts.
+  selectedOptionId: string | null
   correctOptionId: string
   options: { id: string; text: string }[]
   explanationText: string | null

--- a/apps/web/lib/queries/report-question-builder.test.ts
+++ b/apps/web/lib/queries/report-question-builder.test.ts
@@ -21,6 +21,7 @@ describe('buildReportQuestions', () => {
           ],
           explanation_text: 'The answer is 4.',
           explanation_image_url: null,
+          question_image_url: null,
         },
       ],
     ])
@@ -43,6 +44,7 @@ describe('buildReportQuestions', () => {
       ],
       explanationText: 'The answer is 4.',
       explanationImageUrl: null,
+      questionImageUrl: null,
       responseTimeMs: 5000,
     })
   })
@@ -68,6 +70,7 @@ describe('buildReportQuestions', () => {
           options: [leakyOption, { id: 'o2', text: '5' }],
           explanation_text: null,
           explanation_image_url: null,
+          question_image_url: null,
         },
       ],
     ])

--- a/apps/web/lib/queries/report-question-builder.test.ts
+++ b/apps/web/lib/queries/report-question-builder.test.ts
@@ -85,6 +85,55 @@ describe('buildReportQuestions', () => {
     }
   })
 
+  it('passes a non-null question_image_url through to the output', () => {
+    const answers: AnswerRow[] = [
+      { question_id: 'q1', selected_option_id: 'o1', is_correct: true, response_time_ms: 2000 },
+    ]
+    const questionMap = new Map<string, QuestionRow>([
+      [
+        'q1',
+        {
+          id: 'q1',
+          question_text: 'What is lift?',
+          question_number: null,
+          options: [{ id: 'o1', text: 'Upward force' }],
+          explanation_text: null,
+          explanation_image_url: null,
+          question_image_url: 'https://example.com/q-img.png',
+        },
+      ],
+    ])
+
+    const result = buildReportQuestions(answers, questionMap, new Map([['q1', 'o1']]))
+
+    expect(result[0]?.questionImageUrl).toBe('https://example.com/q-img.png')
+  })
+
+  it('passes a null selected_option_id through (VFR RT text-answer row)', () => {
+    // mig 095 made selected_option_id nullable for text-answer rows
+    const answers: AnswerRow[] = [
+      { question_id: 'q1', selected_option_id: null, is_correct: false, response_time_ms: 4000 },
+    ]
+    const questionMap = new Map<string, QuestionRow>([
+      [
+        'q1',
+        {
+          id: 'q1',
+          question_text: 'Describe the procedure.',
+          question_number: null,
+          options: [],
+          explanation_text: null,
+          explanation_image_url: null,
+          question_image_url: null,
+        },
+      ],
+    ])
+
+    const result = buildReportQuestions(answers, questionMap, new Map())
+
+    expect(result[0]?.selectedOptionId).toBeNull()
+  })
+
   it('handles missing question gracefully', () => {
     const answers: AnswerRow[] = [
       {

--- a/apps/web/lib/queries/report-question-builder.test.ts
+++ b/apps/web/lib/queries/report-question-builder.test.ts
@@ -85,7 +85,7 @@ describe('buildReportQuestions', () => {
     }
   })
 
-  it('passes a non-null question_image_url through to the output', () => {
+  it('includes the question image URL in the report when present', () => {
     const answers: AnswerRow[] = [
       { question_id: 'q1', selected_option_id: 'o1', is_correct: true, response_time_ms: 2000 },
     ]
@@ -109,8 +109,8 @@ describe('buildReportQuestions', () => {
     expect(result[0]?.questionImageUrl).toBe('https://example.com/q-img.png')
   })
 
-  it('passes a null selected_option_id through (VFR RT text-answer row)', () => {
-    // mig 095 made selected_option_id nullable for text-answer rows
+  it('returns a null selectedOptionId when the answer has no selected option', () => {
+    // VFR RT text-answer rows carry a null selection
     const answers: AnswerRow[] = [
       { question_id: 'q1', selected_option_id: null, is_correct: false, response_time_ms: 4000 },
     ]

--- a/apps/web/lib/queries/report-question-builder.ts
+++ b/apps/web/lib/queries/report-question-builder.ts
@@ -2,7 +2,8 @@ import type { QuizReportQuestion } from './quiz-report'
 
 export type AnswerRow = {
   question_id: string
-  selected_option_id: string
+  // Nullable since mig 095: VFR RT text-answer rows store response_text with selected_option_id NULL.
+  selected_option_id: string | null
   is_correct: boolean
   response_time_ms: number
 }

--- a/apps/web/lib/queries/report-question-builder.ts
+++ b/apps/web/lib/queries/report-question-builder.ts
@@ -14,6 +14,7 @@ export type QuestionRow = {
   options: { id: string; text: string }[]
   explanation_text: string | null
   explanation_image_url: string | null
+  question_image_url: string | null
 }
 
 export function buildReportQuestions(
@@ -35,6 +36,7 @@ export function buildReportQuestions(
       options: options.map((o) => ({ id: o.id, text: o.text })),
       explanationText: question?.explanation_text ?? null,
       explanationImageUrl: question?.explanation_image_url ?? null,
+      questionImageUrl: question?.question_image_url ?? null,
       responseTimeMs: answer.response_time_ms,
     }
   })


### PR DESCRIPTION
Closes #835

## What

Two report improvements, both flowing through the single shared `ReportQuestionRow` so they land on **all 4 report surfaces** at once (student quiz, student internal-exam, admin session, admin internal-exam):

1. **All options shown by default.** Each report question row now lists every answer option inline — the correct one marked with a green Check + "Correct", the student's pick with "Your answer" (icon **and** text, not colour-only). This replaces the old redundant "Your answer / Correct answer" summary lines.
2. **Question stem image now rendered.** `question_image_url` existed in the schema and the live quiz rendered it, but the report path never fetched it. It's now plumbed through `QuestionRow → buildReportQuestions → QuizReportQuestion`, added to both report `.select()` strings, and rendered via `ZoomableImage`.

The "Show explanation" expander is unchanged (still collapsed by default).

## Notable

- **Nullable fix (caught in review):** mig 095 made `quiz_session_answers.selected_option_id` nullable for VFR RT text-answer rows, but `AnswerRow.selected_option_id` was typed `string` and the path casts `as AnswerRow[]`. Widened `selectedOptionId` to `string | null` end-to-end so the type is honest; a null selection correctly renders "Not answered".
- **VFR RT report UI is still Phase B** — full text-answer rendering (showing `response_text`) is out of scope here; this commit only makes the shared row correct for the column reality.
- No migration, no new RPC, no schema change — reports remain gated to completed sessions (`ended_at`), and the per-option `correct` flag is still stripped server-side. No new exposure surface.

## Verification

- Full web suite: **3613/3613 pass** · typecheck clean · lint 0 errors · `pnpm build` ✅
- Pipeline: plan-critic → impl-critic (×4) → post-commit agents → PR-level semantic sweep (0 ISSUE) → CodeRabbit local (2 rounds, converged)

## ⚠️ Manual eval suggested

This is a user-facing visual change across 4 report surfaces. Worth a click-through (a question with a stem image; a correct answer; a wrong answer; an unanswered/timed-out question) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quiz report options now display with letter labels (A–D) and visual status indicators showing whether each option was correct or selected
  * Question images now appear in quiz reports for enhanced context
  * Improved handling of unanswered questions with explicit "Not answered" messaging

* **Tests**
  * Expanded test coverage for quiz report components and answer option rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->