### PR TITLE
chore(hooks): §7 test-title impl-leakage pre-commit + CI guard (#946)

### DIFF
--- a/.claude/hooks/check-test-title-leakage.mjs
+++ b/.claude/hooks/check-test-title-leakage.mjs
@@ -11,9 +11,9 @@
 // are left untouched. A naive whole-file scan would block commits repo-wide, so
 // this guard reads `git diff` and inspects only `+` lines.
 //
-// Two modes:
-//   node check-test-title-leakage.mjs <file> [file ...]   # staged mode (lefthook): diff each file against the index's HEAD (`git diff --cached`)
-//   node check-test-title-leakage.mjs --base <ref>          # CI mode: diff the whole range <ref>...HEAD for *.test.{ts,tsx}
+// Two modes (run from the repo root):
+//   node .claude/hooks/check-test-title-leakage.mjs <file> [file ...]   # staged mode (lefthook): diff each file against the index's HEAD (`git diff --cached`)
+//   node .claude/hooks/check-test-title-leakage.mjs --base <ref>          # CI mode: diff the whole range <ref>...HEAD for *.test.{ts,tsx}
 //
 // The §7 "Permitted" forms (`calls onClick`, `calls signInWithPassword on valid
 // submit`, `does not call the RPC when …`) are NOT matched by any pattern below:

--- a/.claude/hooks/check-test-title-leakage.mjs
+++ b/.claude/hooks/check-test-title-leakage.mjs
@@ -5,11 +5,11 @@
 // shifts enforcement left from CR-local/code-reviewer (reactive, on the PR) to
 // authoring time (pre-commit) + the CI lint job.
 //
-// GRANDFATHERED + DIFF-SCOPED (decision recorded on #946): only titles ADDED or
-// MODIFIED in the change under inspection are checked. Pre-existing titles —
-// e.g. the many `maps <error_token>` titles already in issue-code.test.ts and
-// sibling action tests — are left untouched. A naive whole-file scan would block
-// commits repo-wide, so this guard reads `git diff` and inspects only `+` lines.
+// GRANDFATHERED + DIFF-SCOPED (decision recorded on #946): only titles on ADDED
+// (`+`) diff lines are checked. Pre-existing titles — e.g. the many
+// `maps <token>` titles already in issue-code.test.ts and sibling action tests —
+// are left untouched. A naive whole-file scan would block commits repo-wide, so
+// this guard reads `git diff` and inspects only `+` lines.
 //
 // Two modes:
 //   node check-test-title-leakage.mjs <file> [file ...]   # staged mode (lefthook): diff each file against the index's HEAD (`git diff --cached`)
@@ -131,7 +131,8 @@ export function extractAddedTitles(diffText) {
       }
       newLine += 1
     } else if (!raw.startsWith('-') && !raw.startsWith('\\')) {
-      // Context line (only present without -U0); advance the new-file counter.
+      // Context line — unreachable under -U0 (zero context), but kept so that
+      // removing -U0 in a future edit doesn't silently break line tracking.
       newLine += 1
     }
   }
@@ -144,47 +145,45 @@ function git(args) {
 
 const TEST_FILE_RE = /\.test\.(ts|tsx)$/
 
-/**
- * Collect added titles for each mode.
- * @returns {{ file: string, line: number, title: string, label: string }[]}
- */
-function collectOffenders(args) {
+/** Match each added title in a multi-file diff against §7 (file from each `diff --git` header). */
+function offendersFromDiff(diff) {
   const offenders = []
-  const baseIdx = args.indexOf('--base')
-  if (baseIdx !== -1) {
-    // CI mode: diff the whole PR range for test files only.
-    const base = args[baseIdx + 1]
-    if (!base) {
-      console.error('✖ test-title guard: --base requires a ref argument')
-      exit(2)
+  for (const { file, body } of splitByFile(diff)) {
+    for (const t of extractAddedTitles(body)) {
+      const label = analyzeTitle(t.title)
+      if (label) offenders.push({ file, line: t.line, title: t.title, label })
     }
-    let diff = ''
-    try {
-      diff = git([
-        'diff',
-        '--diff-filter=AM',
-        '-U0',
-        `${base}...HEAD`,
-        '--',
-        '*.test.ts',
-        '*.test.tsx',
-      ])
-    } catch (err) {
-      console.error(`✖ test-title guard: git diff against ${base} failed: ${err.message}`)
-      exit(2)
-    }
-    // git diff over multiple files emits `diff --git a/<f> b/<f>` separators.
-    for (const { file, body } of splitByFile(diff)) {
-      for (const t of extractAddedTitles(body)) {
-        const label = analyzeTitle(t.title)
-        if (label) offenders.push({ file, line: t.line, title: t.title, label })
-      }
-    }
-    return offenders
   }
-  // Staged mode (lefthook): one `git diff --cached` per passed test file.
-  const files = args.filter((p) => TEST_FILE_RE.test(p))
-  for (const file of files) {
+  return offenders
+}
+
+/** CI mode: diff the whole PR range (<base>...HEAD) for test files only. */
+function collectOffendersCI(base) {
+  if (!base) {
+    console.error('✖ test-title guard: --base requires a ref argument')
+    exit(2)
+  }
+  try {
+    const diff = git([
+      'diff',
+      '--diff-filter=AM',
+      '-U0',
+      `${base}...HEAD`,
+      '--',
+      '*.test.ts',
+      '*.test.tsx',
+    ])
+    return offendersFromDiff(diff)
+  } catch (err) {
+    console.error(`✖ test-title guard: git diff against ${base} failed: ${err.message}`)
+    exit(2)
+  }
+}
+
+/** Staged mode (lefthook): one `git diff --cached` per passed test file. */
+function collectOffendersStaged(args) {
+  const offenders = []
+  for (const file of args.filter((p) => TEST_FILE_RE.test(p))) {
     let diff = ''
     try {
       diff = git(['diff', '--cached', '--diff-filter=AM', '-U0', '--', file])
@@ -197,6 +196,16 @@ function collectOffenders(args) {
     }
   }
   return offenders
+}
+
+/**
+ * Dispatch to the CI (`--base <ref>`) or staged (file args) collector.
+ * @returns {{ file: string, line: number, title: string, label: string }[]}
+ */
+function collectOffenders(args) {
+  const baseIdx = args.indexOf('--base')
+  if (baseIdx !== -1) return collectOffendersCI(args[baseIdx + 1])
+  return collectOffendersStaged(args)
 }
 
 /**

--- a/.claude/hooks/check-test-title-leakage.mjs
+++ b/.claude/hooks/check-test-title-leakage.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+// Mechanical guard (#946): forbid implementation-detail leakage in `it(...)` /
+// `test(...)` titles, per code-style.md §7 "Disallowed in `it(...)` titles".
+// The rule was tracked by the learner to count=5 across distinct commits; this
+// shifts enforcement left from CR-local/code-reviewer (reactive, on the PR) to
+// authoring time (pre-commit) + the CI lint job.
+//
+// GRANDFATHERED + DIFF-SCOPED (decision recorded on #946): only titles ADDED or
+// MODIFIED in the change under inspection are checked. Pre-existing titles —
+// e.g. the many `maps <error_token>` titles already in issue-code.test.ts and
+// sibling action tests — are left untouched. A naive whole-file scan would block
+// commits repo-wide, so this guard reads `git diff` and inspects only `+` lines.
+//
+// Two modes:
+//   node check-test-title-leakage.mjs <file> [file ...]   # staged mode (lefthook): diff each file against the index's HEAD (`git diff --cached`)
+//   node check-test-title-leakage.mjs --base <ref>          # CI mode: diff the whole range <ref>...HEAD for *.test.{ts,tsx}
+//
+// The §7 "Permitted" forms (`calls onClick`, `calls signInWithPassword on valid
+// submit`, `does not call the RPC when …`) are NOT matched by any pattern below:
+// they use the verbs `calls` / `does not call`, which none of the disallowed
+// patterns key on. The hook's unit test pins this (zero false positives on the
+// Permitted examples).
+
+import { execFileSync } from 'node:child_process'
+import { argv, exit } from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+/**
+ * The §7 disallowed-title patterns. Each entry: a regex tested against the title
+ * text (the first string argument of `it(...)` / `test(...)`), plus a short
+ * human label naming the leak. Patterns are deliberately keyed on verbs/shapes
+ * that the §7 "Permitted" forms never use, so public props (`onClick`), public
+ * SDK methods (`signInWithPassword`), and RPC names at the integration boundary
+ * are not flagged.
+ */
+export const DISALLOWED_PATTERNS = [
+  {
+    // `forwards X to <InternalName>` — names an internal helper/hook/component.
+    // Matches a camelCase name (lowercase start with an internal capital, e.g.
+    // startQuizSession) or a PascalCase name (e.g. AnswerOptions) after `to`.
+    // Plural `forwards` only — the singular `forward` is natural-language
+    // navigation ("navigates forward to ResultsPage") and is not the §7 shape.
+    re: /\bforwards\b.*\bto\s+([a-z][A-Za-z0-9]*[A-Z][A-Za-z0-9]*|[A-Z][A-Za-z0-9]+)\b/,
+    label:
+      'forwards X to <InternalName> — names an internal helper/hook/component; describe the outcome, not the call',
+  },
+  {
+    // `from <PascalCaseType>(Opts|Config|Args)` — names an internal input type.
+    re: /\bfrom\s+[A-Z][A-Za-z0-9]*(Opts|Config|Args)\b/,
+    label:
+      'from <PascalCaseType>(Opts|Config|Args) — names an internal type; describe the populated output, not the input type',
+  },
+  {
+    // `through <name>(` / `via <name>(` — names the function under test.
+    re: /\b(through|via)\s+[a-z][A-Za-z0-9]*\(/,
+    label:
+      'through/via <name>( — names the function under test; the enclosing describe() already provides that context',
+  },
+  {
+    // `(non-positive|typeof|isFinite|NaN) guard` — names a specific validator branch.
+    re: /\b(non-positive|typeof|isFinite|NaN)\s+guard\b/,
+    label:
+      '<branch> guard — names a specific || branch in a validator; describe what input is rejected, not which branch fires',
+  },
+  {
+    // `(activates|does not activate) the guard` — internal guard machinery.
+    re: /\b(activates|does not activate)\s+the\s+guard\b/,
+    label:
+      'activates/does not activate the guard — names internal guard machinery; describe the user-observable consequence',
+  },
+  {
+    // `matches <PascalCaseType>` — names a type (internal OR external library /
+    // standard, e.g. ZodError, AuthError) instead of describing the result. The
+    // §7 intent is behavior-first phrasing regardless of where the type is from.
+    re: /\bmatches\s+[A-Z][A-Za-z0-9]+/,
+    label:
+      'matches <Type> — names a type (internal or external) instead of the observable result; describe the behavior (e.g. "rejects invalid input"), not the type it matches',
+  },
+  {
+    // `maps <snake_case_token>` — a snake_case identifier (≥1 underscore): an
+    // error code (admin_not_found) or a DB field (question_type). Either names an
+    // internal token rather than the user-facing outcome of the mapping.
+    re: /\bmaps\s+[a-z][a-z0-9]*(_[a-z0-9]+)+\b/,
+    label:
+      'maps <snake_case_token> — names a snake_case identifier (error code or DB field) instead of the user-facing outcome; describe what the user sees, not the token',
+  },
+]
+
+/**
+ * Test a single title string against the §7 patterns.
+ * @param {string} title the it()/test() title text (without surrounding quotes)
+ * @returns {string | null} the matched rule label, or null if the title is clean
+ */
+export function analyzeTitle(title) {
+  for (const { re, label } of DISALLOWED_PATTERNS) {
+    if (re.test(title)) return label
+  }
+  return null
+}
+
+// Matches `it('…')`, `it("…")`, `test(`…`)`, `it.each(...)('…')` openings and
+// captures the title (group 4). Handles escaped quotes inside the title.
+const TITLE_RE = /\b(it|test)(\.[A-Za-z0-9.()'"\s,[\]-]*)?\(\s*(['"`])((?:\\.|(?!\3).)*)\3/g
+
+/**
+ * Extract every it()/test() title literal that appears on an ADDED diff line,
+ * with the new-file line number. Parses unified-diff text: hunk headers
+ * (`@@ -a,b +c,d @@`) seed the new-file line counter; only `+` lines (excluding
+ * the `+++` file header) are inspected.
+ *
+ * @param {string} diffText output of `git diff … -U0`
+ * @returns {{ line: number, title: string }[]}
+ */
+export function extractAddedTitles(diffText) {
+  const results = []
+  let newLine = 0
+  for (const raw of diffText.split('\n')) {
+    if (raw.startsWith('@@')) {
+      const m = /@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw)
+      if (m) newLine = Number(m[1])
+      continue
+    }
+    if (raw.startsWith('+++') || raw.startsWith('---')) continue
+    if (raw.startsWith('+')) {
+      const content = raw.slice(1)
+      TITLE_RE.lastIndex = 0
+      let m = TITLE_RE.exec(content)
+      while (m !== null) {
+        results.push({ line: newLine, title: m[4] })
+        m = TITLE_RE.exec(content)
+      }
+      newLine += 1
+    } else if (!raw.startsWith('-') && !raw.startsWith('\\')) {
+      // Context line (only present without -U0); advance the new-file counter.
+      newLine += 1
+    }
+  }
+  return results
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+}
+
+const TEST_FILE_RE = /\.test\.(ts|tsx)$/
+
+/**
+ * Collect added titles for each mode.
+ * @returns {{ file: string, line: number, title: string, label: string }[]}
+ */
+function collectOffenders(args) {
+  const offenders = []
+  const baseIdx = args.indexOf('--base')
+  if (baseIdx !== -1) {
+    // CI mode: diff the whole PR range for test files only.
+    const base = args[baseIdx + 1]
+    if (!base) {
+      console.error('✖ test-title guard: --base requires a ref argument')
+      exit(2)
+    }
+    let diff = ''
+    try {
+      diff = git([
+        'diff',
+        '--diff-filter=AM',
+        '-U0',
+        `${base}...HEAD`,
+        '--',
+        '*.test.ts',
+        '*.test.tsx',
+      ])
+    } catch (err) {
+      console.error(`✖ test-title guard: git diff against ${base} failed: ${err.message}`)
+      exit(2)
+    }
+    // git diff over multiple files emits `diff --git a/<f> b/<f>` separators.
+    for (const { file, body } of splitByFile(diff)) {
+      for (const t of extractAddedTitles(body)) {
+        const label = analyzeTitle(t.title)
+        if (label) offenders.push({ file, line: t.line, title: t.title, label })
+      }
+    }
+    return offenders
+  }
+  // Staged mode (lefthook): one `git diff --cached` per passed test file.
+  const files = args.filter((p) => TEST_FILE_RE.test(p))
+  for (const file of files) {
+    let diff = ''
+    try {
+      diff = git(['diff', '--cached', '--diff-filter=AM', '-U0', '--', file])
+    } catch {
+      continue // file deleted/renamed out of the index — nothing to check
+    }
+    for (const t of extractAddedTitles(diff)) {
+      const label = analyzeTitle(t.title)
+      if (label) offenders.push({ file, line: t.line, title: t.title, label })
+    }
+  }
+  return offenders
+}
+
+/**
+ * Split a multi-file `git diff` into per-file bodies keyed by the new path.
+ * @param {string} diff
+ * @returns {{ file: string, body: string }[]}
+ */
+export function splitByFile(diff) {
+  const out = []
+  let current = null
+  for (const line of diff.split('\n')) {
+    const header = /^diff --git a\/.+ b\/(.+)$/.exec(line)
+    if (header) {
+      if (current) out.push(current)
+      current = { file: header[1], body: '' }
+    } else if (current) {
+      current.body += `${line}\n`
+    }
+  }
+  if (current) out.push(current)
+  return out
+}
+
+function main() {
+  const args = argv.slice(2)
+  const offenders = collectOffenders(args)
+  if (offenders.length > 0) {
+    console.error(
+      '✖ test-title impl-leakage guard (code-style.md §7): implementation detail in newly-added test title(s):',
+    )
+    for (const o of offenders) {
+      console.error(`  ${o.file}:${o.line}  '${o.title}'`)
+      console.error(`      → ${o.label}`)
+    }
+    console.error(
+      '\nRename to describe externally observable behavior. See code-style.md §7 "Disallowed in it(...) titles".',
+    )
+    exit(1)
+  }
+  console.log('✓ test-title impl-leakage guard: no new violating titles')
+}
+
+// Run only when executed directly (not when the test imports the helpers).
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  main()
+}

--- a/.claude/hooks/check-test-title-leakage.mjs
+++ b/.claude/hooks/check-test-title-leakage.mjs
@@ -164,14 +164,17 @@ function collectOffendersCI(base) {
     exit(2)
   }
   try {
+    // git pathspec `*` already matches across `/` (no :(glob) magic), so a bare
+    // `*.test.ts` recurses into subdirs — but spell it `**/*.test.ts` so the
+    // recursion is explicit to a reader used to shell-glob (root-only) semantics.
     const diff = git([
       'diff',
       '--diff-filter=AM',
       '-U0',
       `${base}...HEAD`,
       '--',
-      '*.test.ts',
-      '*.test.tsx',
+      '**/*.test.ts',
+      '**/*.test.tsx',
     ])
     return offendersFromDiff(diff)
   } catch (err) {

--- a/.claude/hooks/check-test-title-leakage.mjs
+++ b/.claude/hooks/check-test-title-leakage.mjs
@@ -103,10 +103,15 @@ export function analyzeTitle(title) {
 const TITLE_RE = /\b(it|test)(\.[A-Za-z0-9.()'"\s,[\]-]*)?\(\s*(['"`])((?:\\.|(?!\3).)*)\3/g
 
 /**
- * Extract every it()/test() title literal that appears on an ADDED diff line,
+ * Extract every it()/test() title literal that appears on ADDED diff lines,
  * with the new-file line number. Parses unified-diff text: hunk headers
- * (`@@ -a,b +c,d @@`) seed the new-file line counter; only `+` lines (excluding
- * the `+++` file header) are inspected.
+ * (`@@ -a,b +c,d @@`) seed the new-file line counter.
+ *
+ * A contiguous run of `+` lines is joined into one buffer before matching, so a
+ * split-form call — `it(` on one added line and the `'title'` literal on the
+ * next — is still detected (TITLE_RE's `\s*` between `(` and the quote spans the
+ * joined newline). The match is attributed to the source line where the
+ * `it(`/`test(` token starts (newlines before the match index index the run).
  *
  * @param {string} diffText output of `git diff … -U0`
  * @returns {{ line: number, title: string }[]}
@@ -114,28 +119,40 @@ const TITLE_RE = /\b(it|test)(\.[A-Za-z0-9.()'"\s,[\]-]*)?\(\s*(['"`])((?:\\.|(?
 export function extractAddedTitles(diffText) {
   const results = []
   let newLine = 0
+  /** @type {{ text: string, line: number }[]} current contiguous run of added lines */
+  let run = []
+  const flush = () => {
+    if (run.length === 0) return
+    const buffer = run.map((r) => r.text).join('\n')
+    TITLE_RE.lastIndex = 0
+    let m = TITLE_RE.exec(buffer)
+    while (m !== null) {
+      // The line of the match = the run entry at the count of newlines before it.
+      const nl = (buffer.slice(0, m.index).match(/\n/g) || []).length
+      results.push({ line: run[nl].line, title: m[4] })
+      m = TITLE_RE.exec(buffer)
+    }
+    run = []
+  }
   for (const raw of diffText.split('\n')) {
     if (raw.startsWith('@@')) {
+      flush() // a new hunk breaks the added run
       const m = /@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw)
       if (m) newLine = Number(m[1])
       continue
     }
     if (raw.startsWith('+++') || raw.startsWith('---')) continue
     if (raw.startsWith('+')) {
-      const content = raw.slice(1)
-      TITLE_RE.lastIndex = 0
-      let m = TITLE_RE.exec(content)
-      while (m !== null) {
-        results.push({ line: newLine, title: m[4] })
-        m = TITLE_RE.exec(content)
-      }
+      run.push({ text: raw.slice(1), line: newLine })
       newLine += 1
-    } else if (!raw.startsWith('-') && !raw.startsWith('\\')) {
-      // Context line — unreachable under -U0 (zero context), but kept so that
-      // removing -U0 in a future edit doesn't silently break line tracking.
-      newLine += 1
+    } else if (!raw.startsWith('\\')) {
+      // A removed line (or, only without -U0, a context line) breaks the added
+      // run. Context lines also advance the new-file counter; removed lines do not.
+      flush()
+      if (!raw.startsWith('-')) newLine += 1
     }
   }
+  flush()
   return results
 }
 
@@ -190,8 +207,14 @@ function collectOffendersStaged(args) {
     let diff = ''
     try {
       diff = git(['diff', '--cached', '--diff-filter=AM', '-U0', '--', file])
-    } catch {
-      continue // file deleted/renamed out of the index — nothing to check
+    } catch (err) {
+      // Fail CLOSED: a `git diff --cached` failure must not silently skip
+      // enforcement (a real git error would let a violating title through).
+      // A staged-deleted/renamed file does NOT error here — it yields an empty
+      // or deletion diff with no added lines — so reaching this catch means an
+      // actual git failure worth surfacing.
+      console.error(`✖ test-title guard: git diff --cached for ${file} failed: ${err.message}`)
+      exit(2)
     }
     for (const t of extractAddedTitles(diff)) {
       const label = analyzeTitle(t.title)

--- a/.claude/hooks/check-test-title-leakage.test.mjs
+++ b/.claude/hooks/check-test-title-leakage.test.mjs
@@ -161,6 +161,41 @@ test('extractAddedTitles does not join across a removed line', () => {
   assert.deepEqual(extractAddedTitles(diff), [])
 })
 
+test('extractAddedTitles does not false-positive when a non-whitespace added line separates it( from the title', () => {
+  // TITLE_RE uses \s* between `(` and the opening quote, so a non-whitespace
+  // line inside the run must NOT produce a match — the run is buffered but the
+  // regex boundary rejects it.
+  const diff = [
+    '@@ -0,0 +10,4 @@',
+    '+  it(',
+    '+    someCode()', // non-whitespace added line — NOT whitespace, so \s* cannot span it
+    "+    'maps admin_not_found',",
+    '+    () => {}))',
+  ].join('\n')
+  assert.deepEqual(extractAddedTitles(diff), [])
+})
+
+test('extractAddedTitles detects two split-form titles in one contiguous run with correct line attribution', () => {
+  // Both titles must be found and attributed to the line where their `it(` starts.
+  const diff = [
+    '@@ -0,0 +1,6 @@',
+    '+  it(',
+    "+    'maps admin_not_found',",
+    '+    () => {})',
+    '+  it(',
+    "+    'forwards calcMode to startQuizSession',",
+    '+    () => {})',
+  ].join('\n')
+  const found = extractAddedTitles(diff)
+  assert.equal(found.length, 2)
+  assert.equal(found[0].title, 'maps admin_not_found')
+  assert.equal(found[0].line, 1) // first `it(` is on new-file line 1
+  assert.equal(found[1].title, 'forwards calcMode to startQuizSession')
+  assert.equal(found[1].line, 4) // second `it(` starts on new-file line 4
+  assert.notEqual(analyzeTitle(found[0].title), null)
+  assert.notEqual(analyzeTitle(found[1].title), null)
+})
+
 // --- splitByFile ----------------------------------------------------------
 
 test('splitByFile separates a multi-file diff by new path', () => {

--- a/.claude/hooks/check-test-title-leakage.test.mjs
+++ b/.claude/hooks/check-test-title-leakage.test.mjs
@@ -144,6 +144,27 @@ test('extractAddedTitles handles the test() and test.each() function forms', () 
   )
 })
 
+test('extractAddedTitles handles the it.only/it.skip/test.concurrent modifier forms', () => {
+  // The guard must still catch a disallowed title behind a test modifier —
+  // `it.only`/`it.skip` are common in real test files. TITLE_RE's method-chain
+  // group spans the modifier; this pins it against a future regex regression.
+  const diff = [
+    '@@ -0,0 +1,3 @@',
+    "+  it.only('maps admin_error', () => {})",
+    "+  it.skip('forwards calcMode to startQuizSession', () => {})",
+    "+  test.concurrent('renders the chart', () => {})",
+  ].join('\n')
+  const found = extractAddedTitles(diff)
+  assert.deepEqual(
+    found.map((f) => f.title),
+    ['maps admin_error', 'forwards calcMode to startQuizSession', 'renders the chart'],
+  )
+  // The two disallowed titles are still flagged through the modifier; the third is clean.
+  assert.notEqual(analyzeTitle(found[0].title), null)
+  assert.notEqual(analyzeTitle(found[1].title), null)
+  assert.equal(analyzeTitle(found[2].title), null)
+})
+
 test('extractAddedTitles detects a split-form title (it( and title on separate added lines)', () => {
   const diff = ['@@ -0,0 +5,3 @@', '+  it(', "+    'maps admin_not_found',", '+    () => {})'].join(
     '\n',

--- a/.claude/hooks/check-test-title-leakage.test.mjs
+++ b/.claude/hooks/check-test-title-leakage.test.mjs
@@ -1,0 +1,119 @@
+// Unit tests for the §7 test-title impl-leakage guard (#946).
+// Run: node --test .claude/hooks/check-test-title-leakage.test.mjs
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { analyzeTitle, extractAddedTitles, splitByFile } from './check-test-title-leakage.mjs'
+
+// --- Disallowed §7 forms: each MUST be flagged ----------------------------
+
+const DISALLOWED = [
+  // forwards X to <InternalName> (camelCase + PascalCase)
+  'forwards calcMode to startQuizSession',
+  'forwards the answer to AnswerOptions',
+  // from <PascalCaseType>(Opts|Config|Args)
+  'builds the payload from QuizConfig',
+  'reads filters from StartExamArgs',
+  // through/via <name>(
+  'rejects empty input through validateInput(',
+  'normalizes via formatScore(',
+  // <branch> guard
+  'rejects bad count with the non-positive guard',
+  'handles the typeof guard',
+  'handles the NaN guard',
+  // activates/does not activate the guard
+  'activates the guard when answers exist',
+  'does not activate the guard when empty',
+  // matches <Type> — internal OR external named types are both flagged (§7 intent
+  // is behavior-first phrasing regardless of where the type comes from).
+  'matches QuizSessionResult',
+  'value matches AuthError',
+  // maps <snake_case_token> — error codes AND DB field names are both flagged.
+  'maps admin_not_found',
+  'maps not_authenticated to a friendly message',
+  'maps question_type to the dropdown',
+]
+
+for (const title of DISALLOWED) {
+  test(`flags disallowed title: "${title}"`, () => {
+    assert.notEqual(analyzeTitle(title), null, `expected "${title}" to be flagged`)
+  })
+}
+
+// --- §7 Permitted forms + ordinary behavior titles: MUST NOT be flagged ---
+
+const PERMITTED = [
+  // The explicit §7 "Permitted" examples (public prop / public SDK / RPC boundary).
+  'calls onClick when the button is clicked',
+  'calls signInWithPassword on valid submit',
+  'does not call the RPC when the input is empty',
+  // Ordinary behavior-first titles that resemble — but are not — the disallowed shapes.
+  'schedules a shorter review interval when the answer is wrong',
+  'maps the response to display rows', // "maps the" — not a snake_case token
+  'matches the snapshot', // "matches the" — lowercase, not a PascalCase type
+  'renders the question card',
+  'forwards the click to the parent', // "to the parent" — not an internal Name
+  'navigates forward to ResultsPage', // singular "forward" — natural-language navigation, not the §7 `forwards` shape
+  'reads the count from the server', // "from the" — no PascalType+Opts/Config/Args
+  'shows a guard rail on the chart', // "guard" not in a flagged phrase
+]
+
+for (const title of PERMITTED) {
+  test(`does not flag permitted/behavior title: "${title}"`, () => {
+    assert.equal(analyzeTitle(title), null, `expected "${title}" NOT to be flagged`)
+  })
+}
+
+// --- extractAddedTitles: diff-scoping ------------------------------------
+
+test('extractAddedTitles picks up only added it()/test() titles with new-file line numbers', () => {
+  const diff = [
+    '@@ -10,0 +11,2 @@',
+    "+  it('maps admin_not_found', () => {",
+    "+  it('calls onClick when clicked', () => {",
+  ].join('\n')
+  const found = extractAddedTitles(diff)
+  assert.equal(found.length, 2)
+  assert.deepEqual(found[0], { line: 11, title: 'maps admin_not_found' })
+  assert.deepEqual(found[1], { line: 12, title: 'calls onClick when clicked' })
+})
+
+test('extractAddedTitles ignores removed and context lines', () => {
+  const diff = [
+    '@@ -5,2 +5,1 @@',
+    "-  it('forwards calcMode to startQuizSession', () => {", // removed — must be ignored
+    "   it('renders the card', () => {", // context (no +) — must be ignored
+  ].join('\n')
+  assert.deepEqual(extractAddedTitles(diff), [])
+})
+
+test('extractAddedTitles handles double and template quotes', () => {
+  const diff = [
+    '@@ -0,0 +1,2 @@',
+    '+  it("maps not_authenticated", () => {',
+    '+  test(`matches QuizConfig`, () => {}',
+  ].join('\n')
+  const found = extractAddedTitles(diff)
+  assert.deepEqual(
+    found.map((f) => f.title),
+    ['maps not_authenticated', 'matches QuizConfig'],
+  )
+})
+
+// --- splitByFile ----------------------------------------------------------
+
+test('splitByFile separates a multi-file diff by new path', () => {
+  const diff = [
+    'diff --git a/a.test.ts b/a.test.ts',
+    '@@ -0,0 +1 @@',
+    "+  it('maps x_y', () => {})",
+    'diff --git a/b.test.ts b/b.test.ts',
+    '@@ -0,0 +1 @@',
+    "+  it('ok', () => {})",
+  ].join('\n')
+  const parts = splitByFile(diff)
+  assert.equal(parts.length, 2)
+  assert.equal(parts[0].file, 'a.test.ts')
+  assert.equal(parts[1].file, 'b.test.ts')
+  assert.equal(extractAddedTitles(parts[0].body)[0].title, 'maps x_y')
+})

--- a/.claude/hooks/check-test-title-leakage.test.mjs
+++ b/.claude/hooks/check-test-title-leakage.test.mjs
@@ -100,6 +100,37 @@ test('extractAddedTitles handles double and template quotes', () => {
   )
 })
 
+test('extractAddedTitles handles escaped quotes inside a title', () => {
+  // The TITLE_RE `\\.` branch must consume an escaped delimiter so the title is
+  // not truncated — otherwise a violation could slip past as a false negative.
+  const diff = '@@ -0,0 +1 @@\n+  it("maps not_found when user\\"s token expired", () => {})'
+  const found = extractAddedTitles(diff)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].title, 'maps not_found when user\\"s token expired')
+  assert.notEqual(analyzeTitle(found[0].title), null) // the maps pattern still fires
+})
+
+test('extractAddedTitles handles the it.each(...) form', () => {
+  const diff = "@@ -0,0 +1 @@\n+  it.each([1, 2])('maps code_not_found for %s', () => {})"
+  const found = extractAddedTitles(diff)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].title, 'maps code_not_found for %s')
+})
+
+test('extractAddedTitles tracks line numbers across a second hunk', () => {
+  const diff = [
+    '@@ -1,0 +5,1 @@',
+    "+  it('maps first_token', () => {})",
+    '@@ -10,0 +20,1 @@',
+    "+  it('maps second_token', () => {})",
+  ].join('\n')
+  const found = extractAddedTitles(diff)
+  assert.deepEqual(found, [
+    { line: 5, title: 'maps first_token' },
+    { line: 20, title: 'maps second_token' }, // counter reset by the 2nd @@ header
+  ])
+})
+
 // --- splitByFile ----------------------------------------------------------
 
 test('splitByFile separates a multi-file diff by new path', () => {

--- a/.claude/hooks/check-test-title-leakage.test.mjs
+++ b/.claude/hooks/check-test-title-leakage.test.mjs
@@ -144,6 +144,23 @@ test('extractAddedTitles handles the test() and test.each() function forms', () 
   )
 })
 
+test('extractAddedTitles detects a split-form title (it( and title on separate added lines)', () => {
+  const diff = ['@@ -0,0 +5,3 @@', '+  it(', "+    'maps admin_not_found',", '+    () => {})'].join(
+    '\n',
+  )
+  const found = extractAddedTitles(diff)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].title, 'maps admin_not_found')
+  assert.equal(found[0].line, 5) // attributed to the line where `it(` starts
+  assert.notEqual(analyzeTitle(found[0].title), null) // still flagged
+})
+
+test('extractAddedTitles does not join across a removed line', () => {
+  // A removed `it(` followed by an added title literal must NOT be stitched into a match.
+  const diff = ['@@ -5,1 +5,1 @@', '-  it(', "+    'maps admin_not_found',"].join('\n')
+  assert.deepEqual(extractAddedTitles(diff), [])
+})
+
 // --- splitByFile ----------------------------------------------------------
 
 test('splitByFile separates a multi-file diff by new path', () => {

--- a/.claude/hooks/check-test-title-leakage.test.mjs
+++ b/.claude/hooks/check-test-title-leakage.test.mjs
@@ -131,6 +131,19 @@ test('extractAddedTitles tracks line numbers across a second hunk', () => {
   ])
 })
 
+test('extractAddedTitles handles the test() and test.each() function forms', () => {
+  const diff = [
+    '@@ -0,0 +1,2 @@',
+    "+  test('maps admin_error', () => {})",
+    "+  test.each([1])('matches ConfigOpts', () => {})",
+  ].join('\n')
+  const found = extractAddedTitles(diff)
+  assert.deepEqual(
+    found.map((f) => f.title),
+    ['maps admin_error', 'matches ConfigOpts'],
+  )
+})
+
 // --- splitByFile ----------------------------------------------------------
 
 test('splitByFile separates a multi-file diff by new path', () => {
@@ -147,4 +160,21 @@ test('splitByFile separates a multi-file diff by new path', () => {
   assert.equal(parts[0].file, 'a.test.ts')
   assert.equal(parts[1].file, 'b.test.ts')
   assert.equal(extractAddedTitles(parts[0].body)[0].title, 'maps x_y')
+})
+
+test('integration: detects only the violating title across multiple files', () => {
+  const diff = [
+    'diff --git a/a.test.ts b/a.test.ts',
+    '@@ -0,0 +1 @@',
+    "+  it('calls onClick when clicked', () => {})", // clean (permitted)
+    'diff --git a/b.test.ts b/b.test.ts',
+    '@@ -0,0 +1 @@',
+    "+  it('maps admin_error', () => {})", // violation
+  ].join('\n')
+  const violations = splitByFile(diff)
+    .flatMap((p) => extractAddedTitles(p.body).map((t) => ({ ...t, file: p.file })))
+    .filter((t) => analyzeTitle(t.title) !== null)
+  assert.equal(violations.length, 1)
+  assert.equal(violations[0].title, 'maps admin_error')
+  assert.equal(violations[0].file, 'b.test.ts')
 })

--- a/.claude/rules/agent-coderabbit-sync.md
+++ b/.claude/rules/agent-coderabbit-sync.md
@@ -12,6 +12,7 @@ Run this agent only when one or more of these files change:
 - `docs/security.md`
 - `biome.json`
 - `CLAUDE.md`
+- A new `.claude/hooks/*.mjs` mechanical guard wired into `lefthook.yml` (a guard that pattern-matches source for a rule CodeRabbit also enforces). The guard's detection pattern must be mirrored into `.coderabbit.yaml` `path_instructions` **in the same commit that adds the guard** — not deferred to a follow-up. Promoted at count=2: `check-soft-delete-guard.mjs` (#925 Phase 3, `.coderabbit.yaml` entry slipped to Phase 4) and `check-test-title-leakage.mjs` (#946, the `maps <snake_case_token>` pattern missing from the guard's commit). Both prior instances are already reconciled — no sweep outstanding.
 
 Do NOT run on every commit — only when the above files are in the diff.
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -600,7 +600,8 @@ it('schedules a shorter review interval when the answer is wrong', () => { ... }
 | `through <camelCaseName>(` or `via <camelCaseName>(` | Names the function under test. The enclosing `describe(...)` already provides that context. |
 | `(non-positive\|typeof\|isFinite\|NaN) guard` | Names a specific `\|\|` branch in a validator. Describe what input is rejected, not which branch fires. |
 | `(activates\|does not activate) the guard` | Refers to internal navigation/validation guard machinery. Describe the user-observable consequence (e.g., "does not warn when no answers exist"). |
-| `matches <PascalCaseType>` / `matches <internal helper>` | Asserts congruence with an internal type/helper. Describe the externally observable behavior. |
+| `matches <PascalCaseType>` (internal helper OR external library/standard type, e.g. `ZodError`) | Names a type instead of describing the result. Describe the externally observable behavior (e.g. "rejects invalid input"), not the type it matches. |
+| `maps <snake_case_token>` (e.g. `maps admin_not_found`, `maps question_type`) | Names a snake_case identifier — an error code (RPC `RAISE`/SDK code) or a DB field — not the user-facing result. Describe what the user sees (e.g. "shows a not-found message when the student is soft-deleted"). |
 
 **Permitted** (these are *contracts*, not impl):
 - `it('calls onClick when the button is clicked', ...)` — `onClick` is a public prop / public callback contract.
@@ -608,6 +609,8 @@ it('schedules a shorter review interval when the answer is wrong', () => { ... }
 - `it('does not call the RPC when the input is empty', ...)` — describes the externally observable side-effect.
 
 The distinction: external contracts (props, public callbacks, public SDK calls, RPC names visible at the integration boundary) are part of behavior. Internal helpers, validator branches, and private types are implementation.
+
+A mechanical guard enforces this at pre-commit + CI: `.claude/hooks/check-test-title-leakage.mjs` (#946). It is **diff-scoped and grandfathered** — it flags only `it()`/`test()` titles on ADDED (`+`) diff lines, so the many pre-existing `maps <token>` titles do not block commits; only newly-written titles are caught. The Permitted forms above are never flagged (the patterns key on `forwards`/`from`/`maps`/`matches`, not the `calls`/`does not call` verbs the contracts use).
 
 ### Test Comments: Audit After Renaming
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -610,7 +610,7 @@ it('schedules a shorter review interval when the answer is wrong', () => { ... }
 
 The distinction: external contracts (props, public callbacks, public SDK calls, RPC names visible at the integration boundary) are part of behavior. Internal helpers, validator branches, and private types are implementation.
 
-A mechanical guard enforces this at pre-commit + CI: `.claude/hooks/check-test-title-leakage.mjs` (#946). It is **diff-scoped and grandfathered** — it flags only `it()`/`test()` titles on ADDED (`+`) diff lines, so the many pre-existing `maps <token>` titles do not block commits; only newly-written titles are caught. The Permitted forms above are never flagged (the patterns key on `forwards`/`from`/`maps`/`matches`, not the `calls`/`does not call` verbs the contracts use).
+A mechanical guard enforces this at pre-commit + CI: the `check-test-title-leakage.mjs` hook (PR #946). It is **diff-scoped and grandfathered** — it flags only `it()` / `test()` / `it.each()` / `test.each()` titles on ADDED (`+`) diff lines, so the many pre-existing `maps <token>` titles do not block commits; only newly-written titles are caught. The Permitted forms above are never flagged (the patterns key on `forwards`/`from`/`maps`/`matches`, not the `calls`/`does not call` verbs the contracts use).
 
 ### Test Comments: Audit After Renaming
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -217,9 +217,10 @@ reviews:
           - '(activates|does not activate) the guard' — internal navigation/
             validation guard machinery. Describe the user-observable consequence
             (e.g., 'does not warn when no answers exist').
-          - 'matches <PascalCaseType>' or 'matches <internal helper>' — asserts
-            congruence with internal type/helper. Describe externally observable
-            behavior.
+          - 'matches <PascalCaseType>' (internal OR external library/standard
+            type, e.g. ZodError, AuthError) — names a type instead of describing
+            the result. Describe externally observable behavior (e.g. 'rejects
+            invalid input'), not the type it matches.
           - 'maps <snake_case_token>' (e.g. 'maps admin_not_found', 'maps
             question_type') — names a snake_case identifier (an error code like
             an RPC RAISE/SDK code, or a DB field) instead of the user-facing

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -220,6 +220,10 @@ reviews:
           - 'matches <PascalCaseType>' or 'matches <internal helper>' — asserts
             congruence with internal type/helper. Describe externally observable
             behavior.
+          - 'maps <snake_case_token>' (e.g. 'maps admin_not_found', 'maps
+            question_type') — names a snake_case identifier (an error code like
+            an RPC RAISE/SDK code, or a DB field) instead of the user-facing
+            result. Describe what the user sees, not the token.
           Permitted (these are public contracts, not impl):
           - 'calls onClick when the button is clicked' — onClick is a public prop.
           - 'calls signInWithPassword on valid submit' — public SDK method.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # full history so the test-title guard (#946) can diff against the PR base
+          persist-credentials: false # the guard only reads git history; no step needs write access
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # full history so the test-title guard (#946) can diff against the PR base
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:
@@ -46,6 +48,16 @@ jobs:
 
       - name: Soft-delete column guard — unit test
         run: node --test .claude/hooks/check-soft-delete-guard.test.mjs
+
+      # §7 test-title impl-leakage guard (#946). Diff-scoped + grandfathered:
+      # only titles ADDED in the PR are checked (PR events only — push to master
+      # has no PR base). fetch-depth:0 above makes the base SHA available.
+      - name: Test-title impl-leakage guard (PR diff, code-style.md §7)
+        if: github.event_name == 'pull_request'
+        run: node .claude/hooks/check-test-title-leakage.mjs --base ${{ github.event.pull_request.base.sha }}
+
+      - name: Test-title impl-leakage guard — unit test
+        run: node --test .claude/hooks/check-test-title-leakage.test.mjs
 
   type-check:
     name: Type Check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ Never push without all agents reporting clean.
 
 ## QA pipeline
 Lefthook enforces mechanical gates (blocking):
-- **pre-commit:** biome lint/format + type-check + soft-delete column guard (`.claude/hooks/check-soft-delete-guard.mjs`, glob-gated to staged `.ts`/`.tsx`; also runs in the CI lint job) — unit tests intentionally NOT in pre-commit; lefthook.yml runs fast gates only and the full suite runs in CI
+- **pre-commit:** biome lint/format + type-check + soft-delete column guard (`.claude/hooks/check-soft-delete-guard.mjs`, glob-gated to staged `.ts`/`.tsx`; also runs in the CI lint job) + test-title impl-leakage guard (`.claude/hooks/check-test-title-leakage.mjs`, glob-gated to staged `*.test.{ts,tsx}`; diff-scoped + grandfathered — flags only NEWLY-added `it()`/`test()` titles violating code-style.md §7; also runs in the CI lint job against the PR base) — unit tests intentionally NOT in pre-commit; lefthook.yml runs fast gates only and the full suite runs in CI
 - **commit-msg:** conventional commit format
 - **pre-push:** security-auditor agent + dependency audit
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,6 +27,12 @@ pre-commit:
     soft-delete-guard:
       glob: "*.{ts,tsx}"
       run: node .claude/hooks/check-soft-delete-guard.mjs {staged_files}
+    # Forbid impl-detail leakage in NEWLY-added it()/test() titles (code-style.md §7, #946).
+    # Diff-scoped + grandfathered: the script reads `git diff --cached` and checks only
+    # added titles, so pre-existing `maps <token>` titles never block a commit.
+    test-title-leakage:
+      glob: "*.test.{ts,tsx}"
+      run: node .claude/hooks/check-test-title-leakage.mjs {staged_files}
     # Full test suite runs in CI (ci.yml). Pre-commit runs fast gates only.
     # test:
     #   run: pnpm test


### PR DESCRIPTION
## Summary

The learner tracked internal-symbol leakage in `it()`/`test()` titles (code-style.md §7) to **count=5** across distinct commits. Enforcement was reactive (CR-local / code-reviewer on the PR); this shifts it left to authoring time + the CI lint job.

New `.claude/hooks/check-test-title-leakage.mjs` (mirrors the `check-soft-delete-guard.mjs` model):
- **Grandfathered + diff-scoped** (decision chosen with the maintainer): reads `git diff` and checks only titles on **ADDED (`+`) lines**, so the ~26 pre-existing `maps <token>` titles never block a commit — only newly-written titles are caught.
- Two modes: **staged** (lefthook, `git diff --cached` per `*.test.{ts,tsx}`) and **`--base <ref>`** (CI, diffs the PR range).
- Flags the §7 disallowed forms (`forwards`-to-Internal, `from`-PascalType(Opts|Config|Args), `through`/`via`-fn(, `<branch> guard`, `activates the guard`, `matches <Type>`, `maps <snake_case_token>`). The §7 **Permitted** forms (`calls onClick` / `calls signInWithPassword` / `does not call the RPC`) are never matched — the patterns key on different verbs.

## Wiring
- `lefthook.yml` pre-commit `test-title-leakage` (glob `*.test.{ts,tsx}`).
- `ci.yml` lint job: `fetch-depth: 0` + `persist-credentials: false` on checkout, a PR-only `--base` step, and the unit-test step — matching the soft-delete guard's dual placement.
- `code-style.md` §7: added the `maps <snake_case_token>` row + a mechanical-guard enforcement note; `CLAUDE.md` §QA-pipeline updated; `.coderabbit.yaml` mirrors the patterns; `agent-coderabbit-sync.md` gains a trigger (learner count=2 promotion: a new hook guard must sync `.coderabbit.yaml` in the same commit).

## Verification
- **36 hook unit tests** pass (every disallowed form flagged, every Permitted/ordinary title clean, diff-parsing incl. escaped quotes / `it.each` / `test.each` / multi-hunk).
- **Baseline:** 26 / 4495 existing titles match — all grandfathered (zero block).
- **E2E (manual):** new `maps admin_not_found` blocked via `lefthook run pre-commit` on a nested file; editing a file with existing `maps X` titles does NOT re-flag them.
- `pnpm lint` / `check-types` clean · full web suite **4121 pass** · `pnpm build` succeeds.
- CR-local: 2 consecutive clean rounds (floor met). Two CR "critical" glob/pathspec findings were **empirically disproven** (git & lefthook globs already recurse) and skipped.

## Deferred / skipped
- **#961** — repo-wide `persist-credentials: false` sweep of the other ~16 CI checkouts (separate concern, needs per-job audit).
- `through/via` requires a literal `(` in the title — intentional, matches the documented §7 shape (SKIP).

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated “test-title impl-leakage” guard that validates newly added `it(...)`/`test(...)` titles in staged changes and PRs.
* **Tests**
  * Added unit tests covering title parsing, diff scoping, and per-file reporting.
* **Documentation**
  * Updated code style rules and QA pipeline docs to clarify the new title restrictions and how the guard behaves.
* **Chores**
  * Extended pre-commit, CI lint steps, and sync trigger patterns to run the guard consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->