### PR TITLE
docs: remove stale health-monitoring.yml workflow reference (#804)

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -658,7 +658,6 @@ Migrations 044–047. 1082 tests, all passing. Production Supabase email templat
     - Dependabot **security updates** enabled (`automated-security-fixes` repo setting → auto-remediation PRs for vulnerable deps); vulnerability **alerts** were already on (#109, 2026-06-08)
   - **Socket.dev** (GitHub App, no CI workflow) — supply-chain / malicious-package detection (install scripts, network/env/filesystem access, obfuscation, typosquatting) auto-commented on dependency PRs. Layered on top of `pnpm audit` + Dependabot + CodeQL, which only catch known CVEs; Socket covers freshly-published malicious packages that have no CVE yet. App install is a one-time repo-admin action (see Decision 40, #109)
   - **Snyk** — a leftover #109 trial (Snyk↔GitHub App, `security/snyk` PR check, no repo files) is being **removed** as redundant with `pnpm audit` + Dependabot + CodeQL; disconnect is a one-time repo-admin action (see Decision 40, #109)
-  - `health-monitoring.yml` — weekly workflows: dependency audit, security audit, codeql scan (added 2026-03-15, moved to separate weekly schedule for visibility)
   - Local Supabase spun up in CI via `supabase/setup-cli` — runs all migrations automatically
   - `apps/web/scripts/seed-e2e.ts` — seeds org, users, question bank, and 20 questions for E2E (expanded from 5 to support review flow after quiz)
   - Playwright config updated: uses `pnpm start` (production build) in CI, `pnpm dev` locally


### PR DESCRIPTION
## Summary
`docs/plan.md` listed a weekly `health-monitoring.yml` workflow that never landed under that name. The functions it described are already documented at their real homes in the same CI block:
- **dependency audit** → `ci.yml` (line 642, `pnpm audit --audit-level=high`)
- **codeql scan** → `codeql.yml` (line 655, weekly Monday 05:30 UTC)
- **security audit** → the security-auditor agent runs pre-push via Lefthook, not a GitHub Actions workflow

The stale line is removed; no redirection needed since both live functions are already covered.

## Verification
- Confirmed `health-monitoring.yml` absent from `.github/workflows/`.
- doc-updater swept all `docs/` + steering docs: no other reference to `health-monitoring`; `decisions.md` Decision 28 already documents the four real health workflows (`agent-health.yml`, `coverage-trend.yml`, `bundle-size.yml`, `stale-issues.yml`).
- Post-commit agents (code-reviewer, semantic-reviewer, doc-updater, test-writer): all clean.

## Deferred follow-ups
None.

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI/E2E testing pipeline documentation with comprehensive details about test environment initialization and setup procedures, test data preparation and seeding, configuration differences between development and production testing environments, testing artifact management and storage locations, and mechanisms to prevent duplicate test executions on the same development branch to enhance overall workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->