### PR TITLE
fix(924): synchronous useRef re-entry guards on multi-source submit handlers + §6 rule

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -566,6 +566,32 @@ function useExamNavigation() {
 
 The same applies to any scalar captured across a hook split (e.g. a `currentIndex` read in a save handler defined in a different hook). When in doubt: if a value is read inside a callback and also changes via `setState`, mirror it. Promoted at count=2 — `df5d354` (stale `currentIndex` in `handleSave` after a hook split) and `e137e93` (stale `feedback` Map read in `wrappedNavigateTo`'s checkpoint).
 
+### Synchronous Re-Entry Guard for Multi-Source Async Handlers
+
+An async submit/close/finish handler that can fire from **more than one source** — a countdown/timer auto-fire, a manual button click, a keyboard shortcut, a form `onSubmit` — must gate re-entry with a **synchronous `useRef` one-shot lock**, checked-and-set before the first `await`/transition. Async React state — a `useState` loading flag, `useTransition`'s `isPending` — is **not** a valid re-entry lock: between the triggering event and the state commit there is a window where two sources both read the stale "not pending" value and both run the action (double submit, double RPC, double navigation). The on-screen `disabled={pending}` attribute only blocks the *button* path; a timer or programmatic caller bypasses it entirely.
+
+```tsx
+// ❌ WRONG — isPending/loading is async; a timer fire + a click in the same tick both pass
+const [isPending, startTransition] = useTransition()
+function handleSubmit() {
+  if (isPending) return          // stale until React commits — both callers proceed
+  startTransition(() => submit())
+}
+
+// ✅ CORRECT — useRef is synchronous; the second caller sees current=true immediately
+const submittedRef = useRef(false)
+function handleSubmit() {
+  if (submittedRef.current) return
+  submittedRef.current = true     // set before any await/transition
+  startTransition(async () => {
+    try { await submit() }
+    catch { submittedRef.current = false }   // reset ONLY on the retryable failure path
+  })
+}
+```
+
+Reset `ref.current = false` on the **retryable failure path** (a save/post the user can re-attempt, a rejected exam code). **Omit the reset** when the action is terminal — an exam start that navigates away, a final submit that closes the dialog — so a late duplicate can't re-fire after success. For a validator that early-returns *before* starting the action, set the ref **after** validation passes (never on the early-return), or a corrected re-attempt is wrongly blocked. Promoted at count=3 — quiz session hooks, the stale-closure ref-mirroring sibling above, and the VFR-RT runner Finish race (timer `onExpired` + manual click) in PR #923. The mechanical analog: prefer one `*Ref` one-shot over an `isPending`/`loading`-only guard on any handler reachable from a timer.
+
 ---
 
 ## 7. Testing Rules

--- a/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
@@ -152,4 +152,67 @@ describe('CodeEntryModal', () => {
     )
     expect(mockRouterPush).not.toHaveBeenCalled()
   })
+
+  // ---- Synchronous re-entry guard -----------------------------------------
+
+  it('starts the exam once when the form is submitted twice before the action resolves', async () => {
+    // Never-resolving promise keeps isPending true so the button stays in the
+    // loading state, simulating a double-submit race.
+    mockStartInternalExam.mockReturnValue(new Promise(() => {}))
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    await userEvent.type(input, 'ABCD2345')
+
+    const form = screen.getByTestId('code-entry-form')
+    // Dispatch two submit events back-to-back without awaiting the transition.
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+
+    await waitFor(() => expect(mockStartInternalExam).toHaveBeenCalledTimes(1))
+  })
+
+  it('allows a retry after the action returns a failure response', async () => {
+    // First call fails, second call also fails — both must go through.
+    mockStartInternalExam
+      .mockResolvedValueOnce({ success: false, error: 'Code expired.' })
+      .mockResolvedValueOnce({ success: false, error: 'Code expired again.' })
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    await userEvent.type(input, 'ABCD2345')
+
+    const form = screen.getByTestId('code-entry-form')
+
+    // First attempt — action returns a failure. Dispatch form submit and wait for
+    // the error alert to appear (confirming the action ran and setError was called).
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/code expired/i))
+    expect(mockStartInternalExam).toHaveBeenCalledTimes(1)
+
+    // Lock resets on failure — second attempt dispatched after the alert confirms
+    // the transition settled must also invoke the action.
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+    await waitFor(() => expect(mockStartInternalExam).toHaveBeenCalledTimes(2))
+  })
+
+  it('allows a retry after the action throws', async () => {
+    mockStartInternalExam
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({ success: false, error: 'Code expired.' })
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    await userEvent.type(input, 'ABCD2345')
+
+    const form = screen.getByTestId('code-entry-form')
+
+    // First attempt — action throws. Wait for the error alert (transition settled).
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/something went wrong/i),
+    )
+    expect(mockStartInternalExam).toHaveBeenCalledTimes(1)
+
+    // Lock resets after a throw — second attempt must proceed.
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+    await waitFor(() => expect(mockStartInternalExam).toHaveBeenCalledTimes(2))
+  })
 })

--- a/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
@@ -228,28 +228,34 @@ describe('CodeEntryModal', () => {
       passMark: 75,
       startedAt: '2026-04-29T10:00:00.000Z',
     })
+    // mockImplementationOnce throws on the FIRST setItem only; the retry's setItem
+    // falls through to the real impl. restore in finally so an assertion failure
+    // before the end can't leak the global prototype spy into later tests.
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(() => {
       throw new DOMException('QuotaExceededError')
     })
 
-    renderModal()
-    const input = screen.getByTestId('code-input') as HTMLInputElement
-    await userEvent.type(input, 'ABCD2345')
+    try {
+      renderModal()
+      const input = screen.getByTestId('code-input') as HTMLInputElement
+      await userEvent.type(input, 'ABCD2345')
 
-    const form = screen.getByTestId('code-entry-form')
-    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+      const form = screen.getByTestId('code-entry-form')
+      form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
 
-    // Error banner shown — router must NOT have been called (no navigation on handoff failure).
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent(/unable to start internal exam/i),
-    )
-    expect(mockRouterPush).not.toHaveBeenCalled()
-    expect(mockStartInternalExam).toHaveBeenCalledTimes(1)
+      // Error banner shown — router must NOT have been called (no navigation on handoff failure).
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent(/unable to start internal exam/i),
+      )
+      expect(mockRouterPush).not.toHaveBeenCalled()
+      expect(mockStartInternalExam).toHaveBeenCalledTimes(1)
 
-    // Lock is reset — student can retry; this time sessionStorage succeeds.
-    setItemSpy.mockRestore()
-    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
-    await waitFor(() => expect(mockStartInternalExam).toHaveBeenCalledTimes(2))
-    await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/app/quiz/session'))
+      // Lock is reset — student can retry; this time sessionStorage succeeds.
+      form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+      await waitFor(() => expect(mockStartInternalExam).toHaveBeenCalledTimes(2))
+      await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/app/quiz/session'))
+    } finally {
+      setItemSpy.mockRestore()
+    }
   })
 })

--- a/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
+++ b/apps/web/app/app/internal-exam/_components/code-entry-modal.test.tsx
@@ -215,4 +215,41 @@ describe('CodeEntryModal', () => {
     form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
     await waitFor(() => expect(mockStartInternalExam).toHaveBeenCalledTimes(2))
   })
+
+  it('shows an error and allows a retry when sessionStorage write fails after a successful action response', async () => {
+    // The action succeeds but sessionStorage.setItem throws (e.g. quota exceeded or
+    // private-browsing restriction). The lock must reset (startedRef.current = false)
+    // so the student can retry, and the error banner must be shown.
+    mockStartInternalExam.mockResolvedValue({
+      success: true,
+      sessionId: 'sess-abc',
+      questionIds: ['q-1'],
+      timeLimitSeconds: 1800,
+      passMark: 75,
+      startedAt: '2026-04-29T10:00:00.000Z',
+    })
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(() => {
+      throw new DOMException('QuotaExceededError')
+    })
+
+    renderModal()
+    const input = screen.getByTestId('code-input') as HTMLInputElement
+    await userEvent.type(input, 'ABCD2345')
+
+    const form = screen.getByTestId('code-entry-form')
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+
+    // Error banner shown — router must NOT have been called (no navigation on handoff failure).
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/unable to start internal exam/i),
+    )
+    expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(mockStartInternalExam).toHaveBeenCalledTimes(1)
+
+    // Lock is reset — student can retry; this time sessionStorage succeeds.
+    setItemSpy.mockRestore()
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+    await waitFor(() => expect(mockStartInternalExam).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/app/quiz/session'))
+  })
 })

--- a/apps/web/app/app/internal-exam/_components/code-entry-modal.tsx
+++ b/apps/web/app/app/internal-exam/_components/code-entry-modal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useState, useTransition } from 'react'
+import { useRef, useState, useTransition } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -51,6 +51,7 @@ export function CodeEntryModal({
   const [code, setCode] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+  const startedRef = useRef(false)
 
   function handleClose(next: boolean) {
     if (!next) {
@@ -62,11 +63,13 @@ export function CodeEntryModal({
 
   function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
     e.preventDefault()
+    if (startedRef.current) return
     setError(null)
     if (!ALLOWED_RE.test(code)) {
       setError(`Code must be ${CODE_LENGTH} characters (letters and digits, no I/O/0/1).`)
       return
     }
+    startedRef.current = true
     startTransition(async () => {
       try {
         const result = await startInternalExam({ code })
@@ -91,16 +94,20 @@ export function CodeEntryModal({
             console.error('[code-entry-modal] sessionStorage handoff failed:', storageErr)
             // Internal exam cannot be discarded by design — surface the error
             // and let the recovery banner handle resume on next visit.
+            startedRef.current = false
             setError(
               'Unable to start internal exam right now. Please try again or refresh the page.',
             )
             return
           }
+          // Terminal — do not reset startedRef; the exam has started.
           router.push('/app/quiz/session')
           return
         }
+        startedRef.current = false
         setError(result.error)
       } catch {
+        startedRef.current = false
         setError('Something went wrong. Please try again.')
       }
     })

--- a/apps/web/app/app/quiz/_components/comments-tab.test.tsx
+++ b/apps/web/app/app/quiz/_components/comments-tab.test.tsx
@@ -298,38 +298,25 @@ describe('CommentsTab', () => {
   })
 
   it('allows a retry after the post handler throws', async () => {
-    // handleSubmit is an async function. When addComment throws, the finally
-    // block still runs (releasing the lock), but the rejected promise propagates
-    // out of handleSubmit. Because React discards the return value of onClick
-    // handlers, the rejection becomes an unhandled rejection at the Node process
-    // level. Intercept it with a process listener so Vitest does not fail the
-    // test on this expected network-error throw.
-    const suppressRejection = (reason: unknown) => {
-      if (reason instanceof Error && reason.message === 'network error') return
-      // Re-throw anything unexpected so it still fails the test.
-      throw reason
-    }
-    process.on('unhandledRejection', suppressRejection)
+    // handleSubmit catches a rejected addComment locally (logging it), so the throw
+    // never escapes the click handler — assert it is logged and the lock is released.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockAddComment.mockRejectedValueOnce(new Error('network error')).mockResolvedValueOnce(true)
+    const user = userEvent.setup()
+    render(<CommentsTab questionId="q-1" currentUserId={CURRENT_USER_ID} />)
 
-    try {
-      mockAddComment.mockRejectedValueOnce(new Error('network error')).mockResolvedValueOnce(true)
-      const user = userEvent.setup()
-      render(<CommentsTab questionId="q-1" currentUserId={CURRENT_USER_ID} />)
+    const input = screen.getByPlaceholderText('Add a comment...')
+    await user.type(input, 'throw retry message')
 
-      const input = screen.getByPlaceholderText('Add a comment...')
-      await user.type(input, 'throw retry message')
+    // First attempt — rejects. The catch logs it and the finally releases the lock.
+    await user.click(screen.getByRole('button', { name: 'Post' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Post' })).not.toBeDisabled())
+    expect(consoleError).toHaveBeenCalled()
 
-      // First attempt — throws. The finally block releases the lock.
-      await user.click(screen.getByRole('button', { name: 'Post' }))
+    // Second attempt — succeeds. Confirms the lock was fully released.
+    await user.click(screen.getByRole('button', { name: 'Post' }))
+    await waitFor(() => expect(mockAddComment).toHaveBeenCalledTimes(2))
 
-      // Wait for the button to become re-enabled: the finally block must have run.
-      await waitFor(() => expect(screen.getByRole('button', { name: 'Post' })).not.toBeDisabled())
-
-      // Second attempt — succeeds. Confirms the lock was fully released.
-      await user.click(screen.getByRole('button', { name: 'Post' }))
-      await waitFor(() => expect(mockAddComment).toHaveBeenCalledTimes(2))
-    } finally {
-      process.removeListener('unhandledRejection', suppressRejection)
-    }
+    consoleError.mockRestore()
   })
 })

--- a/apps/web/app/app/quiz/_components/comments-tab.test.tsx
+++ b/apps/web/app/app/quiz/_components/comments-tab.test.tsx
@@ -137,6 +137,31 @@ describe('CommentsTab', () => {
     expect(mockRemoveComment).toHaveBeenCalledWith('c-own')
   })
 
+  it('logs an error and does not crash when the delete handler rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockRemoveComment.mockRejectedValueOnce(new Error('network error'))
+    mockUseComments.mockReturnValue(
+      defaultHookState({
+        comments: [makeComment('c-own', { user_id: CURRENT_USER_ID })],
+      }),
+    )
+
+    const user = userEvent.setup()
+    render(<CommentsTab questionId="q-1" currentUserId={CURRENT_USER_ID} />)
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        '[CommentsTab] Failed to delete comment:',
+        expect.any(Error),
+      ),
+    )
+    // The UI should still be rendered — no unhandled rejection / crash
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+
+    consoleError.mockRestore()
+  })
+
   it('shows an error message when the hook reports an error', () => {
     mockUseComments.mockReturnValue(defaultHookState({ error: 'Failed to load comments' }))
     render(<CommentsTab questionId="q-1" currentUserId={CURRENT_USER_ID} />)
@@ -311,7 +336,10 @@ describe('CommentsTab', () => {
     // First attempt — rejects. The catch logs it and the finally releases the lock.
     await user.click(screen.getByRole('button', { name: 'Post' }))
     await waitFor(() => expect(screen.getByRole('button', { name: 'Post' })).not.toBeDisabled())
-    expect(consoleError).toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[CommentsTab] Failed to post comment:',
+      expect.any(Error),
+    )
 
     // Second attempt — succeeds. Confirms the lock was fully released.
     await user.click(screen.getByRole('button', { name: 'Post' }))

--- a/apps/web/app/app/quiz/_components/comments-tab.test.tsx
+++ b/apps/web/app/app/quiz/_components/comments-tab.test.tsx
@@ -259,4 +259,41 @@ describe('CommentsTab', () => {
     render(<CommentsTab questionId="q-1" currentUserId={CURRENT_USER_ID} />)
     expect(screen.getByRole('button', { name: 'Post' })).not.toHaveAttribute('aria-busy')
   })
+
+  // ---- Synchronous re-entry guard -----------------------------------------
+
+  it('submits once when the button and Enter key fire simultaneously while a post is in flight', async () => {
+    // addComment never resolves so the component stays in the submitting state,
+    // simulating a concurrent click + Enter key race.
+    mockAddComment.mockReturnValue(new Promise(() => {}))
+    const user = userEvent.setup()
+    render(<CommentsTab questionId="q-1" currentUserId={CURRENT_USER_ID} />)
+
+    const input = screen.getByPlaceholderText('Add a comment...')
+    await user.type(input, 'concurrent race')
+    // Fire click and Enter in the same tick to simulate a multi-source race.
+    await user.click(screen.getByRole('button', { name: 'Post' }))
+    // Trigger the onKeyDown handler while the first submission is still in flight.
+    await user.keyboard('{Enter}')
+
+    expect(mockAddComment).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows a retry after a failed post', async () => {
+    // First call fails (returns false), second call succeeds.
+    mockAddComment.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    const user = userEvent.setup()
+    render(<CommentsTab questionId="q-1" currentUserId={CURRENT_USER_ID} />)
+
+    const input = screen.getByPlaceholderText('Add a comment...')
+    await user.type(input, 'retry message')
+
+    // First attempt — fails.
+    await user.click(screen.getByRole('button', { name: 'Post' }))
+    await waitFor(() => expect(mockAddComment).toHaveBeenCalledTimes(1))
+
+    // Lock should be released after failure — second attempt should go through.
+    await user.click(screen.getByRole('button', { name: 'Post' }))
+    await waitFor(() => expect(mockAddComment).toHaveBeenCalledTimes(2))
+  })
 })

--- a/apps/web/app/app/quiz/_components/comments-tab.test.tsx
+++ b/apps/web/app/app/quiz/_components/comments-tab.test.tsx
@@ -296,4 +296,40 @@ describe('CommentsTab', () => {
     await user.click(screen.getByRole('button', { name: 'Post' }))
     await waitFor(() => expect(mockAddComment).toHaveBeenCalledTimes(2))
   })
+
+  it('allows a retry after the post handler throws', async () => {
+    // handleSubmit is an async function. When addComment throws, the finally
+    // block still runs (releasing the lock), but the rejected promise propagates
+    // out of handleSubmit. Because React discards the return value of onClick
+    // handlers, the rejection becomes an unhandled rejection at the Node process
+    // level. Intercept it with a process listener so Vitest does not fail the
+    // test on this expected network-error throw.
+    const suppressRejection = (reason: unknown) => {
+      if (reason instanceof Error && reason.message === 'network error') return
+      // Re-throw anything unexpected so it still fails the test.
+      throw reason
+    }
+    process.on('unhandledRejection', suppressRejection)
+
+    try {
+      mockAddComment.mockRejectedValueOnce(new Error('network error')).mockResolvedValueOnce(true)
+      const user = userEvent.setup()
+      render(<CommentsTab questionId="q-1" currentUserId={CURRENT_USER_ID} />)
+
+      const input = screen.getByPlaceholderText('Add a comment...')
+      await user.type(input, 'throw retry message')
+
+      // First attempt — throws. The finally block releases the lock.
+      await user.click(screen.getByRole('button', { name: 'Post' }))
+
+      // Wait for the button to become re-enabled: the finally block must have run.
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Post' })).not.toBeDisabled())
+
+      // Second attempt — succeeds. Confirms the lock was fully released.
+      await user.click(screen.getByRole('button', { name: 'Post' }))
+      await waitFor(() => expect(mockAddComment).toHaveBeenCalledTimes(2))
+    } finally {
+      process.removeListener('unhandledRejection', suppressRejection)
+    }
+  })
 })

--- a/apps/web/app/app/quiz/_components/comments-tab.tsx
+++ b/apps/web/app/app/quiz/_components/comments-tab.tsx
@@ -25,9 +25,14 @@ export function CommentsTab({ questionId, currentUserId }: CommentsTabProps) {
     try {
       const ok = await addComment(body.trim())
       if (ok) setBody('')
+    } catch (err) {
+      // addComment awaits a Server Action that can reject (network/RSC failure). Catch it
+      // locally so it doesn't escape this click handler as an unhandled rejection; the
+      // comment text is preserved (setBody not cleared) so the student can retry.
+      console.error('[CommentsTab] Failed to post comment:', err)
     } finally {
-      // addComment awaits a Server Action that can reject (network/RSC failure); without
-      // finally the locks would stay engaged and the student could never retry the comment.
+      // Always release the locks — on success, the caught rejection, or an early return —
+      // otherwise the Post button would stay disabled and block retries.
       submittingRef.current = false
       setSubmitting(false)
     }
@@ -87,7 +92,13 @@ export function CommentsTab({ questionId, currentUserId }: CommentsTabProps) {
                 {isOwn && (
                   <button
                     type="button"
-                    onClick={() => removeComment(c.id)}
+                    onClick={() => {
+                      // Catch so a rejected deleteComment Server Action doesn't escape this
+                      // handler as an unhandled rejection (same guard as handleSubmit above).
+                      removeComment(c.id).catch((err) =>
+                        console.error('[CommentsTab] Failed to delete comment:', err),
+                      )
+                    }}
                     className="mt-1 text-xs text-destructive hover:underline"
                   >
                     Delete

--- a/apps/web/app/app/quiz/_components/comments-tab.tsx
+++ b/apps/web/app/app/quiz/_components/comments-tab.tsx
@@ -22,10 +22,15 @@ export function CommentsTab({ questionId, currentUserId }: CommentsTabProps) {
     if (submittingRef.current) return
     submittingRef.current = true
     setSubmitting(true)
-    const ok = await addComment(body.trim())
-    if (ok) setBody('')
-    submittingRef.current = false
-    setSubmitting(false)
+    try {
+      const ok = await addComment(body.trim())
+      if (ok) setBody('')
+    } finally {
+      // addComment awaits a Server Action that can reject (network/RSC failure); without
+      // finally the locks would stay engaged and the student could never retry the comment.
+      submittingRef.current = false
+      setSubmitting(false)
+    }
   }
 
   if (isLoading) return <CommentsSkeleton />

--- a/apps/web/app/app/quiz/_components/comments-tab.tsx
+++ b/apps/web/app/app/quiz/_components/comments-tab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Loader2 } from 'lucide-react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useComments } from '../session/_hooks/use-comments'
 import { getAvatarColor, getInitials } from './comment-helpers'
 import { CommentsSkeleton } from './comments-skeleton'
@@ -15,12 +15,16 @@ export function CommentsTab({ questionId, currentUserId }: CommentsTabProps) {
   const { comments, isLoading, error, addComment, removeComment } = useComments(questionId)
   const [body, setBody] = useState('')
   const [submitting, setSubmitting] = useState(false)
+  const submittingRef = useRef(false)
 
   async function handleSubmit() {
     if (!body.trim() || submitting) return
+    if (submittingRef.current) return
+    submittingRef.current = true
     setSubmitting(true)
     const ok = await addComment(body.trim())
     if (ok) setBody('')
+    submittingRef.current = false
     setSubmitting(false)
   }
 

--- a/apps/web/app/app/quiz/session/_hooks/quiz-submit.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/quiz-submit.test.ts
@@ -528,13 +528,10 @@ describe('handleSubmitSession', () => {
     }
   }
 
-  it('shows error and releases the submit lock when submitting with no answers', async () => {
+  it('shows an error and lets the student retry when there are no answers to submit', async () => {
     const opts = makeOpts({ answers: new Map() })
     await handleSubmitSession(opts)
     expect(opts.setError).toHaveBeenCalledWith('No answers to submit.')
-    // Releases the caller's useRef re-entry lock (#924): without setSubmitting(false)
-    // the synchronous gate in useQuizSubmit.handleSubmit stays stuck and the student
-    // can never retry Submit in the same session.
     expect(opts.setSubmitting).toHaveBeenCalledWith(false)
     expect(mockBatchSubmitQuiz).not.toHaveBeenCalled()
   })

--- a/apps/web/app/app/quiz/session/_hooks/quiz-submit.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/quiz-submit.test.ts
@@ -528,11 +528,14 @@ describe('handleSubmitSession', () => {
     }
   }
 
-  it('shows error when submitting with no answers', async () => {
+  it('shows error and releases the submit lock when submitting with no answers', async () => {
     const opts = makeOpts({ answers: new Map() })
     await handleSubmitSession(opts)
     expect(opts.setError).toHaveBeenCalledWith('No answers to submit.')
-    expect(opts.setSubmitting).not.toHaveBeenCalled()
+    // Releases the caller's useRef re-entry lock (#924): without setSubmitting(false)
+    // the synchronous gate in useQuizSubmit.handleSubmit stays stuck and the student
+    // can never retry Submit in the same session.
+    expect(opts.setSubmitting).toHaveBeenCalledWith(false)
     expect(mockBatchSubmitQuiz).not.toHaveBeenCalled()
   })
 

--- a/apps/web/app/app/quiz/session/_hooks/quiz-submit.ts
+++ b/apps/web/app/app/quiz/session/_hooks/quiz-submit.ts
@@ -137,6 +137,10 @@ export async function handleSubmitSession(opts: {
     opts.examMode === 'internal_exam' ? '/app/internal-exam/report' : '/app/quiz/report'
   if (opts.answers.size === 0 && !opts.isExam) {
     opts.setError('No answers to submit.')
+    // Release the caller's re-entry lock: this path never called setSubmitting(true),
+    // so without this the synchronous useRef gate in useQuizSubmit.handleSubmit would
+    // stay stuck and the student could never retry Submit in the same session.
+    opts.setSubmitting(false)
     return
   }
   if (opts.answers.size === 0 && opts.isExam) {

--- a/apps/web/app/app/quiz/session/_hooks/use-quiz-state.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-quiz-state.test.ts
@@ -336,7 +336,7 @@ describe('useQuizState — handleSubmit empty-answers guard', () => {
     // Simulate the empty-answers guard: handleSubmitSession calls setError when answers empty.
     // We replicate the guard by having the mock invoke setError via the passed opts.
     mockHandleSubmitSession.mockImplementation(
-      (opts: { answers: Map<unknown, unknown>; setError: (e: string | null) => void }) => {
+      async (opts: { answers: Map<unknown, unknown>; setError: (e: string | null) => void }) => {
         if (opts.answers.size === 0) opts.setError('No answers to submit.')
       },
     )
@@ -354,7 +354,7 @@ describe('useQuizState — handleSubmit empty-answers guard', () => {
 describe('useQuizState — handleSubmit', () => {
   it('navigates to the report page after a successful submission', async () => {
     mockHandleSubmitSession.mockImplementation(
-      (opts: {
+      async (opts: {
         router: { push: (url: string) => void }
         sessionId: string
         onSuccess: () => void
@@ -379,7 +379,10 @@ describe('useQuizState — handleSubmit', () => {
 
   it('shows error when submission fails', async () => {
     mockHandleSubmitSession.mockImplementation(
-      (opts: { setError: (e: string | null) => void; setSubmitting: (v: boolean) => void }) => {
+      async (opts: {
+        setError: (e: string | null) => void
+        setSubmitting: (v: boolean) => void
+      }) => {
         opts.setError('Session expired')
         opts.setSubmitting(false)
       },

--- a/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.test.ts
@@ -300,6 +300,28 @@ describe('useQuizSubmit — handleSubmit re-entry guard', () => {
     expect(mockHandleSubmitSession).toHaveBeenCalledTimes(2)
   })
 
+  it('allows a retry after a submit attempt rejects', async () => {
+    // Throw path: the action rejects before ever calling setSubmitting(false), so the
+    // lock can only be released by the finally handler (submitted stays false → retryable).
+    mockHandleSubmitSession
+      .mockImplementationOnce(async () => {
+        throw new Error('network')
+      })
+      .mockImplementationOnce(async () => {})
+
+    const { result } = renderHook(() => useQuizSubmit(makeDefaultOpts()))
+
+    // First attempt rejects — swallow so act() doesn't surface the rejection.
+    await act(async () => {
+      await result.current.handleSubmit()?.catch(() => {})
+    })
+    expect(mockHandleSubmitSession).toHaveBeenCalledTimes(1)
+
+    // Lock released by finally → second attempt must go through.
+    await act(async () => result.current.handleSubmit())
+    expect(mockHandleSubmitSession).toHaveBeenCalledTimes(2)
+  })
+
   it('remains locked after success so a concurrent timer fire does not double-submit', async () => {
     // Simulate success path: onSuccess sets submitted.current = true, then the action
     // navigates away without calling setSubmitting(false).

--- a/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.test.ts
@@ -258,6 +258,67 @@ describe('useQuizSubmit — clearError', () => {
   })
 })
 
+// ---- Synchronous re-entry guard for handleSubmit --------------------------
+
+describe('useQuizSubmit — handleSubmit re-entry guard', () => {
+  it('invokes the session handler once when timer and click fire simultaneously before the action resolves', async () => {
+    // Never-resolving promise keeps the action in flight so the guard is exercised.
+    mockHandleSubmitSession.mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useQuizSubmit(makeDefaultOpts()))
+
+    await act(async () => {
+      // Fire handleSubmit twice synchronously — second call must be suppressed.
+      result.current.handleSubmit()
+      result.current.handleSubmit()
+    })
+
+    expect(mockHandleSubmitSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows a retry after a submit attempt finishes without succeeding', async () => {
+    // Simulate an error path: action calls setSubmitting(true) then setSubmitting(false)
+    // without calling onSuccess (submitted stays false → lock resets).
+    let capturedSetSubmitting: ((v: boolean) => void) | undefined
+    mockHandleSubmitSession.mockImplementation(
+      async (opts: { setSubmitting: (v: boolean) => void }) => {
+        capturedSetSubmitting = opts.setSubmitting
+        opts.setSubmitting(true)
+        opts.setSubmitting(false) // failure path — submitted.current is still false
+      },
+    )
+
+    const { result } = renderHook(() => useQuizSubmit(makeDefaultOpts()))
+
+    // First attempt — action signals failure.
+    await act(async () => result.current.handleSubmit())
+    expect(mockHandleSubmitSession).toHaveBeenCalledTimes(1)
+    // Ensure the captured setter was exercised.
+    expect(capturedSetSubmitting).toBeDefined()
+
+    // Lock should be reset — second attempt must go through.
+    await act(async () => result.current.handleSubmit())
+    expect(mockHandleSubmitSession).toHaveBeenCalledTimes(2)
+  })
+
+  it('remains locked after success so a concurrent timer fire does not double-submit', async () => {
+    // Simulate success path: onSuccess sets submitted.current = true, then the action
+    // navigates away without calling setSubmitting(false).
+    mockHandleSubmitSession.mockImplementation(async (opts: { onSuccess: () => void }) => {
+      opts.onSuccess() // sets submitted.current = true
+      // No setSubmitting(false) on success — terminal path.
+    })
+
+    const { result } = renderHook(() => useQuizSubmit(makeDefaultOpts()))
+
+    await act(async () => result.current.handleSubmit())
+    expect(mockHandleSubmitSession).toHaveBeenCalledTimes(1)
+
+    // A second call after success must be suppressed (both submitted and inFlight guard it).
+    await act(async () => result.current.handleSubmit())
+    expect(mockHandleSubmitSession).toHaveBeenCalledTimes(1)
+  })
+})
+
 // ---- pendingAction discriminator -----------------------------------------
 
 // The session functions are mocked, so they only flip pendingAction if the mock

--- a/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.ts
@@ -24,6 +24,9 @@ export function useQuizSubmit(opts: {
   examMode?: DbQuizMode
 }) {
   const submitted = useRef(false)
+  // Synchronous one-shot re-entry guard for handleSubmit (multi-source: timer/click/keyboard).
+  // Separate from `submitted` (success flag) so failure resets the lock for retry.
+  const inFlight = useRef(false)
   const [showFinishDialog, setShowFinishDialog] = useState(false)
   // One action runs at a time (the dialog disables all buttons while any is pending),
   // so a single discriminator drives both per-button spinners and the derived `submitting`.
@@ -32,11 +35,19 @@ export function useQuizSubmit(opts: {
   const [error, setError] = useState<string | null>(null)
   const sharedFor = (action: Exclude<QuizPendingAction, null>) => ({
     router: opts.router,
-    setSubmitting: (v: boolean) => setPendingAction(v ? action : null),
+    setSubmitting: (v: boolean) => {
+      setPendingAction(v ? action : null)
+      // Reset the re-entry lock when the action finishes without having succeeded
+      // (on success, onSuccess sets submitted.current = true first, so inFlight
+      // stays locked — terminal; on error, submitted is still false — retryable).
+      if (!v && !submitted.current) inFlight.current = false
+    },
     setError,
   })
 
   function handleSubmit() {
+    if (inFlight.current || submitted.current) return
+    inFlight.current = true
     const pending = opts.pendingQuestionIdRef.current
     const safeAnswers =
       pending.size > 0

--- a/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.ts
@@ -37,10 +37,12 @@ export function useQuizSubmit(opts: {
     router: opts.router,
     setSubmitting: (v: boolean) => {
       setPendingAction(v ? action : null)
-      // Reset the re-entry lock when the action finishes without having succeeded
-      // (on success, onSuccess sets submitted.current = true first, so inFlight
-      // stays locked — terminal; on error, submitted is still false — retryable).
-      if (!v && !submitted.current) inFlight.current = false
+      // Reset the submit re-entry lock when the submit finishes without having
+      // succeeded (on success, onSuccess sets submitted.current = true first, so
+      // inFlight stays locked — terminal; on error, submitted is still false —
+      // retryable). Scoped to 'submit' so a save/discard completion can never
+      // reset an in-flight submit's lock (inFlight is only set by handleSubmit).
+      if (!v && action === 'submit' && !submitted.current) inFlight.current = false
     },
     setError,
   })

--- a/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-quiz-submit.ts
@@ -67,6 +67,11 @@ export function useQuizSubmit(opts: {
         setShowFinishDialog(false)
       },
       ...sharedFor('submit'),
+    }).finally(() => {
+      // If submit rejected/threw before any setSubmitting(false), release the re-entry lock
+      // so the student can retry. On success onSuccess set submitted.current = true first, so
+      // the lock intentionally stays engaged here (terminal — navigating to the report).
+      if (!submitted.current) inFlight.current = false
     })
   }
 


### PR DESCRIPTION
> **Hand-off PR — do not auto-merge.** Behavioral change to submit flows; opened for review + manual sign-off per the conservative batch scope.

## What

Promotes a learner-detected pattern (count=3) to **code-style.md §6** and sweeps the handlers that still violated it.

**Rule:** an async submit/close/finish handler triggerable from **multiple sources** (timer auto-fire, click, keyboard, form `onSubmit`) must gate re-entry with a **synchronous `useRef` one-shot lock**, not async React state (`isPending`/`isLoading`/`loading`) — between the trigger and the state commit, two sources can both read the stale "not pending" value and both run the action (double submit/RPC/nav). The on-screen `disabled={pending}` only blocks the *button* path; a timer/programmatic caller bypasses it.

## Sweep (Sweep-On-Rule-Promotion — complete)

Audited every multi-source async handler in `apps/web`: **5 already correctly guarded**, **3 gaps fixed**:

| Handler | Sources | Reset strategy |
|---|---|---|
| `comments-tab.tsx` handleSubmit | click + Enter | `submittingRef`, reset on both paths (retryable post) |
| `code-entry-modal.tsx` handleSubmit | form + click + Enter (was `isPending`) | `startedRef` set *after* validation, reset on all 3 failure paths, NOT on terminal `router.push` |
| `use-quiz-submit.ts` handleSubmit | timer auto-fire + click + confirm | separate `inFlight` ref (the existing `submitted` is a success flag); reset centrally in `sharedFor.setSubmitting`, scoped to `action === 'submit'` |

`handleSave`/`handleDiscard` are single-button (out of the multi-source rule scope) — left as-is.

## Notable: a CRITICAL caught + fixed in-PR

The internal semantic-reviewer found a **stuck-lock** the guard introduced: `handleSubmitSession`'s "no answers, non-exam" early-return set an error but never called `setSubmitting`, so `inFlight` stayed locked and the student could never retry Submit (button looked enabled — no spinner). Fixed (`quiz-submit.ts` calls `setSubmitting(false)` there) + the existing test that **encoded the bug** (`expect(setSubmitting).not.toHaveBeenCalled()`) inverted to assert the fix. Re-review confirmed resolved; full inFlight lifecycle matrix verified clean.

## Verification

- ✅ 11 co-located tests (double-fire-once + retry-after-failure + sessionStorage-failure reset branch); full suite **293 files / 4130 tests** green; `lint`/`check-types`/`build` clean.
- ✅ Internal pipeline: impl-critic ×3, semantic-reviewer ×3 (CRITICAL→fixed→verified), code-reviewer, test-writer (gap filled), doc-updater, learner (pattern PROMOTED), coderabbit-sync (no `.coderabbit.yaml` change — React-context rule, like sibling §6 rules). CR-local: 1 finding (test spy leak) fixed.

## Known / deferred

- **2 code-reviewer WARNINGs** (non-blocking): the guards add a few lines to two files already over their size caps — `code-entry-modal.tsx` (179/150) and `use-quiz-submit.ts` (112/80). The guard lines are minimal; splitting these is separate tech-debt (the quiz submit hook is tracked in **#887**).

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate/rapid submissions across internal exam code entry, quiz comment posting, and quiz session submission when multiple triggers occur simultaneously.
  * Improved retry behavior after failures (including rejected/thrown actions and session storage write failures) while keeping submissions locked on success; prevented crashes during comment deletion and logged errors instead.
  * Ensured “no answers” early-exit releases the submitting state (when not in exam mode).

* **Documentation**
  * Added code-style guidance for synchronous re-entry guards in multi-trigger async handlers.

* **Tests**
  * Expanded coverage for double-submit prevention, retry/lock reset behavior, and safe handling of rejected delete actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->