### PR TITLE
feat(reports): flag questions from the report page + show flagged state

### DIFF
--- a/apps/web/app/app/internal-exam/report/page.tsx
+++ b/apps/web/app/app/internal-exam/report/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from 'next/navigation'
 import { QuestionBreakdown } from '@/app/app/quiz/report/_components/question-breakdown'
+import { ReportFlagProvider } from '@/app/app/quiz/report/_components/report-flag-context'
 import { ResultSummary } from '@/app/app/quiz/report/_components/result-summary'
+import { getFlaggedQuestionIds } from '@/lib/queries/flagged-questions'
 import { getQuizReportSummary, PAGE_SIZE } from '@/lib/queries/quiz-report'
 import { getQuizReportQuestions } from '@/lib/queries/quiz-report-questions'
 import { parsePageParam } from '@/lib/utils/parse-page-param'
@@ -30,15 +32,19 @@ export default async function InternalExamReportPage({
     redirect(`/app/internal-exam/report?session=${sessionId}&page=${totalPages}`)
   }
 
+  const flaggedIds = await getFlaggedQuestionIds(questionsResult.questions.map((q) => q.questionId))
+
   return (
     <main className="space-y-6">
       <ResultSummary summary={summary} />
-      <QuestionBreakdown
-        questions={questionsResult.questions}
-        page={page}
-        totalCount={questionsResult.totalCount}
-        pageSize={PAGE_SIZE}
-      />
+      <ReportFlagProvider key={`${sessionId}-${page}`} initialFlaggedIds={flaggedIds}>
+        <QuestionBreakdown
+          questions={questionsResult.questions}
+          page={page}
+          totalCount={questionsResult.totalCount}
+          pageSize={PAGE_SIZE}
+        />
+      </ReportFlagProvider>
       <ReportFooter />
     </main>
   )

--- a/apps/web/app/app/quiz/report/_components/report-flag-context.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-flag-context.test.tsx
@@ -129,7 +129,10 @@ describe('ReportFlagProvider', () => {
     // finally{} must clear pending state even when the action rejects.
     await waitFor(() => expect(button).not.toBeDisabled())
     expect(button).toHaveTextContent('not-flagged')
-    expect(warnSpy).toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[ReportFlagProvider] flag toggle failed:',
+      expect.any(Error),
+    )
     warnSpy.mockRestore()
   })
 })

--- a/apps/web/app/app/quiz/report/_components/report-flag-context.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-flag-context.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ReportFlagProvider, useReportFlag } from './report-flag-context'
+
+// ---- Mocks ------------------------------------------------------------------
+
+const { mockToggleFlag } = vi.hoisted(() => ({ mockToggleFlag: vi.fn() }))
+
+vi.mock('../../actions/flag', () => ({ toggleFlag: mockToggleFlag }))
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+// ---- Harness ----------------------------------------------------------------
+
+const QID = 'q1'
+
+function FlagConsumer({ questionId = QID }: { questionId?: string }) {
+  const flag = useReportFlag()
+  if (!flag) return <div data-testid="no-context">no context</div>
+  return (
+    <button
+      type="button"
+      data-testid="toggle"
+      onClick={() => flag.toggle(questionId)}
+      disabled={flag.isToggling(questionId)}
+    >
+      {flag.isFlagged(questionId) ? 'flagged' : 'not-flagged'}
+    </button>
+  )
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+describe('useReportFlag', () => {
+  it('returns null when rendered without a provider', () => {
+    render(<FlagConsumer />)
+    expect(screen.getByTestId('no-context')).toBeInTheDocument()
+  })
+})
+
+describe('ReportFlagProvider', () => {
+  it('seeds the flagged state from initialFlaggedIds', () => {
+    render(
+      <ReportFlagProvider initialFlaggedIds={[QID]}>
+        <FlagConsumer />
+      </ReportFlagProvider>,
+    )
+    expect(screen.getByTestId('toggle')).toHaveTextContent('flagged')
+  })
+
+  it('shows a question as not flagged when it is absent from initialFlaggedIds', () => {
+    render(
+      <ReportFlagProvider initialFlaggedIds={[]}>
+        <FlagConsumer />
+      </ReportFlagProvider>,
+    )
+    expect(screen.getByTestId('toggle')).toHaveTextContent('not-flagged')
+  })
+
+  it('flags a question after the server reports it flagged', async () => {
+    mockToggleFlag.mockResolvedValue({ success: true, flagged: true })
+    render(
+      <ReportFlagProvider initialFlaggedIds={[]}>
+        <FlagConsumer />
+      </ReportFlagProvider>,
+    )
+    fireEvent.click(screen.getByTestId('toggle'))
+    await waitFor(() => expect(screen.getByTestId('toggle')).toHaveTextContent('flagged'))
+    expect(mockToggleFlag).toHaveBeenCalledWith({ questionId: QID })
+  })
+
+  it('unflags a question after the server reports it unflagged', async () => {
+    mockToggleFlag.mockResolvedValue({ success: true, flagged: false })
+    render(
+      <ReportFlagProvider initialFlaggedIds={[QID]}>
+        <FlagConsumer />
+      </ReportFlagProvider>,
+    )
+    fireEvent.click(screen.getByTestId('toggle'))
+    await waitFor(() => expect(screen.getByTestId('toggle')).toHaveTextContent('not-flagged'))
+  })
+
+  it('does not change state when the server reports failure', async () => {
+    mockToggleFlag.mockResolvedValue({ success: false, error: 'nope' })
+    render(
+      <ReportFlagProvider initialFlaggedIds={[]}>
+        <FlagConsumer />
+      </ReportFlagProvider>,
+    )
+    fireEvent.click(screen.getByTestId('toggle'))
+    await waitFor(() => expect(mockToggleFlag).toHaveBeenCalled())
+    expect(screen.getByTestId('toggle')).toHaveTextContent('not-flagged')
+  })
+
+  it('ignores a second toggle while the first is still pending', async () => {
+    let resolveToggle: (v: { success: true; flagged: boolean }) => void = () => {}
+    mockToggleFlag.mockReturnValue(
+      new Promise((resolve) => {
+        resolveToggle = resolve
+      }),
+    )
+    render(
+      <ReportFlagProvider initialFlaggedIds={[]}>
+        <FlagConsumer />
+      </ReportFlagProvider>,
+    )
+    const button = screen.getByTestId('toggle')
+    fireEvent.click(button)
+    // Button is disabled while the toggle is in flight.
+    await waitFor(() => expect(button).toBeDisabled())
+    fireEvent.click(button) // second click should be a no-op
+    resolveToggle({ success: true, flagged: true })
+    await waitFor(() => expect(button).toHaveTextContent('flagged'))
+    expect(mockToggleFlag).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/app/app/quiz/report/_components/report-flag-context.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-flag-context.test.tsx
@@ -115,4 +115,21 @@ describe('ReportFlagProvider', () => {
     await waitFor(() => expect(button).toHaveTextContent('flagged'))
     expect(mockToggleFlag).toHaveBeenCalledTimes(1)
   })
+
+  it('re-enables the button and preserves state when toggleFlag throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockToggleFlag.mockRejectedValue(new Error('network'))
+    render(
+      <ReportFlagProvider initialFlaggedIds={[]}>
+        <FlagConsumer />
+      </ReportFlagProvider>,
+    )
+    const button = screen.getByTestId('toggle')
+    fireEvent.click(button)
+    // finally{} must clear pending state even when the action rejects.
+    await waitFor(() => expect(button).not.toBeDisabled())
+    expect(button).toHaveTextContent('not-flagged')
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
 })

--- a/apps/web/app/app/quiz/report/_components/report-flag-context.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-flag-context.tsx
@@ -41,6 +41,10 @@ export function ReportFlagProvider({
           return next
         })
       }
+    } catch (err) {
+      // Best-effort: a thrown action (e.g. network failure) leaves flag state unchanged.
+      // Log for observability — this path never touches answer data.
+      console.warn('[ReportFlagProvider] flag toggle failed:', err)
     } finally {
       pendingRef.current.delete(questionId)
       setPendingIds((prev) => {

--- a/apps/web/app/app/quiz/report/_components/report-flag-context.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-flag-context.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react'
+import { toggleFlag } from '../../actions/flag'
+
+type ReportFlagContextValue = {
+  isFlagged: (questionId: string) => boolean
+  isToggling: (questionId: string) => boolean
+  toggle: (questionId: string) => void
+}
+
+// Null when no provider is present (e.g. admin report views) — the row renders no flag UI.
+const ReportFlagContext = createContext<ReportFlagContextValue | null>(null)
+
+export function ReportFlagProvider({
+  initialFlaggedIds,
+  children,
+}: {
+  initialFlaggedIds: string[]
+  children: React.ReactNode
+}) {
+  // Seeded server-side; remounted per page via a `key` on this provider so each
+  // page's server-read state re-seeds on pagination.
+  const [flaggedIds, setFlaggedIds] = useState<Set<string>>(() => new Set(initialFlaggedIds))
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set())
+  // Ref for synchronous guard — avoids stale-closure window in concurrent toggle calls.
+  const pendingRef = useRef<Set<string>>(new Set())
+
+  const toggle = useCallback(async (questionId: string) => {
+    if (pendingRef.current.has(questionId)) return
+    pendingRef.current.add(questionId)
+    setPendingIds((prev) => new Set(prev).add(questionId))
+    try {
+      // Server-result-driven (mirrors useFlaggedQuestions): set state from result.flagged.
+      const result = await toggleFlag({ questionId })
+      if (result.success) {
+        setFlaggedIds((prev) => {
+          const next = new Set(prev)
+          if (result.flagged) next.add(questionId)
+          else next.delete(questionId)
+          return next
+        })
+      }
+    } finally {
+      pendingRef.current.delete(questionId)
+      setPendingIds((prev) => {
+        const next = new Set(prev)
+        next.delete(questionId)
+        return next
+      })
+    }
+  }, [])
+
+  const value = useMemo<ReportFlagContextValue>(
+    () => ({
+      isFlagged: (questionId) => flaggedIds.has(questionId),
+      isToggling: (questionId) => pendingIds.has(questionId),
+      toggle,
+    }),
+    [flaggedIds, pendingIds, toggle],
+  )
+
+  return <ReportFlagContext.Provider value={value}>{children}</ReportFlagContext.Provider>
+}
+
+export function useReportFlag(): ReportFlagContextValue | null {
+  return useContext(ReportFlagContext)
+}

--- a/apps/web/app/app/quiz/report/_components/report-flag-context.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-flag-context.tsx
@@ -22,7 +22,7 @@ export function ReportFlagProvider({
   // Seeded server-side; remounted per page via a `key` on this provider so each
   // page's server-read state re-seeds on pagination.
   const [flaggedIds, setFlaggedIds] = useState<Set<string>>(() => new Set(initialFlaggedIds))
-  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set())
+  const [pendingIds, setPendingIds] = useState<Set<string>>(() => new Set())
   // Ref for synchronous guard — avoids stale-closure window in concurrent toggle calls.
   const pendingRef = useRef<Set<string>>(new Set())
 

--- a/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
@@ -1,9 +1,14 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { QuizReportQuestion } from '@/lib/queries/quiz-report'
+import { ReportFlagProvider } from './report-flag-context'
 import { ReportQuestionRow } from './report-question-row'
 
 // ---- Mocks ------------------------------------------------------------------
+
+const { mockToggleFlag } = vi.hoisted(() => ({ mockToggleFlag: vi.fn() }))
+
+vi.mock('../../actions/flag', () => ({ toggleFlag: mockToggleFlag }))
 
 vi.mock('@/app/app/_components/markdown-text', () => ({
   MarkdownText: ({ children, className }: { children: string; className?: string }) => (
@@ -325,6 +330,49 @@ describe('ReportQuestionRow', () => {
       const longText = 'A'.repeat(120)
       render(<ReportQuestionRow question={makeQuestion({ questionText: longText })} index={0} />)
       expect(screen.getByText(longText)).toBeInTheDocument()
+    })
+  })
+
+  describe('flag toggle', () => {
+    it('does not render a flag button without a flag provider (e.g. admin report view)', () => {
+      render(<ReportQuestionRow question={makeQuestion({ questionId: 'q1' })} index={0} />)
+      expect(screen.queryByTestId('report-flag-button')).not.toBeInTheDocument()
+    })
+
+    it('renders an unpressed Flag button when the question is not flagged', () => {
+      render(
+        <ReportFlagProvider initialFlaggedIds={[]}>
+          <ReportQuestionRow question={makeQuestion({ questionId: 'q1' })} index={0} />
+        </ReportFlagProvider>,
+      )
+      const button = screen.getByTestId('report-flag-button')
+      expect(button).toHaveAttribute('aria-pressed', 'false')
+      expect(button).toHaveAttribute('aria-label', 'Flag question')
+    })
+
+    it('renders a pressed Unflag button when the question is already flagged', () => {
+      render(
+        <ReportFlagProvider initialFlaggedIds={['q1']}>
+          <ReportQuestionRow question={makeQuestion({ questionId: 'q1' })} index={0} />
+        </ReportFlagProvider>,
+      )
+      const button = screen.getByTestId('report-flag-button')
+      expect(button).toHaveAttribute('aria-pressed', 'true')
+      expect(button).toHaveAttribute('aria-label', 'Unflag question')
+    })
+
+    it('flags the question via the toggleFlag action when clicked', async () => {
+      mockToggleFlag.mockResolvedValue({ success: true, flagged: true })
+      render(
+        <ReportFlagProvider initialFlaggedIds={[]}>
+          <ReportQuestionRow question={makeQuestion({ questionId: 'q1' })} index={0} />
+        </ReportFlagProvider>,
+      )
+      fireEvent.click(screen.getByTestId('report-flag-button'))
+      await waitFor(() =>
+        expect(screen.getByTestId('report-flag-button')).toHaveAttribute('aria-pressed', 'true'),
+      )
+      expect(mockToggleFlag).toHaveBeenCalledWith({ questionId: 'q1' })
     })
   })
 })

--- a/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
@@ -374,5 +374,25 @@ describe('ReportQuestionRow', () => {
       )
       expect(mockToggleFlag).toHaveBeenCalledWith({ questionId: 'q1' })
     })
+
+    it('disables the flag button while the toggle action is in-flight', async () => {
+      let resolveToggle: (v: { success: true; flagged: boolean }) => void = () => {}
+      mockToggleFlag.mockReturnValue(
+        new Promise((resolve) => {
+          resolveToggle = resolve
+        }),
+      )
+      render(
+        <ReportFlagProvider initialFlaggedIds={[]}>
+          <ReportQuestionRow question={makeQuestion({ questionId: 'q1' })} index={0} />
+        </ReportFlagProvider>,
+      )
+      const button = screen.getByTestId('report-flag-button')
+      expect(button).not.toBeDisabled()
+      fireEvent.click(button)
+      await waitFor(() => expect(button).toBeDisabled())
+      resolveToggle({ success: true, flagged: true })
+      await waitFor(() => expect(button).not.toBeDisabled())
+    })
   })
 })

--- a/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.test.tsx
@@ -361,7 +361,7 @@ describe('ReportQuestionRow', () => {
       expect(button).toHaveAttribute('aria-label', 'Unflag question')
     })
 
-    it('flags the question via the toggleFlag action when clicked', async () => {
+    it('flags the question when clicked', async () => {
       mockToggleFlag.mockResolvedValue({ success: true, flagged: true })
       render(
         <ReportFlagProvider initialFlaggedIds={[]}>

--- a/apps/web/app/app/quiz/report/_components/report-question-row.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.tsx
@@ -65,7 +65,10 @@ export function ReportQuestionRow({
                 <button
                   type="button"
                   data-testid="report-flag-button"
-                  onClick={() => flag.toggle(question.questionId)}
+                  onClick={() => {
+                    // HTML `disabled` is not a behavioral contract — guard the handler too.
+                    if (!isFlagToggling) flag.toggle(question.questionId)
+                  }}
                   aria-pressed={isFlagged}
                   aria-label={isFlagged ? 'Unflag question' : 'Flag question'}
                   disabled={isFlagToggling}

--- a/apps/web/app/app/quiz/report/_components/report-question-row.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.tsx
@@ -66,7 +66,8 @@ export function ReportQuestionRow({
                   type="button"
                   data-testid="report-flag-button"
                   onClick={() => {
-                    // HTML `disabled` is not a behavioral contract — guard the handler too.
+                    // Guards programmatic invocation; pointer clicks are also blocked by
+                    // `disabled:pointer-events-none`. HTML `disabled` is not a behavioral contract.
                     if (!isFlagToggling) flag.toggle(question.questionId)
                   }}
                   aria-pressed={isFlagged}

--- a/apps/web/app/app/quiz/report/_components/report-question-row.tsx
+++ b/apps/web/app/app/quiz/report/_components/report-question-row.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { Check, ChevronDown, ChevronUp, X } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp, Flag, X } from 'lucide-react'
 import { useState } from 'react'
 import { MarkdownText } from '@/app/app/_components/markdown-text'
 import { ZoomableImage } from '@/app/app/_components/zoomable-image'
 import type { QuizReportQuestion } from '@/lib/queries/quiz-report'
 import { OptionsList } from './options-list'
+import { useReportFlag } from './report-flag-context'
 
 function formatResponseTime(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`
@@ -19,6 +20,11 @@ export function ReportQuestionRow({
   index: number
 }) {
   const [expanded, setExpanded] = useState(false)
+
+  // Null on admin report views (no provider) — the flag toggle is student-only.
+  const flag = useReportFlag()
+  const isFlagged = flag?.isFlagged(question.questionId) ?? false
+  const isFlagToggling = flag?.isToggling(question.questionId) ?? false
 
   const label = question.questionNumber ?? `Q${index + 1}`
   const hasExplanation = Boolean(question.explanationText || question.explanationImageUrl)
@@ -51,9 +57,28 @@ export function ReportQuestionRow({
           <div className="flex items-baseline gap-2">
             <span className="text-xs font-medium text-muted-foreground">{label}</span>
             <span className="text-sm">{question.questionText}</span>
-            <span className="ml-auto flex-shrink-0 text-xs text-muted-foreground">
-              {formatResponseTime(question.responseTimeMs)}
-            </span>
+            <div className="ml-auto flex flex-shrink-0 items-center gap-2">
+              <span className="text-xs text-muted-foreground">
+                {formatResponseTime(question.responseTimeMs)}
+              </span>
+              {flag && (
+                <button
+                  type="button"
+                  data-testid="report-flag-button"
+                  onClick={() => flag.toggle(question.questionId)}
+                  aria-pressed={isFlagged}
+                  aria-label={isFlagged ? 'Unflag question' : 'Flag question'}
+                  disabled={isFlagToggling}
+                  className={
+                    isFlagged
+                      ? 'inline-flex items-center rounded-md p-1 text-orange-600 transition-colors hover:bg-orange-500/10 disabled:opacity-50 disabled:pointer-events-none dark:text-orange-400'
+                      : 'inline-flex items-center rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50 disabled:pointer-events-none'
+                  }
+                >
+                  <Flag size={14} aria-hidden className={isFlagged ? 'fill-current' : undefined} />
+                </button>
+              )}
+            </div>
           </div>
 
           {question.questionImageUrl && (

--- a/apps/web/app/app/quiz/report/page.tsx
+++ b/apps/web/app/app/quiz/report/page.tsx
@@ -1,8 +1,10 @@
 import { redirect } from 'next/navigation'
+import { getFlaggedQuestionIds } from '@/lib/queries/flagged-questions'
 import { getQuizReportSummary, PAGE_SIZE } from '@/lib/queries/quiz-report'
 import { getQuizReportQuestions } from '@/lib/queries/quiz-report-questions'
 import { parsePageParam } from '@/lib/utils/parse-page-param'
 import { ReportCard } from './_components/report-card'
+import { ReportFlagProvider } from './_components/report-flag-context'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -27,16 +29,20 @@ export default async function QuizReportPage({
     redirect(`/app/quiz/report?session=${sessionId}&page=${totalPages}`)
   }
 
+  const flaggedIds = await getFlaggedQuestionIds(questionsResult.questions.map((q) => q.questionId))
+
   return (
     <main className="space-y-6">
       <h1 className="text-2xl font-semibold tracking-tight">Quiz Results</h1>
-      <ReportCard
-        summary={summary}
-        questions={questionsResult.questions}
-        page={page}
-        totalCount={questionsResult.totalCount}
-        pageSize={PAGE_SIZE}
-      />
+      <ReportFlagProvider key={`${sessionId}-${page}`} initialFlaggedIds={flaggedIds}>
+        <ReportCard
+          summary={summary}
+          questions={questionsResult.questions}
+          page={page}
+          totalCount={questionsResult.totalCount}
+          pageSize={PAGE_SIZE}
+        />
+      </ReportFlagProvider>
     </main>
   )
 }

--- a/apps/web/e2e/redteam/flag-idor.spec.ts
+++ b/apps/web/e2e/redteam/flag-idor.spec.ts
@@ -3,8 +3,9 @@
  *
  * Vector S (MEDIUM): An authenticated attacker attempts to read or corrupt another
  * student's flagged_questions rows. flagged_questions RLS scopes every policy to
- * student_id = auth.uid(); toggleFlag/getFlaggedIds also hard-code student_id from
- * the auth token, so the attack is only expressible at the direct-table layer — which
+ * student_id = auth.uid(); toggleFlag/getFlaggedIds (and the report-page read helper
+ * getFlaggedQuestionIds) also hard-code student_id from the auth token, so the attack
+ * is only expressible at the direct-table layer — which
  * this spec exercises. Defenses must hold: attacker sees 0 of the victim's flags and
  * cannot insert a flag as the victim.
  *

--- a/apps/web/e2e/redteam/flag-idor.spec.ts
+++ b/apps/web/e2e/redteam/flag-idor.spec.ts
@@ -3,9 +3,10 @@
  *
  * Vector S (MEDIUM): An authenticated attacker attempts to read or corrupt another
  * student's flagged_questions rows. flagged_questions RLS scopes every policy to
- * student_id = auth.uid(); the flag Server Actions (toggleFlag, getFlaggedIds) and the
- * report-page read helper getFlaggedQuestionIds all hard-code student_id from the auth
- * token, so the attack is only expressible at the direct-table layer — which
+ * student_id = auth.uid(); every server entry point that touches flagged_questions
+ * (the in-quiz flag actions and the report-page read helper getFlaggedQuestionIds)
+ * hard-codes student_id from the auth token, so the attack is only expressible at the
+ * direct-table layer — which
  * this spec exercises. Defenses must hold: attacker sees 0 of the victim's flags and
  * cannot insert a flag as the victim.
  *

--- a/apps/web/e2e/redteam/flag-idor.spec.ts
+++ b/apps/web/e2e/redteam/flag-idor.spec.ts
@@ -3,9 +3,9 @@
  *
  * Vector S (MEDIUM): An authenticated attacker attempts to read or corrupt another
  * student's flagged_questions rows. flagged_questions RLS scopes every policy to
- * student_id = auth.uid(); toggleFlag/getFlaggedIds (and the report-page read helper
- * getFlaggedQuestionIds) also hard-code student_id from the auth token, so the attack
- * is only expressible at the direct-table layer — which
+ * student_id = auth.uid(); the flag Server Actions (toggleFlag, getFlaggedIds) and the
+ * report-page read helper getFlaggedQuestionIds all hard-code student_id from the auth
+ * token, so the attack is only expressible at the direct-table layer — which
  * this spec exercises. Defenses must hold: attacker sees 0 of the victim's flags and
  * cannot insert a flag as the victim.
  *

--- a/apps/web/lib/queries/flagged-questions.test.ts
+++ b/apps/web/lib/queries/flagged-questions.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---- Mocks -----------------------------------------------------------------
+
+const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+}))
+
+vi.mock('@repo/db/server', () => ({
+  createServerSupabaseClient: async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  }),
+}))
+
+// ---- Subject under test ----------------------------------------------------
+
+import { getFlaggedQuestionIds } from './flagged-questions'
+
+// ---- Helpers ---------------------------------------------------------------
+
+/** Builds a fluent Supabase chain that resolves to the given return value. */
+function buildChain(returnValue: unknown) {
+  const awaitable = {
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable for Supabase chain mock
+    then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+      Promise.resolve(returnValue).then(resolve, reject),
+  }
+  const proxy = new Proxy(awaitable as Record<string, unknown>, {
+    get(target, prop) {
+      if (prop === 'then') return target.then
+      return (..._args: unknown[]) => proxy
+    },
+  })
+  return proxy
+}
+
+// ---- Fixtures --------------------------------------------------------------
+
+const USER_ID = '00000000-0000-4000-a000-000000000001'
+const QUESTION_ID_A = '00000000-0000-4000-a000-000000000011'
+const QUESTION_ID_B = '00000000-0000-4000-a000-000000000022'
+
+function setupAuthenticatedUser() {
+  mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } }, error: null })
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+describe('getFlaggedQuestionIds', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns an empty array without querying when no question IDs are given', async () => {
+    setupAuthenticatedUser()
+    const result = await getFlaggedQuestionIds([])
+    expect(result).toEqual([])
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty array when the user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null })
+    const result = await getFlaggedQuestionIds([QUESTION_ID_A])
+    expect(result).toEqual([])
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty array when auth returns an error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'JWT expired' } })
+    const result = await getFlaggedQuestionIds([QUESTION_ID_A])
+    expect(result).toEqual([])
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('returns the flagged question IDs from the active_flagged_questions view', async () => {
+    setupAuthenticatedUser()
+    mockFrom.mockReturnValue(buildChain({ data: [{ question_id: QUESTION_ID_A }], error: null }))
+    const result = await getFlaggedQuestionIds([QUESTION_ID_A, QUESTION_ID_B])
+    expect(mockFrom).toHaveBeenCalledWith('active_flagged_questions')
+    expect(result).toEqual([QUESTION_ID_A])
+  })
+
+  it('returns an empty array when none of the questions are flagged', async () => {
+    setupAuthenticatedUser()
+    mockFrom.mockReturnValue(buildChain({ data: [], error: null }))
+    const result = await getFlaggedQuestionIds([QUESTION_ID_A, QUESTION_ID_B])
+    expect(result).toEqual([])
+  })
+
+  it('degrades to an empty array and logs when the query errors', async () => {
+    setupAuthenticatedUser()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockFrom.mockReturnValue(buildChain({ data: null, error: { message: 'boom' } }))
+    const result = await getFlaggedQuestionIds([QUESTION_ID_A])
+    expect(result).toEqual([])
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/apps/web/lib/queries/flagged-questions.test.ts
+++ b/apps/web/lib/queries/flagged-questions.test.ts
@@ -95,7 +95,7 @@ describe('getFlaggedQuestionIds', () => {
     mockFrom.mockReturnValue(buildChain({ data: null, error: { message: 'boom' } }))
     const result = await getFlaggedQuestionIds([QUESTION_ID_A])
     expect(result).toEqual([])
-    expect(errorSpy).toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith('[getFlaggedQuestionIds] Query error:', 'boom')
     errorSpy.mockRestore()
   })
 })

--- a/apps/web/lib/queries/flagged-questions.ts
+++ b/apps/web/lib/queries/flagged-questions.ts
@@ -1,0 +1,35 @@
+import { createServerSupabaseClient } from '@repo/db/server'
+
+/**
+ * Reads which of the given question IDs the current student has actively flagged.
+ *
+ * Non-throwing by design: flag state is decorative on the report page, so a
+ * transient DB/RLS hiccup degrades to "nothing flagged" rather than breaking the
+ * whole report render. Mirrors the `console.error + return` posture of the sibling
+ * report helpers in `quiz-report.ts`. Scoped to `auth.uid()` via the
+ * `active_flagged_questions` security_invoker view.
+ */
+export async function getFlaggedQuestionIds(questionIds: string[]): Promise<string[]> {
+  if (questionIds.length === 0) return []
+
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+  if (authError || !user) return []
+
+  const { data, error } = await supabase
+    .from('active_flagged_questions')
+    .select('question_id')
+    .eq('student_id', user.id)
+    .in('question_id', questionIds)
+
+  if (error) {
+    console.error('[getFlaggedQuestionIds] Query error:', error.message)
+    return []
+  }
+
+  // View columns typed nullable (Postgres artifact); safe to cast — underlying table has NOT NULL constraints.
+  return data.map((r) => r.question_id as string)
+}


### PR DESCRIPTION
## What

Students can **flag/unflag a question directly from the report page**, and each report row now **shows whether the question is already flagged** — across **all** student report types:

- Quick Quiz, Smart Review, Practice (mock) Exam, VFR RT → `/app/quiz/report`
- Internal Exam → `/app/internal-exam/report`

Closes #836.

## How

- **Reuses the existing `toggleFlag` Server Action** and `flagged_questions` soft-delete — **no schema change, no new migration, no new RPC**.
- **Server-side initial state** (`getFlaggedQuestionIds` in `lib/queries/flagged-questions.ts`): reads `active_flagged_questions` scoped to `auth.uid()` once on the server — no `useEffect` data fetching, no flash of unflagged state. Degrades to `[]` on error (flag state is decorative; never breaks the report).
- **`ReportFlagProvider` / `useReportFlag`** (`report-flag-context.tsx`): client context seeds flagged state from the server read and toggles via `toggleFlag`. Server-result-driven (mirrors the in-quiz `useFlaggedQuestions`), with a synchronous concurrent-toggle guard and a `catch` so a thrown action (e.g. network failure) leaves state unchanged instead of becoming an unhandled rejection.
- **`ReportQuestionRow`** renders the flag toggle only when a provider is present.

## Admin views stay read-only (by construction)

The report row is shared with the **admin** report pages (admin viewing a student's session). Flags are owned by `auth.uid()`, so an admin can't meaningfully flag a student's question. The admin pages simply **don't wrap with `ReportFlagProvider`**, so `useReportFlag()` returns `null` and no flag button renders. The exclusion is structural — no per-component `if (isAdmin)` guard to forget.

## Tests

- `flagged-questions.test.ts` — auth/empty/happy/none/error-degrade paths (asserts the logged message).
- `report-flag-context.test.tsx` — no-provider null, server-seed, flag, unflag, failure no-op, concurrent-toggle guard, **thrown-action cleanup**.
- `report-question-row.test.tsx` — no button without provider, aria-pressed/label states, click calls the action, **disabled while in-flight**.
- Full suite: **3632 passed**. Red-team suite: **270 passed / 1 skipped** (incl. `flag-idor`). Build + type-check + lint clean.

## Review trail

Plan-critic → impl-critic (APPROVED) → post-commit fleet (code/semantic/doc/test + learner) → PR-level semantic sweep → CodeRabbit-local (3 rounds → 0 findings). Zero unresolved CRITICAL/ISSUE.

## Follow-up

- **#849** (deferred, S/P2) — harden pre-existing vacuous cross-student isolation assertions in `flag-idor.spec.ts` per code-style §7 (not introduced by this PR; only its header comment was touched here).

## Manual eval

**Recommended.** This is user-facing UI. Worth a click-through: open a completed quiz/exam report, flag a couple of questions, confirm the orange flag state persists on reload and that the flagged questions then appear under the "Flagged questions" quiz filter. Confirm admin report views show **no** flag button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Students can flag/unflag questions in quiz reports with a right-aligned flag button.
  * Flagged state is loaded and restored when revisiting reports and resets when switching sessions/pages.
  * Flag toggle shows disabled/disabled-feedback while an update is in progress.

* **Tests**
  * Added comprehensive tests covering flag seeding, toggling success/failure, concurrent-toggle prevention, and UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->