### PR TITLE
chore: resolve knip dead-code report (#791)

### DIFF
--- a/apps/web/app/app/admin/questions/_components/filter-select.tsx
+++ b/apps/web/app/app/admin/questions/_components/filter-select.tsx
@@ -8,7 +8,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
-export type FilterSelectItem = { value: string; label: string }
+type FilterSelectItem = { value: string; label: string }
 
 type Props = {
   value: string

--- a/apps/web/app/app/quiz/_components/filter-pill.tsx
+++ b/apps/web/app/app/quiz/_components/filter-pill.tsx
@@ -13,7 +13,7 @@ export function getSquareClass(opts: {
   return 'border border-border text-muted-foreground'
 }
 
-export function FilterPill({
+function FilterPill({
   active,
   onClick,
   label,

--- a/apps/web/app/app/quiz/_hooks/use-topic-tree.ts
+++ b/apps/web/app/app/quiz/_hooks/use-topic-tree.ts
@@ -8,8 +8,6 @@ import {
   computeToggleTopic,
 } from './topic-tree-helpers'
 
-export type { UseTopicTreeReturn } from './topic-tree-helpers'
-
 export function useTopicTree() {
   const [topics, setTopics] = useState<TopicWithSubtopics[]>([])
   const [checkedTopics, setCheckedTopics] = useState<Set<string>>(new Set())

--- a/apps/web/app/app/quiz/types.ts
+++ b/apps/web/app/app/quiz/types.ts
@@ -29,7 +29,7 @@ export type CompleteQuizResult =
   | { success: true; totalQuestions: number; correctCount: number; scorePercentage: number }
   | { success: false; error: string }
 
-export type BatchAnswerResult = {
+type BatchAnswerResult = {
   questionId: string
   isCorrect: boolean
   correctOptionId: string
@@ -98,8 +98,6 @@ export type DraftData = {
 }
 
 export type DraftResult = { success: true } | { success: false; error: string }
-
-export type LoadDraftResult = { draft: DraftData | null }
 
 export type LoadDraftsResult = { drafts: DraftData[] }
 

--- a/apps/web/e2e/redteam/helpers/seed.ts
+++ b/apps/web/e2e/redteam/helpers/seed.ts
@@ -7,8 +7,8 @@ export const VICTIM_PASSWORD = 'redteam-victim-2026!'
 
 export const ADMIN_EMAIL = 'redteam-admin@lmsplus.local'
 export const ADMIN_PASSWORD = 'redteam-admin-2026!'
-export const CROSS_ORG_ADMIN_EMAIL = 'redteam-crossorg-admin@lmsplus.local'
-export const CROSS_ORG_ADMIN_PASSWORD = 'redteam-crossorg-admin-2026!'
+const CROSS_ORG_ADMIN_EMAIL = 'redteam-crossorg-admin@lmsplus.local'
+const CROSS_ORG_ADMIN_PASSWORD = 'redteam-crossorg-admin-2026!'
 
 // E2E hermiticity markers — exported per code-style.md §7 so cleanup queries
 // in any spec or maintenance script can target the rows these tests create.

--- a/apps/web/lib/queries/progress.ts
+++ b/apps/web/lib/queries/progress.ts
@@ -16,7 +16,7 @@ export type SubjectDetail = {
   topics: TopicDetail[]
 }
 
-export type TopicDetail = {
+type TopicDetail = {
   id: string
   code: string
   name: string

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -79,7 +79,7 @@ After umbrella #668 closed, focus shifted to DB/security hardening and adversari
 - Hermetic `easa_*` reference-data cleanup in integration suites (#775, #593, PR #779).
 - "Red Team Specs" promoted to a required status check (#771).
 
-**Open follow-ups (P2 tech-debt):** #791 (knip dead code), #794 (promote 2 learner rule candidates + sweep).
+**Open follow-ups (P2 tech-debt):** #794 (promote 2 learner rule candidates + sweep).
 
 **Resolved this sprint:** #797 (consolidate duplicated `ActionResult` type into `@/lib/action-result`, PR #801); #793 (renumber start_quiz_session smuggling vectors BL/BM/BN → CU/CV/CW, commit b388dc9c) — resolved the pre-existing matrix ID collision; #792 (dedupe learner tracker rows — merged 4 duplicate live-table pairs, counts unchanged).
 

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     ".": {
-      "ignoreDependencies": ["zod", "lefthook"]
+      "ignoreDependencies": ["zod"]
     },
     "apps/web": {
       "entry": [
@@ -26,6 +26,6 @@
       "ignoreDependencies": ["react", "@types/react"]
     }
   },
-  "ignore": ["packages/typescript-config/**", ".claude/**"],
+  "ignore": ["packages/typescript-config/**", ".claude/**", "apps/web/components/ui/**"],
   "ignoreBinaries": ["only-allow"]
 }


### PR DESCRIPTION
## Summary
Resolves the weekly knip dead-code report (#791): 20 unused exports + 5 unused types + 1 config hint. Each symbol was triaged (most flags were false positives or vendored-library API); the changes are behaviour-preserving.

### knip.json
- **Ignore `apps/web/components/ui/**`** — the 14 flagged exports (`CardFooter`, `DialogClose`, `SelectSeparator`, `TableCaption`, `badgeVariants`, …) are shadcn/ui primitives in a vendored directory where the full upstream API is intentionally retained; deleting them would diverge from `shadcn add` re-sync. Consistent with the existing `sonar.exclusions` entry for the same dir.
- **Drop stale `lefthook` from `ignoreDependencies`** — per knip's own config hint; knip now resolves it via `lefthook.yml`.

### Source cleanup
- **Delete dead type `LoadDraftResult`** (`quiz/types.ts`) — zero references (distinct from the live `LoadDraftsResult`).
- **Remove redundant re-export** of `UseTopicTreeReturn` in `use-topic-tree.ts` — the type stays in `topic-tree-helpers.ts`, where its real consumers (`use-available-count.ts` + 2 tests) import it directly.
- **Drop the unused `export` keyword** on internal-only symbols: `FilterPill`, `FilterSelectItem`, `BatchAnswerResult`, `TopicDetail`, and the `CROSS_ORG_ADMIN_*` red-team seed credentials (consumed via `seedCrossOrgAdmin`'s return value, never imported).

## Verification
- `pnpm knip` now **exits 0** (report fully resolved).
- `pnpm check-types` clean (3/3); `pnpm exec biome check` clean (7 files); `pnpm --filter @repo/web test` **3708/3708** pass.
- Post-commit agents: code-reviewer (clean), semantic-reviewer (6× GOOD), doc-updater (plan.md follow-up line updated), test-writer (no tests), red-team (**COVERED** — `seedCrossOrgAdmin` behaviour unchanged, no spec imports the de-exported constants).

## Deferred follow-ups
None.

Closes #791

🤖 Generated with [Claude Code](https://claude.com/claude-code)