### PR TITLE
test: enable restoreMocks app-wide in vitest configs (#929)

### DIFF
--- a/.claude/rules/agent-test-writer.md
+++ b/.claude/rules/agent-test-writer.md
@@ -29,7 +29,8 @@ Writes Vitest unit and integration tests for new or changed TypeScript functions
 - Co-located `.test.ts` / `.test.tsx` files next to source files
 - Behavior-focused test names
 - Supabase client mocks using the project's established `vi.hoisted` + `buildChain` pattern
-- `vi.resetAllMocks()` in `beforeEach`
+- `vi.resetAllMocks()` in `beforeEach` — still required: it resets `vi.fn()` mock state (calls/return values), which `restoreMocks` does NOT touch.
+- Do NOT hand-add `afterEach(() => vi.restoreAllMocks())` spy-cleanup nets. `restoreMocks: true` in both vitest configs (`vitest.config.ts` + `vitest.integration.config.ts`) already restores every `vi.spyOn` spy to its original before each test, globally and leak-safe even on assertion failure (#929). Per-test `spy.mockRestore()` is likewise redundant.
 - Tests that run and pass before being reported
 
 ## When Tests Reveal Bugs

--- a/.claude/rules/agent-test-writer.md
+++ b/.claude/rules/agent-test-writer.md
@@ -30,7 +30,7 @@ Writes Vitest unit and integration tests for new or changed TypeScript functions
 - Behavior-focused test names
 - Supabase client mocks using the project's established `vi.hoisted` + `buildChain` pattern
 - `vi.resetAllMocks()` in `beforeEach` — still required: it resets `vi.fn()` mock state (calls/return values), which `restoreMocks` does NOT touch.
-- Do NOT hand-add `afterEach(() => vi.restoreAllMocks())` spy-cleanup nets. `restoreMocks: true` in both vitest configs (`vitest.config.ts` + `vitest.integration.config.ts`) already restores every `vi.spyOn` spy to its original before each test, globally and leak-safe even on assertion failure (#929). Per-test `spy.mockRestore()` is likewise redundant.
+- Do NOT hand-add `afterEach(() => vi.restoreAllMocks())` spy-cleanup nets. `restoreMocks: true` in both vitest configs (`vitest.config.ts` + `vitest.integration.config.ts`) already restores every `vi.spyOn` spy to its original before each test, globally and leak-safe even on assertion failure (#929). Per-test `spy.mockRestore()` is no longer required for correctness — but keep it for global/prototype spies (`globalThis.confirm`, `Storage.prototype.setItem`, `document.createElement`) where the explicit restore communicates intent. Drop only the `afterEach` nets.
 - Tests that run and pass before being reported
 
 ## When Tests Reveal Bugs

--- a/apps/web/app/app/quiz/_hooks/use-exam-start.test.ts
+++ b/apps/web/app/app/quiz/_hooks/use-exam-start.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks ----------------------------------------------------------------
 
@@ -106,13 +106,6 @@ beforeEach(() => {
   mockReadActiveSession.mockReturnValue(null)
   // Default: discard cleanup succeeds (used only on the handoff-failure path)
   mockDiscardQuiz.mockResolvedValue({ success: true })
-})
-
-// Failure-safe spy cleanup: resetAllMocks does NOT detach vi.spyOn spies, and a
-// per-test mockRestore() is skipped if an assertion throws first. restoreAllMocks
-// runs on both pass and failure, so a spy can never leak into a later test.
-afterEach(() => {
-  vi.restoreAllMocks()
 })
 
 // ---- Initial state -------------------------------------------------------

--- a/apps/web/app/app/quiz/_hooks/use-quiz-start.test.ts
+++ b/apps/web/app/app/quiz/_hooks/use-quiz-start.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks ----------------------------------------------------------------
 
@@ -89,13 +89,6 @@ beforeEach(() => {
   mockTopicTree.getSelectedSubtopicIds.mockReturnValue(['sub-1'])
   // Default: no existing session
   mockReadActiveSession.mockReturnValue(null)
-})
-
-// Failure-safe spy cleanup: resetAllMocks does NOT detach vi.spyOn spies, and a
-// per-test mockRestore() is skipped if an assertion throws first. restoreAllMocks
-// runs on both pass and failure, so a spy can never leak into a later test.
-afterEach(() => {
-  vi.restoreAllMocks()
 })
 
 // ---- Initial state -------------------------------------------------------

--- a/apps/web/app/app/settings/_components/data-export-card.test.tsx
+++ b/apps/web/app/app/settings/_components/data-export-card.test.tsx
@@ -57,8 +57,9 @@ beforeEach(() => {
 
 /**
  * Stub document.createElement so the anchor's .click() is a no-op (jsdom does not
- * implement navigation). Returns the spy so the caller can restore it in a finally
- * block — beforeEach uses resetAllMocks, which does NOT reinstate the original impl.
+ * implement navigation). Returns the spy so a test can restore the original
+ * mid-test if it needs the real createElement; cross-test cleanup is handled
+ * globally by restoreMocks (vitest.config.ts).
  */
 function stubLinkClick() {
   const originalCreateElement = document.createElement.bind(document)

--- a/apps/web/app/app/vfr-rt/_hooks/use-vfr-rt-start.test.ts
+++ b/apps/web/app/app/vfr-rt/_hooks/use-vfr-rt-start.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---- Mocks ----------------------------------------------------------------
 
@@ -69,13 +69,6 @@ beforeEach(() => {
   sessionStorage.clear()
   mockStartQuizSession.mockResolvedValue(SUCCESS_RESULT)
   mockReadActiveSession.mockReturnValue(null)
-})
-
-// Failure-safe spy cleanup: resetAllMocks does NOT detach vi.spyOn spies, and a
-// per-test mockRestore() is skipped if an assertion throws first. restoreAllMocks
-// runs on both pass and failure, so a spy can never leak into a later test.
-afterEach(() => {
-  vi.restoreAllMocks()
 })
 
 // ---- Guard: no parts selected --------------------------------------------
@@ -164,8 +157,8 @@ describe('useVfrRtStart — failure path', () => {
     await act(async () => result.current.handleStart())
     expect(result.current.error).toMatch(/unable to start/i)
     expect(mockRouterPush).not.toHaveBeenCalled()
-    // resetAllMocks resets impl but doesn't detach the spy — restore so it can't
-    // leak into later tests in this file (matches the confirm-spy restores below).
+    // restoreMocks (vitest.config.ts) auto-detaches spies before each test; this
+    // explicit restore is belt-and-suspenders, mirroring the confirm-spy restores below.
     setItemSpy.mockRestore()
   })
 })

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    // Restore every vi.spyOn spy to its original before each test. A per-test
+    // spy.mockRestore() is skipped when an earlier expect() throws, leaking the
+    // spy (installed on a prototype/global) into later tests; this flag closes
+    // that leak class globally so no per-file afterEach net is needed (#929).
+    restoreMocks: true,
     setupFiles: ['./vitest.setup.ts'],
     include: ['**/*.test.{ts,tsx}'],
     // Integration tests run in a separate node-env tier against real Postgres

--- a/apps/web/vitest.integration.config.ts
+++ b/apps/web/vitest.integration.config.ts
@@ -8,6 +8,11 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    // Restore every vi.spyOn spy to its original before each test, mirroring the
+    // unit config — closes the assertion-throw spy-leak class here too (#929).
+    // Does not touch the vi.mock() module mocks below (those mock factories are
+    // unaffected by restoreMocks, which only restores spies).
+    restoreMocks: true,
     include: ['**/*.integration.test.ts'],
     exclude: ['node_modules', '.next'],
     // Mocks `next/headers`/`next/cache`/`next/navigation` once for the whole tier


### PR DESCRIPTION
## Summary

CodeRabbit follow-up on PR #927. 74 apps/web test files use `vi.spyOn`, but the vitest config set no mock-restore flag — so a spy was detached only by a per-test `spy.mockRestore()`, which is **skipped when an earlier `expect()` throws**, leaking the spy (installed on a prototype/global) into later tests. `vi.resetAllMocks()` in `beforeEach` does NOT detach spies.

This sets `restoreMocks: true` in **both** `vitest.config.ts` and `vitest.integration.config.ts`. Vitest now restores every `vi.spyOn` spy to its original **before each test**, globally and leak-safe even on assertion failure — closing the leak class for all current and future tests with no per-file maintenance. It does not touch `vi.fn()`/`vi.mock()` factory mocks.

## Controlled rollout (per the issue — flip-and-triage, not a blind flip)

- The only breakage class is a spy installed in `beforeAll` and relied on across tests. **Grep confirms ZERO apps/web files have `vi.spyOn` inside `beforeAll`** (74 files use `vi.spyOn`; none in `beforeAll`).
- **Ground-truth run with the flag flipped:** full unit suite **4121 pass** (293 files), integration tier **75 pass** (16 files).
- Semantic review confirmed "restore before each test" is equivalent-or-stronger than the removed "restore after each test" nets for cross-test isolation.

## Cleanup (same PR)

- Removed the 3 redundant `afterEach(vi.restoreAllMocks())` nets added in #927 (`use-quiz-start`, `use-exam-start`, `use-vfr-rt-start`) + their now-orphaned `afterEach` imports.
- Updated 2 comments that justified manual restore via "resetAllMocks does not detach spies" — now stale under `restoreMocks` (`data-export-card`, `use-vfr-rt-start`).
- Updated `.claude/rules/agent-test-writer.md`: annotated the still-required `vi.resetAllMocks()` bullet and added guidance not to hand-add `afterEach` spy nets (keeping intent-signaling per-test restores on global/prototype spies).

## Out of scope (deliberate)

- **Per-test `spy.mockRestore()` calls left in place** — redundant under `restoreMocks` but harmless; kept as belt-and-suspenders / intent signal on global/prototype spies.
- **~10 pre-existing `afterEach(restoreAllMocks)` nets in other files** (e.g. `use-vfr-rt-start-utils`, `session-operations`, `dashboard-stats`) — redundant-but-harmless under the flag; sweeping them is pure cosmetic churn the issue explicitly scoped out. Not filed as a follow-up (won't-do).

## Verification

- `pnpm lint` clean · `pnpm check-types --force` pass · unit **4121 pass** · integration **75 pass** · `pnpm build` succeeds.
- CR-local: 2 consecutive clean rounds (floor met).

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized test infrastructure with automatic mock restoration between tests, preventing spy leakage and improving test suite reliability across unit and integration test suites.
  * Simplified test file maintenance by removing redundant manual cleanup code and consolidating mock handling configuration for consistent, failure-safe test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->