### PR TITLE
chore(ci): correct codecov-action version comment v5 -> v7.0.0 (#812)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload web coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: apps/web/coverage/lcov.info
           flags: web
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload db coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: packages/db/coverage/lcov.info
           flags: db


### PR DESCRIPTION
## Summary
The `codecov/codecov-action` SHA pin in `.github/workflows/ci.yml` (`fb8b3582…`) was bumped to v7.0.0 by Dependabot #808, but the trailing version comment was left as `# v5`. This corrects the comment on both occurrences (lines 96 & 105).

## Verification
- Verified via the GitHub API that SHA `fb8b3582c8e4def4969c97caa2f19720cb33a72f` is exactly the commit the annotated tag **v7.0.0** dereferences to (v6.0.1 = `e79a6962…`, v5.x SHAs differ — so it is genuinely v7.0.0, not v5).
- The SHA pin itself is authoritative and **unchanged** — only the misleading comment is corrected. No behavior change.
- Post-commit agents (code-reviewer, semantic-reviewer, doc-updater, test-writer): all clean. No doc references the codecov version.

## Deferred follow-ups
None.

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration pipeline’s code coverage upload to the latest version for both web and database coverage reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->