### PR TITLE
refactor(quiz): consolidate ActionResult-shaped unions (#800)

### DIFF
--- a/apps/web/app/app/quiz/_hooks/quiz-recovery-handlers.test.ts
+++ b/apps/web/app/app/quiz/_hooks/quiz-recovery-handlers.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ActionResult } from '@/lib/action-result'
 
 const {
   mockSaveDraft,
@@ -7,8 +8,8 @@ const {
   mockClearActiveSession,
   mockSessionStorageSetItem,
 } = vi.hoisted(() => ({
-  mockSaveDraft: vi.fn<() => Promise<{ success: true } | { success: false; error: string }>>(),
-  mockDiscardQuiz: vi.fn<() => Promise<{ success: true } | { success: false; error: string }>>(),
+  mockSaveDraft: vi.fn<() => Promise<ActionResult>>(),
+  mockDiscardQuiz: vi.fn<() => Promise<ActionResult>>(),
   mockClearDeploymentPin: vi.fn<() => Promise<void>>(),
   mockClearActiveSession: vi.fn<(userId: string) => void>(),
   mockSessionStorageSetItem: vi.fn<(key: string, value: string) => void>(),

--- a/apps/web/app/app/quiz/actions/discard.ts
+++ b/apps/web/app/app/quiz/actions/discard.ts
@@ -2,15 +2,14 @@
 
 import { createServerSupabaseClient } from '@repo/db/server'
 import { z } from 'zod'
+import type { ActionResult } from '@/lib/action-result'
 
 const DiscardQuizInput = z.object({
   sessionId: z.uuid(),
   draftId: z.uuid().optional(),
 })
 
-export async function discardQuiz(
-  raw: unknown,
-): Promise<{ success: true } | { success: false; error: string }> {
+export async function discardQuiz(raw: unknown): Promise<ActionResult> {
   try {
     const supabase = await createServerSupabaseClient()
     const {

--- a/apps/web/app/app/quiz/session/_hooks/quiz-submit.ts
+++ b/apps/web/app/app/quiz/session/_hooks/quiz-submit.ts
@@ -1,4 +1,5 @@
 import type { useRouter } from 'next/navigation'
+import type { ActionResult } from '@/lib/action-result'
 import type { QuizMode as DbQuizMode } from '@/lib/constants/exam-modes'
 import { batchSubmitQuiz } from '../../actions/batch-submit'
 import { clearDeploymentPin } from '../../actions/clear-deployment-pin'
@@ -46,7 +47,7 @@ export async function discardQuizSession(
   router: AppRouterInstance,
   userId: string,
   draftId?: string,
-): Promise<{ success: true } | { success: false; error: string }> {
+): Promise<ActionResult> {
   clearActiveSession(userId) // Always clear — respect discard intent even if Server Action fails
   clearDeploymentPin().catch(() => {})
   try {

--- a/apps/web/app/app/quiz/types.ts
+++ b/apps/web/app/app/quiz/types.ts
@@ -1,3 +1,5 @@
+import type { ActionResult } from '@/lib/action-result'
+
 export type SubmitRpcResult = {
   is_correct: boolean
   correct_option_id: string
@@ -97,7 +99,7 @@ export type DraftData = {
   createdAt?: string
 }
 
-export type DraftResult = { success: true } | { success: false; error: string }
+export type DraftResult = ActionResult
 
 export type LoadDraftsResult = { drafts: DraftData[] }
 


### PR DESCRIPTION
## Summary
Finishes the `ActionResult` consolidation started in #797 for the three remaining quiz-flow sites the semantic-reviewer flagged. All carry the structurally-identical `{ success: true } | { success: false; error: string }` union; this routes them through the canonical `@/lib/action-result`.

- **`quiz/types.ts`** — `DraftResult` kept as a **named domain alias** (`type DraftResult = ActionResult`) so its `draft.ts` / `draft-helpers.ts` call sites still read with the domain name, rather than re-declaring the shape.
- **`quiz/actions/discard.ts`** — `discardQuiz` return type → `Promise<ActionResult>`.
- **`quiz/session/_hooks/quiz-submit.ts`** — `discardQuizSession` return type → `Promise<ActionResult>`.
- **`quiz/_hooks/quiz-recovery-handlers.test.ts`** — the `saveDraft` / `discardQuiz` `vi.fn` mock annotations now use `ActionResult` too, so **exactly one** `{ success: true } | { success: false; error: string }` shape remains in the quiz flow (the acceptance criterion).

Pure type-alias substitution — identical shape, zero behaviour change.

## Verification
- `pnpm check-types` clean (3/3); biome clean (imports auto-sorted); quiz unit suite **1588/1588** pass.
- Post-commit agents: code-reviewer (clean), semantic-reviewer (3× GOOD — confirms `import type` inside `vi.hoisted` is safe, erased at compile time), doc-updater (no changes), test-writer (no tests), **red-team (COVERED** — Vector G session-race path unchanged; type-only annotation change, no auth/RLS/logic touched, no spec re-run needed).

## Deferred follow-ups
None.

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)