### PR TITLE
chore: drop unused getAnonClient re-export from integration harness (#940)

### DIFF
--- a/apps/web/lib/integration-support/harness.ts
+++ b/apps/web/lib/integration-support/harness.ts
@@ -15,7 +15,6 @@ export {
   createTestOrg,
   createTestUser,
   getAdminClient,
-  getAnonClient,
   getAuthenticatedClient,
   type ReferenceIds,
   seedQuestions,


### PR DESCRIPTION
## Summary

The weekly knip dead-code scan (#940) flagged `getAnonClient` as an unused export at `apps/web/lib/integration-support/harness.ts:18`. This removes that one re-export line.

```diff
   getAdminClient,
-  getAnonClient,
   getAuthenticatedClient,
```

The harness is a **curated test-only re-export surface** (explicitly "NOT a barrel over feature code" per its header). No apps/web integration test imports `getAnonClient` from it.

## Verification

- `getAnonClient` stays defined in `packages/db/src/__integration__/setup.ts` and exported from `@repo/db/test-helpers`. Its real consumers — `rpc-check-non-mc-answer.integration.test.ts` and `rpc-record-internal-exam-code-emailed.integration.test.ts` — import it directly from there and are **untouched**.
- `grep -r getAnonClient apps/` → zero results after the change. No dynamic/string-based import either.
- `pnpm knip` now exits **0** (dead export resolved).
- `pnpm lint` / `pnpm check-types --force` pass · full web suite **4121 tests pass** · `pnpm build` succeeds.

## Deferred follow-ups

None.

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused test helper re-export from internal integration test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->