### PR TITLE
docs(rules): promote HTML/SVG escaping + SDK error-sanitization to code-style §5 (#903)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -349,7 +349,7 @@ if ((discarded?.length ?? 0) > 0) {
 
 Match the surrounding error posture:
 - **Server Component query helpers** (e.g. `lib/queries/*`) — `throw new Error(\`Failed to fetch X: ${error.message}\`)`, mirroring the sibling reads in the same file. The throw surfaces via `app/error.tsx` + Sentry.
-- **Server Actions** — `console.error` server-side and return a generic domain message (never return `error.message` — see *Sanitize Error Messages*).
+- **Server Actions** — `console.error` server-side and return a generic domain message (never return `error.message` — see *Sanitize Error Messages Returned to Callers*).
 
 ```ts
 // ❌ WRONG — RLS-blocked read looks like an empty list

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -421,6 +421,7 @@ scorePercentage: r.score_percentage === null ? null : Number(r.score_percentage)
 Type the wire shape honestly (`count: number | string`) so a future reader can't strip the coercion thinking TypeScript already guarantees a number. **Precedent:** `quiz.ts` (total_time_ms), `profile.ts` (avg_score), `dashboard-stats.ts` (subject_count), `reports.ts` (total_count, answered_count, score_percentage).
 
 ### Sanitize Error Messages Returned to Callers
+
 Every `if (error)` block in a Server Action — or in any exported function or library/SDK wrapper that returns a result type with an `error` field — must either match a known error code (e.g. `23505`, `PGRST116`) and return a domain-specific message, or log server-side with `console.error` and return a generic string. Never return `error.message` directly through an exported result type — internal error strings from **any** source (Postgres, Resend, Stripe, or any third-party SDK) can expose internal implementation details; log the raw error server-side and return a generic domain string. (Promoted count=2 — Supabase 2026-03-12, Resend #901.)
 
 ```ts
@@ -435,6 +436,7 @@ if (error) {
 ```
 
 ### Escape Dynamic Values in HTML/SVG/XML Templates
+
 Any function that builds an HTML, SVG, or XML string via template literals must escape caller-supplied or DB-derived parameters with an HTML-entity escape helper (`esc()` or an equivalent entity-encoder) before interpolation — **even when current call sites are server-trusted**. Escape at the interpolation site, not at the call sites: a future caller passing untrusted input is the injection vector, and call-site escaping is invisible to the template author.
 
 ```ts

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -421,7 +421,7 @@ scorePercentage: r.score_percentage === null ? null : Number(r.score_percentage)
 Type the wire shape honestly (`count: number | string`) so a future reader can't strip the coercion thinking TypeScript already guarantees a number. **Precedent:** `quiz.ts` (total_time_ms), `profile.ts` (avg_score), `dashboard-stats.ts` (subject_count), `reports.ts` (total_count, answered_count, score_percentage).
 
 ### Sanitize Error Messages in Server Actions
-Every `if (error)` block in a Server Action must either match a known error code (e.g. `23505`, `PGRST116`) and return a domain-specific message, or log server-side with `console.error` and return a generic string. Never return `error.message` directly — Postgres error strings can expose connection details, schema names, and internal state.
+Every `if (error)` block in a Server Action must either match a known error code (e.g. `23505`, `PGRST116`) and return a domain-specific message, or log server-side with `console.error` and return a generic string. Never return `error.message` directly through an exported result type — internal error strings from **any** source (Postgres, Resend, Stripe, or any third-party SDK) can expose internal implementation details; log the raw error server-side and return a generic domain string. (Promoted count=2 — Supabase 2026-03-12, Resend #901.)
 
 ```ts
 // ❌ WRONG — raw DB error leaked to client
@@ -433,6 +433,19 @@ if (error) {
   return { success: false, error: 'Failed to save question' }
 }
 ```
+
+### Escape Dynamic Values in HTML/SVG/XML Templates
+Any function that builds an HTML, SVG, or XML string via template literals must escape caller-supplied or DB-derived parameters with an HTML-entity escape helper (`esc()` / `escapeSvgAttr()` or equivalent) before interpolation — **even when current call sites are server-trusted**. Escape at the interpolation site, not at the call sites: a future caller passing untrusted input is the injection vector, and call-site escaping is invisible to the template author.
+
+```ts
+// ❌ WRONG — DB-derived value interpolated raw into SVG markup
+return `<text x="10" y="20">${question.prompt}</text>`
+
+// ✅ CORRECT — escape at the interpolation site
+return `<text x="10" y="20">${escapeSvgAttr(question.prompt)}</text>`
+```
+
+(Promoted count=2 — SVG seed `escapeSvgAttr` #890, email template `esc()` #901.)
 
 ### Log Every Error Path, Including Rollbacks
 Every error path — including compensating (rollback) paths — must emit `console.error` before returning. Secondary error paths are not exempt from observability. If a rollback fails silently, the system enters an inconsistent state with no server-side signal.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -420,8 +420,8 @@ scorePercentage: r.score_percentage === null ? null : Number(r.score_percentage)
 
 Type the wire shape honestly (`count: number | string`) so a future reader can't strip the coercion thinking TypeScript already guarantees a number. **Precedent:** `quiz.ts` (total_time_ms), `profile.ts` (avg_score), `dashboard-stats.ts` (subject_count), `reports.ts` (total_count, answered_count, score_percentage).
 
-### Sanitize Error Messages in Server Actions
-Every `if (error)` block in a Server Action must either match a known error code (e.g. `23505`, `PGRST116`) and return a domain-specific message, or log server-side with `console.error` and return a generic string. Never return `error.message` directly through an exported result type — internal error strings from **any** source (Postgres, Resend, Stripe, or any third-party SDK) can expose internal implementation details; log the raw error server-side and return a generic domain string. (Promoted count=2 — Supabase 2026-03-12, Resend #901.)
+### Sanitize Error Messages Returned to Callers
+Every `if (error)` block in a Server Action — or in any exported function or library/SDK wrapper that returns a result type with an `error` field — must either match a known error code (e.g. `23505`, `PGRST116`) and return a domain-specific message, or log server-side with `console.error` and return a generic string. Never return `error.message` directly through an exported result type — internal error strings from **any** source (Postgres, Resend, Stripe, or any third-party SDK) can expose internal implementation details; log the raw error server-side and return a generic domain string. (Promoted count=2 — Supabase 2026-03-12, Resend #901.)
 
 ```ts
 // ❌ WRONG — raw DB error leaked to client
@@ -435,17 +435,17 @@ if (error) {
 ```
 
 ### Escape Dynamic Values in HTML/SVG/XML Templates
-Any function that builds an HTML, SVG, or XML string via template literals must escape caller-supplied or DB-derived parameters with an HTML-entity escape helper (`esc()` / `escapeSvgAttr()` or equivalent) before interpolation — **even when current call sites are server-trusted**. Escape at the interpolation site, not at the call sites: a future caller passing untrusted input is the injection vector, and call-site escaping is invisible to the template author.
+Any function that builds an HTML, SVG, or XML string via template literals must escape caller-supplied or DB-derived parameters with an HTML-entity escape helper (`esc()` or an equivalent entity-encoder) before interpolation — **even when current call sites are server-trusted**. Escape at the interpolation site, not at the call sites: a future caller passing untrusted input is the injection vector, and call-site escaping is invisible to the template author.
 
 ```ts
 // ❌ WRONG — DB-derived value interpolated raw into SVG markup
 return `<text x="10" y="20">${question.prompt}</text>`
 
-// ✅ CORRECT — escape at the interpolation site
-return `<text x="10" y="20">${escapeSvgAttr(question.prompt)}</text>`
+// ✅ CORRECT — escape at the interpolation site (esc() = the same entity-encode helper used by the seed/email builders)
+return `<text x="10" y="20">${esc(question.prompt)}</text>`
 ```
 
-(Promoted count=2 — SVG seed `escapeSvgAttr` #890, email template `esc()` #901.)
+(Promoted count=2 — SVG seed `esc()` #890, email template `esc()` #901.)
 
 ### Log Every Error Path, Including Rollbacks
 Every error path — including compensating (rollback) paths — must emit `console.error` before returning. Secondary error paths are not exempt from observability. If a rollback fails silently, the system enters an inconsistent state with no server-side signal.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -441,7 +441,8 @@ Any function that builds an HTML, SVG, or XML string via template literals must 
 // ❌ WRONG — DB-derived value interpolated raw into SVG markup
 return `<text x="10" y="20">${question.prompt}</text>`
 
-// ✅ CORRECT — escape at the interpolation site (esc() = the same entity-encode helper used by the seed/email builders)
+// ✅ CORRECT — escape at the interpolation site. esc() is a local HTML-entity escaper, not a shared export —
+// copy the inline pattern from an existing builder (seed-quiz-setup-eval.ts or email/templates/internal-exam-code.ts).
 return `<text x="10" y="20">${esc(question.prompt)}</text>`
 ```
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -116,6 +116,13 @@ reviews:
           query helpers throw `Failed to fetch X: ${error.message}`; Server Actions console.error + return a
           generic message. Exempt PGRST116 (no rows) on .single()/.maybeSingle() expected-empty branches.
           Read-only test/setup helpers may wrap atomic chained reads in one try/catch.
+        - HTML/SVG/XML template builders: any function building an HTML/SVG/XML string via template
+          literals must escape caller-supplied or DB-derived `${...}` interpolations with an HTML-entity
+          escape helper (esc()/escapeSvgAttr() or equivalent) at the interpolation site — even when
+          current call sites are server-trusted (code-style.md §5).
+        - Never return a raw SDK `error.message` through an exported result type — from ANY source
+          (Postgres, Resend, Stripe, any third-party SDK). Log the raw error server-side (console.error)
+          and return a generic domain string or a closed error-literal union (code-style.md §5).
 
     # Database package — security critical
     - path: "packages/db/src/**/*.ts"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -118,7 +118,7 @@ reviews:
           Read-only test/setup helpers may wrap atomic chained reads in one try/catch.
         - HTML/SVG/XML template builders: any function building an HTML/SVG/XML string via template
           literals must escape caller-supplied or DB-derived `${...}` interpolations with an HTML-entity
-          escape helper (esc()/escapeSvgAttr() or equivalent) at the interpolation site — even when
+          escape helper (esc() or an equivalent entity-encoder) at the interpolation site — even when
           current call sites are server-trusted (code-style.md §5).
         - Never return a raw SDK `error.message` through an exported result type — from ANY source
           (Postgres, Resend, Stripe, any third-party SDK). Log the raw error server-side (console.error)


### PR DESCRIPTION
## Summary

Promotes two learner-tracked patterns (each count=2 across distinct commits) into hard rules in `.claude/rules/code-style.md` §5, and mirrors them into `.coderabbit.yaml` so CodeRabbit enforces them on PRs. **Doc/config-only — no production code changed.**

1. **Escape Dynamic Values in HTML/SVG/XML Templates** — any function building an HTML/SVG/XML string via template literals must escape caller-supplied or DB-derived values with an HTML-entity escaper at the interpolation site, even when current call sites are server-trusted. (count=2: SVG seed `esc()` #890, email template `esc()` #901.)
2. **Sanitize Error Messages Returned to Callers** (broadened from the prior "in Server Actions") — never return a raw `error.message` through an exported result type, from **any** source (Postgres, Resend, Stripe, any third-party SDK); log server-side and return a generic domain string. (count=2: Supabase 2026-03-12, Resend #901.)

## Sweep result

Repo-wide grep found **zero offenders**: no raw `error.message` returns through exported result types, and the only template-literal SVG/HTML builders (`seed-quiz-setup-eval.ts`, `email/templates/internal-exam-code.ts`) already escape via local `esc()`. The triggering instances (#890/#901) were already fixed — this PR codifies the rule so future code is gated. No behavior changes; nothing to manually evaluate.

## Commits

- `9be145a0` codify both rules in §5 + `.coderabbit.yaml`
- `8e9eecea` fix heading scope + replace non-existent `escapeSvgAttr` → `esc()` (the helper that actually exists)
- `28ae94d9` clarify `esc()` is a per-builder local helper, not a shared export
- `b8e3a1d6` update the stale cross-ref left by the heading rename

## Verification

- Post-commit agents: code-reviewer clean · semantic-reviewer per-commit + PR-level sweep clean (0 ISSUE) · doc-updater no-change · coderabbit-sync IN SYNC · learner transitioned both tracker rows to PROMOTED · impl-critic APPROVED each commit. test-writer/red-team N/A (doc/config only, no source/security paths).
- CR-local: 2/2 clean-round floor met (6 rounds; MD022 nits SKIP'd as ungated + contradicting the file's heading style).
- `/fullpush`: lint clean · check-types clean · **4121 tests pass** · build success.

Closes #903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal code-style guidelines to tighten server-side error handling and prevent leaking raw error messages to callers.
  * Added a new rule requiring escaping of dynamic interpolations in HTML/SVG/XML template builders at the interpolation site.
  * Enhanced automated code review configurations to enforce the new error-sanitization and template-escaping safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->