### PR TITLE
chore(biome): migrate deprecated linter.rules.recommended → preset (#935)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedVariables": "error",
         "noUnusedImports": "error"


### PR DESCRIPTION
## Summary

Biome 2.5 deprecated `linter.rules.recommended`; it emits a `DEPRECATED` INFO on every `biome check`/`lint` run and will be removed at the next major. This migrates to the successor field `preset: "recommended"` via the canonical `biome migrate --write`.

```diff
   "rules": {
-    "recommended": true,
+    "preset": "recommended",
```

**Behaviorally identical** — same recommended ruleset, all category overrides and test-file override blocks untouched.

## Verification

- `biome migrate --write` produced exactly this one-line change (canonical migration path).
- Bundled `configuration_schema.json` (2.5.0): `PresetConfig` enum is `["recommended","all","none"]`, so `"preset": "recommended"` is the direct successor to `"recommended": true`.
- **Empirical A/B (ruleset still active):** with `preset:"recommended"` a recommended-only rule (`noDoubleEquals`) fires; with `preset:"none"` it's silent. Proves the string preset genuinely activates the ruleset.
- Deprecation INFO gone; `biome check .` clean (838 files, no fixes).
- `pnpm lint` / `pnpm check-types` pass · full web suite **4121 tests pass** · `pnpm build` succeeds.

## Note for reviewers

CodeRabbit local round 1 raised a CRITICAL claiming `"preset": "recommended"` is invalid and Biome "uses a boolean flag." That is a **false positive from pre-2.5 knowledge** — disproven by the 2.5.0 bundled schema, the `biome migrate` output that generated this change, and the A/B above. Rounds 2 and 3 returned no findings (it was non-deterministic flake).

## Deferred follow-ups

None.

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->