### PR TITLE
fix(quiz): await discardQuiz before nav + codify await-before-terminal-nav rule (#941)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -566,6 +566,34 @@ function useExamNavigation() {
 
 The same applies to any scalar captured across a hook split (e.g. a `currentIndex` read in a save handler defined in a different hook). When in doubt: if a value is read inside a callback and also changes via `setState`, mirror it. Promoted at count=2 — `df5d354` (stale `currentIndex` in `handleSave` after a hook split) and `e137e93` (stale `feedback` Map read in `wrappedNavigateTo`'s checkpoint).
 
+### Await Server Actions Before Terminal Navigation
+
+A **terminal navigation** — `router.push(...)`, `router.replace(...)`, or `window.location.assign(...)` to a different page the user cannot return from by staying in place — must be the **last statement** on its path. `router.refresh()` is **not** terminal: it revalidates in place and the user stays, so a racing Server Action has no pending navigation to cancel.
+
+A Server Action that runs before a terminal navigation must not merely be *sequenced* before the call. A slow Server Action's App Router revalidation can cancel the pending soft navigation **even when invoked before** `router.push`, stranding the user on the current page.
+
+- **Critical mutations** — those that must *settle* before the user leaves (e.g. `discardQuiz`, `deleteDraft`): **await** them before the terminal navigation so the action resolves before the nav fires (an un-awaited or post-nav revalidation can cancel the pending soft-nav); make the handler `async` if needed. Sequencing-before is *not* sufficient — in #909 (`f1333974`/`d6e3ed17`) `deleteDraft` was already before `router.push` but, being a slow round-trip, resolved after it and cancelled the nav; the fix was to await.
+- **Non-critical fire-and-forget cleanup** (e.g. `clearDeploymentPin`): at minimum fire it **before** the terminal navigation so the navigation stays the last statement — in #568 (`68216d56`) firing `clearDeploymentPin` *after* `router.push` cancelled the soft nav. For slow non-critical cleanup, bound the await (`Promise.race([action(), timeout])`, clearing the timer in `.finally`) and pair with a `window.location.assign` hard-nav fallback.
+
+```ts
+// ❌ WRONG — a Server Action fired AFTER the terminal navigation can cancel the soft-nav
+router.replace('/app/quiz')
+discardQuiz({ sessionId, draftId }).catch(() => {})
+
+// ✅ CORRECT — await the critical mutation; non-critical cleanup fires before; nav is last
+clearDeploymentPin().catch(() => {})                       // non-critical: fire before nav
+await discardQuiz({ sessionId, draftId }).catch(() => {})  // critical: await to settle (best-effort)
+router.replace('/app/quiz')                                // terminal nav: last statement
+
+// ✅ CORRECT — no critical mutation; non-critical cleanup fires before, nav is last (save path)
+clearDeploymentPin().catch(() => {})
+router.push('/app/quiz')
+```
+
+The awaited mutation's `.catch(() => {})` above is intentional: the `await` is for **ordering** (let the action settle so it cannot cancel the nav), not a success guarantee — `discardQuiz` is best-effort cleanup, so we navigate regardless of its outcome. When the action's *success* is a precondition for navigating, branch on the error instead of swallowing it (don't `.catch(() => {})`).
+
+A sync React state update between the action and the navigation (e.g. `setLoading(false)`) is fine — it is not a Server Action and does not displace the navigation as the last effectful statement. Promoted at count=2 — #568 (`68216d56`), #909 (`f1333974`/`d6e3ed17`); sweep #941.
+
 ---
 
 ## 7. Testing Rules

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -96,6 +96,20 @@ reviews:
         - No useEffect for data fetching.
         - No direct Supabase calls.
 
+    # Terminal-navigation ordering — await Server Actions before router.push/replace (code-style.md §6)
+    - path: "apps/web/app/**/{_hooks,_components}/**"
+      instructions: |
+        Await Server Actions before terminal navigation:
+        - A terminal navigation is router.push()/router.replace()/window.location.assign() to a
+          different page; it must be the last statement on its path. router.refresh() is NOT
+          terminal (user stays in place) — exempt.
+        - Critical mutations (discardQuiz, deleteDraft) MUST be awaited before the terminal
+          navigation. Sequencing them before is insufficient — a slow action's revalidation can
+          cancel the pending soft-nav and strand the user (#568, #909).
+        - Non-critical fire-and-forget cleanup (clearDeploymentPin) must at least be fired before
+          the navigation so the navigation stays the last statement.
+        - Never invoke a Server Action after router.push/replace.
+
     # TypeScript — type safety
     - path: "**/*.ts"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -96,7 +96,7 @@ reviews:
         - No useEffect for data fetching.
         - No direct Supabase calls.
 
-    # Terminal-navigation ordering — await Server Actions before router.push/replace (code-style.md §6)
+    # Terminal-navigation ordering — await Server Actions before terminal navigation (code-style.md §6)
     - path: "apps/web/app/**/{_hooks,_components}/**"
       instructions: |
         Await Server Actions before terminal navigation:
@@ -108,7 +108,8 @@ reviews:
           cancel the pending soft-nav and strand the user (#568, #909).
         - Non-critical fire-and-forget cleanup (clearDeploymentPin) must at least be fired before
           the navigation so the navigation stays the last statement.
-        - Never invoke a Server Action after router.push/replace.
+        - Never invoke a Server Action after a terminal navigation (router.push/replace or
+          window.location.assign).
 
     # TypeScript — type safety
     - path: "**/*.ts"

--- a/apps/web/app/app/quiz/_hooks/quiz-recovery-handlers.ts
+++ b/apps/web/app/app/quiz/_hooks/quiz-recovery-handlers.ts
@@ -63,6 +63,8 @@ export function buildSaveHandler(
       })
       if (result.success) {
         clearActiveSession(userId)
+        // router.refresh() is non-terminal (user stays in place) — exempt from the
+        // await-before-terminal-nav rule (code-style.md §6).
         clearDeploymentPin().catch(() => {})
         router.refresh()
         setSession(null)
@@ -86,6 +88,8 @@ export function buildDiscardHandler(
   return function handleDiscard() {
     if (loading) return
     clearActiveSession(userId)
+    // No terminal navigation in this handler at all (the parent component navigates), so the
+    // await-before-terminal-nav rule (code-style.md §6) does not apply here.
     clearDeploymentPin().catch(() => {})
     if (session)
       discardQuiz({ sessionId: session.sessionId, draftId: session.draftId }).catch(() => {})

--- a/apps/web/app/app/quiz/session/_hooks/use-session-recovery.test.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-session-recovery.test.ts
@@ -178,29 +178,34 @@ describe('useSessionRecovery — handleSave', () => {
 // ---- handleDiscard --------------------------------------------------------
 
 describe('useSessionRecovery — handleDiscard', () => {
-  it('clears the session and redirects to /app/quiz', () => {
+  it('clears the session and redirects to /app/quiz', async () => {
     const { result } = renderHook(() => useSessionRecovery(RECOVERY, 'user-001'))
 
-    act(() => {
-      result.current.handleDiscard()
+    await act(async () => {
+      await result.current.handleDiscard()
     })
 
     expect(mockClearActiveSession).toHaveBeenCalledWith('user-001')
     expect(mockRouterReplace).toHaveBeenCalledWith('/app/quiz')
   })
 
-  it('fires discardQuiz with sessionId and draftId in the background', async () => {
+  it('discards the session before redirecting to /app/quiz', async () => {
     const { result } = renderHook(() => useSessionRecovery(RECOVERY, 'user-001'))
 
-    act(() => {
-      result.current.handleDiscard()
+    await act(async () => {
+      await result.current.handleDiscard()
     })
 
-    await waitFor(() => expect(mockDiscardQuiz).toHaveBeenCalledTimes(1))
+    expect(mockDiscardQuiz).toHaveBeenCalledTimes(1)
     expect(mockDiscardQuiz).toHaveBeenCalledWith({
       sessionId: 'sess-001',
       draftId: 'draft-001',
     })
+    expect(mockRouterReplace).toHaveBeenCalledWith('/app/quiz')
+    // Both mocks were called above (toHaveBeenCalledTimes(1) already asserted), so [0] is defined.
+    expect(mockDiscardQuiz.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockRouterReplace.mock.invocationCallOrder[0]!,
+    )
   })
 
   it('does not call discardQuiz when recovery is null', () => {
@@ -214,7 +219,7 @@ describe('useSessionRecovery — handleDiscard', () => {
   })
 
   it('is idempotent — a second call while loading is a no-op', async () => {
-    // Make discardQuiz hang so loading stays true
+    // Make discardQuiz hang so loading stays true during the first call
     let resolve: (v: unknown) => void
     mockDiscardQuiz.mockReturnValue(
       new Promise((r) => {
@@ -224,35 +229,37 @@ describe('useSessionRecovery — handleDiscard', () => {
 
     const { result } = renderHook(() => useSessionRecovery(RECOVERY, 'user-001'))
 
-    act(() => {
+    // Start the async flow without awaiting the inner handleDiscard — it hangs at the await
+    await act(async () => {
       result.current.handleDiscard()
     })
 
-    // loading is now true; second call should be ignored
-    act(() => {
+    // loading is now true; second call returns immediately due to `if (loading) return`
+    await act(async () => {
       result.current.handleDiscard()
     })
 
-    // Resolve to clean up
-    resolve!({ success: true })
+    // Resolve the hanging discard and flush
+    await act(async () => {
+      resolve!({ success: true })
+    })
 
-    // discardQuiz and clearActiveSession called only once
-    await waitFor(() => expect(mockDiscardQuiz).toHaveBeenCalledTimes(1))
+    // discardQuiz and clearActiveSession called only once; router.replace fires after discard resolves
+    await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledTimes(1))
+    expect(mockDiscardQuiz).toHaveBeenCalledTimes(1)
     expect(mockClearActiveSession).toHaveBeenCalledTimes(1)
-    expect(mockRouterReplace).toHaveBeenCalledTimes(1)
   })
 
-  it('does not block the UI when discardQuiz rejects', async () => {
+  it('still redirects to /app/quiz when the discard fails', async () => {
     mockDiscardQuiz.mockRejectedValue(new Error('server error'))
     const { result } = renderHook(() => useSessionRecovery(RECOVERY, 'user-001'))
 
-    act(() => {
-      result.current.handleDiscard()
+    await act(async () => {
+      await result.current.handleDiscard()
     })
 
-    // discardQuiz rejects, but no unhandled rejection propagates
+    // .catch swallows the rejection; redirect still fires after the failed discard
     await waitFor(() => expect(mockDiscardQuiz).toHaveBeenCalledTimes(1))
-    // Redirect already happened regardless
     expect(mockRouterReplace).toHaveBeenCalledWith('/app/quiz')
   })
 })

--- a/apps/web/app/app/quiz/session/_hooks/use-session-recovery.ts
+++ b/apps/web/app/app/quiz/session/_hooks/use-session-recovery.ts
@@ -27,6 +27,8 @@ export function useSessionRecovery(recovery: ActiveSession | null, userId: strin
       })
       if (result.success) {
         clearActiveSession(userId)
+        // Non-critical cleanup fired before the terminal nav; setLoading is a sync state
+        // update, so router.replace stays the last statement (code-style.md §6).
         clearDeploymentPin().catch(() => {})
         setLoading(false)
         router.replace('/app/quiz')
@@ -40,16 +42,21 @@ export function useSessionRecovery(recovery: ActiveSession | null, userId: strin
     }
   }
 
-  function handleDiscard() {
+  async function handleDiscard() {
     if (loading) return
     setLoading(true)
     const captured = recovery
     clearActiveSession(userId)
+    // Non-critical cleanup: fire before the terminal nav (code-style.md §6).
     clearDeploymentPin().catch(() => {})
-    router.replace('/app/quiz')
+    // Critical: await the discard before navigating — a Server Action fired AFTER
+    // router.replace can cancel the soft-nav and strand the user (#568/#909; sweep #941).
     if (captured) {
-      discardQuiz({ sessionId: captured.sessionId, draftId: captured.draftId }).catch(() => {})
+      await discardQuiz({ sessionId: captured.sessionId, draftId: captured.draftId }).catch(
+        () => {},
+      )
     }
+    router.replace('/app/quiz')
   }
 
   return { loading, error, handleSave, handleDiscard }


### PR DESCRIPTION
## Summary

Codifies the learner-promoted (count=2, #568/#909) **"await Server Actions before terminal navigation"** rule into `code-style.md §6`, mirrors it to `.coderabbit.yaml`, and sweeps the two recovery-flow hooks.

**The rule:** a terminal navigation (`router.push`/`replace`/`window.location.assign` to a different page) must be the **last statement** on its path. Critical mutations (`discardQuiz`, `deleteDraft`) must be **awaited** before it — sequencing-before is insufficient because a slow action's App Router revalidation can cancel the pending soft-nav and strand the user (#909). Non-critical fire-and-forget cleanup (`clearDeploymentPin`) must at least fire **before** the nav (#568). `router.refresh()` is non-terminal → exempt.

## Sweep result

| Site | Verdict |
|------|---------|
| `use-session-recovery.ts` `handleDiscard` | **Fixed** — fired `discardQuiz` *after* `router.replace` (the exact #568 anti-pattern). Now `async`, awaits `discardQuiz` before `router.replace` (last statement). |
| `use-session-recovery.ts` `handleSave` | Annotated — `clearDeploymentPin` fired before; `setLoading` is sync state. |
| `quiz-recovery-handlers.ts` `buildSaveHandler` | Annotated exempt — `router.refresh()` is non-terminal. |
| `quiz-recovery-handlers.ts` `buildDiscardHandler` | Annotated exempt — no terminal nav in handler. |

⚠️ **One behavioral change you approved:** `handleDiscard` now blocks on the (fast soft-delete) `discardQuiz` before redirecting, instead of firing it in the background. The `.catch(() => {})` is retained so the redirect still fires if the discard fails (best-effort). 3 tests updated to the new ordering, incl. an invocation-order assertion (`discardQuiz` precedes `router.replace`) that mechanically guards the rule.

## Changes
- `.claude/rules/code-style.md` §6 — new rule + examples.
- `.coderabbit.yaml` — mirror for `apps/web/app/**/{_hooks,_components}/**`.
- `use-session-recovery.ts` / `.test.ts` — fix + 4 tests.
- `quiz-recovery-handlers.ts` — 2 exempt annotations.

## Verification
- impl-critic: APPROVED (0). code-reviewer: clean. semantic-reviewer: 0 CRITICAL/0 ISSUE, 5 GOOD (2 suggestions applied: save-path rule example + widened CR glob to `_components`). doc-updater: no doc changes. test-writer: 32/32 pass. coderabbit-sync: in sync. learner: rule PROMOTED.
- CR-local: 2/2 consecutive clean rounds (R1 applied a rule-prose clarification; R2 skips validated). Lint / check-types / 4121 tests / build all green.

## Notes
- `Closes #941` on merge.
- Behavioral change is in the recovery-discard flow (you approved the await treatment); worth a click-through of "discard an in-progress session → lands on /app/quiz" before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured quiz recovery cleanup runs in the correct sequence so critical server-side cleanup completes before redirect/navigation begins, reducing race conditions and preventing navigation from being interrupted.

* **Tests**
  * Strengthened session recovery tests to verify cleanup/navigation call ordering, one-time execution behavior, and idempotency during loading states.

* **Documentation**
  * Added/updated code style guidance and review rules clarifying when to await Server Actions vs when fire-and-forget cleanup is acceptable, and that terminal navigation should be the final step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->