### PR TITLE
docs(vfr-rt): document submitVfrRtExam error collapse as deliberate token-map exception (#920)

### DIFF
--- a/apps/web/app/app/vfr-rt-exam/actions/submit.ts
+++ b/apps/web/app/app/vfr-rt-exam/actions/submit.ts
@@ -43,6 +43,15 @@ export async function submitVfrRtExam(raw: unknown): Promise<SubmitVfrRtExamResu
     })
 
     if (error) {
+      // Deliberate single-message collapse — the documented exception to the
+      // error-token-map completeness rule (agent-semantic-reviewer.md; sweep #920).
+      // submit_vfr_rt_exam_answers raises 14 distinct tokens (19 raise sites), all
+      // integrity/validation failures (malformed payload, answer_type_mismatch,
+      // invalid option/blank index, question-not-in-session) that signal a client
+      // bug or tampering, not a state a correctly-built submission can reach. None
+      // are individually actionable by a student mid-exam, so we intentionally do
+      // NOT map them to distinct messages — every path returns one generic "retry"
+      // string.
       console.error('[submitVfrRtExam] RPC error:', error.message)
       return { success: false, error: 'Failed to submit exam' }
     }


### PR DESCRIPTION
## Summary

Closes the **#920** tech-debt sweep — *"Server Action error-token maps vs RPC RAISE sets"* (rule promotion count=3). An exhaustive audit of all 4 in-scope Server Actions found **zero offenders**: each already maps every one of its RPC's `RAISE EXCEPTION` tokens to a distinct user message, with co-located tests:

| Action | RPC | Tokens mapped | Tests |
|--------|-----|---------------|-------|
| `issue-code.ts` | `issue_internal_exam_code` | 7/7 | ✓ |
| `void-code.ts` | `void_internal_exam_code` | 8/8 | ✓ |
| `start-internal-exam.ts` | `start_internal_exam_session` | 10/10 | ✓ |
| `vfr-rt-exam/start.ts` | `start_vfr_rt_exam_session` | 5/5 | ✓ (completed earlier in `2bbf0252`) |

The **only** residual was the issue's final acceptance bullet: document `submitVfrRtExam`'s deliberate error collapse as the exception to the rule. `submit_vfr_rt_exam_answers` raises **14 distinct tokens (19 raise sites)** — all integrity/validation failures (malformed payload, `answer_type_mismatch`, invalid option/blank index, question-not-in-session) that signal a client bug or tampering, none individually actionable by a student mid-exam. Collapsing them to one generic `'Failed to submit exam'` message is the correct design, not a token-map gap.

This PR adds a 9-line inline comment recording that rationale so a future semantic-reviewer doesn't re-flag it.

## Changes

- `apps/web/app/app/vfr-rt-exam/actions/submit.ts` — comment-only (no behavioral change).

## Verification

- **Audit:** all 4 actions + `submitVfrRtExam` traced against their RPCs' latest `CREATE OR REPLACE FUNCTION` bodies.
- **Counts** confirmed via `grep -c` (19 raise sites / 14 distinct tokens).
- Post-commit agents: code-reviewer / doc-updater / test-writer clean; semantic-reviewer 1 SUGGESTION (site-count 21→19) fixed.
- CR-local: 2/2 clean rounds. Lint / check-types / 4121 tests / build all green.

## Notes

- Comment-only; no migration, schema, or behavior change — nothing to manually evaluate.
- `Closes #920` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation and code comments to clarify error-handling behavior.

**Note:** No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->