### PR TITLE
fix(turbo): declare RESEND_API_KEY, EMAIL_FROM, SENTRY_DSN in build env

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,15 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "env": ["SUPABASE_SERVICE_ROLE_KEY", "SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"],
+      "env": [
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG",
+        "SENTRY_PROJECT",
+        "SENTRY_DSN",
+        "RESEND_API_KEY",
+        "EMAIL_FROM"
+      ],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },


### PR DESCRIPTION
## Problem

The internal-exam code email feature (#904) returns **"Failed to send email"** in production. Root cause: Turborepo's strict env mode prunes any environment variable not declared in `turbo.json`, so `RESEND_API_KEY` and `EMAIL_FROM` — set on Vercel but absent from `turbo.json` — were stripped from the build and never reached the app. Vercel surfaces this as a build warning:

> the following environment variables are set on your Vercel project, but missing from "turbo.json" … These variables WILL NOT be available to your application

`NEXT_PUBLIC_APP_URL` was unaffected because `NEXT_PUBLIC_*` vars are inlined at build time. `RESEND_API_KEY`/`EMAIL_FROM` are server-only runtime vars and were the ones being dropped.

## Fix

Add `RESEND_API_KEY`, `EMAIL_FROM`, and `SENTRY_DSN` (same latent gap, also flagged) to the `build` task's `env` array in `turbo.json`.

## Verification

- `turbo.json` valid JSON; `pnpm check-types` + biome pass (pre-commit).
- After merge: redeploy Vercel → build reads updated `turbo.json` → vars pass through → email sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include additional environment variables for error tracking and email service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->