### PR TITLE
fix(security): add active-user gate to get_session_reports (#883)

### DIFF
--- a/apps/web/lib/queries/reports.integration.test.ts
+++ b/apps/web/lib/queries/reports.integration.test.ts
@@ -232,6 +232,9 @@ describe('getSessionReports (app-layer integration)', () => {
       await signInAs(emailB, password)
       const r = await getSessionReports({ page: 1, sort: 'date', dir: 'desc' })
       expect(r.ok).toBe(false)
+      // The raw RAISE ('user not found or inactive') must be sanitized to the
+      // generic domain string — never leaked to the caller (reports.ts).
+      if (!r.ok) expect(r.error).toBe('Failed to load reports')
     } finally {
       const { error: restoreErr } = await admin
         .from('users')

--- a/apps/web/lib/queries/reports.integration.test.ts
+++ b/apps/web/lib/queries/reports.integration.test.ts
@@ -209,4 +209,37 @@ describe('getSessionReports (app-layer integration)', () => {
       expect(bSet.has(session.id)).toBe(false)
     }
   })
+
+  it('rejects a soft-deleted caller and does not leak their session history (#883)', async () => {
+    // Positive control (non-vacuous): while active, B sees their own 3 sessions —
+    // so a missing active-user gate would return them.
+    await signInAs(emailB, password)
+    const active = await getSessionReports({ page: 1, sort: 'date', dir: 'desc' })
+    expect(active.ok).toBe(true)
+    if (!active.ok) throw new Error(active.error)
+    expect(active.totalCount).toBe(3)
+
+    // Soft-delete B (deactivation does NOT cascade to quiz_sessions, so the per-session
+    // ownership filter still matches). The active-user gate (mig 122) fires first and must
+    // refuse even B's own owned, completed sessions.
+    const { error: softDeleteErr } = await admin
+      .from('users')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('id', studentBId)
+    if (softDeleteErr) throw new Error(`soft-delete setup: ${softDeleteErr.message}`)
+
+    try {
+      await signInAs(emailB, password)
+      const r = await getSessionReports({ page: 1, sort: 'date', dir: 'desc' })
+      expect(r.ok).toBe(false)
+    } finally {
+      const { error: restoreErr } = await admin
+        .from('users')
+        .update({ deleted_at: null })
+        .eq('id', studentBId)
+      if (restoreErr) {
+        console.error('[#883 soft-delete restore] studentB left soft-deleted:', restoreErr.message)
+      }
+    }
+  })
 })

--- a/docs/database.md
+++ b/docs/database.md
@@ -2339,7 +2339,7 @@ Returns one page of the admin's student roster joined with each student's sessio
 
 Returns paginated session reports for the authenticated student with subject name join. Used by the progress/session history page.
 
-**Security:** `SECURITY DEFINER` + `auth.uid()` check + `SET search_path = public`.
+**Security:** `SECURITY DEFINER` + `auth.uid()` check + active-user gate (a soft-deleted caller with a live JWT is rejected — `PERFORM 1 FROM users u WHERE u.id = auth.uid() AND u.deleted_at IS NULL`, mig 122, #883) + `SET search_path = public`.
 
 **Parameters:** `p_sort TEXT DEFAULT 'started_at'`, `p_dir TEXT DEFAULT 'desc'`, `p_limit INT DEFAULT 10`, `p_offset INT DEFAULT 0`
 
@@ -2349,7 +2349,7 @@ Returns paginated session reports for the authenticated student with subject nam
 
 **Returns:** `TABLE(id UUID, mode TEXT, total_questions INT, correct_count INT, score_percentage NUMERIC NULL, started_at TIMESTAMPTZ, ended_at TIMESTAMPTZ, subject_id UUID, subject_name TEXT, total_count BIGINT)` — `score_percentage` is nullable (NULL for sessions with no scored result); consumers must handle null (the TS `RpcRow`/`SessionReport` type it as `number | null`).
 
-**Migration:** `20260410000010_get_session_reports_rpc.sql` (created); `20260606000007_get_session_reports_drop_unused_answered_count.sql` (migration 091 — removed unused `answered_count` correlated subquery, #471)
+**Migration:** `20260410000010_get_session_reports_rpc.sql` (created); `20260606000007_get_session_reports_drop_unused_answered_count.sql` (migration 091 — removed unused `answered_count` correlated subquery, #471); `20260623000100_get_session_reports_active_user_gate.sql` (migration 122 — added active-user gate, `u.id`-aliased to avoid 42702 vs the `id` OUT param, #883)
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -679,7 +679,7 @@ SECURITY DEFINER functions accrue defensive guards over time, one migration at a
 
 **Justified exceptions:** admin / org-wide RPCs behind `is_admin()` are exempt from per-caller ownership scoping; a function that reads no soft-deletable table needs no soft-delete filter; a function with no `audit_events` INSERT has no audit-subquery concern. `SET search_path = public` has no exceptions — every SECURITY DEFINER function requires it.
 
-**Promotion sweep finding (#883):** the count=3 promotion swept every SECURITY DEFINER RPC by family and found 4 legacy read-RPCs missing the active-user gate — `check_quiz_answer` (mig 029, HIGH — answer key), `get_report_correct_options` (mig 037, HIGH — `correct_option_id`), `get_quiz_questions` (mig 002, MEDIUM — explanations), `get_session_reports` (mig 091, MEDIUM — history). These are the four functions oldest enough to predate the mig-076 gate family. Fix tracked in #883 (migration + per-RPC soft-deleted-caller rejection tests).
+**Promotion sweep finding (#883) — CLOSED:** the count=3 promotion swept every SECURITY DEFINER RPC by family and found 4 legacy read-RPCs (oldest enough to predate the mig-076 gate family) missing the active-user gate. All four now have it: `check_quiz_answer` (added mig 117, #823), `get_report_correct_options` (added mig 114, #856), `get_quiz_questions` (added mig 118, Phase 2 — folded into the org-scope `SELECT … INTO`), and `get_session_reports` (added mig 122, this PR). mig 122 aliases `users u` (`u.id`) because `get_session_reports`'s `RETURNS TABLE` declares an `id` OUT param — an unqualified `id` in the gate would be ambiguous (42702 at execution, code-style.md §5(c)). Each is covered by a soft-deleted-caller rejection test.
 
 ---
 

--- a/packages/db/migrations/122_get_session_reports_active_user_gate.sql
+++ b/packages/db/migrations/122_get_session_reports_active_user_gate.sql
@@ -1,0 +1,98 @@
+-- Migration 122: add the active-user (soft-deleted-caller) gate to get_session_reports (#883).
+--
+-- get_session_reports (mig 091) had the auth.uid() null-check + per-session
+-- deleted_at filter, but NOT the active-user gate that all its newer SECURITY
+-- DEFINER siblings enforce (check_quiz_answer mig 117, get_report_correct_options
+-- mig 114, submit_quiz_answer mig 095c/110). A student soft-deleted via
+-- toggle-student-status (users.deleted_at = now()) holding a still-valid JWT
+-- (up to ~1h until expiry) could keep reading their historical session list —
+-- deactivation does not cascade to quiz_sessions, so the per-session ownership
+-- filter still matches. This gate closes that window: a soft-deleted caller
+-- fails closed before the session read.
+--
+-- The return type is unchanged, so CREATE OR REPLACE suffices (no DROP). The gate
+-- aliases `users u` and references `u.id`: the RETURNS TABLE declares an `id` OUT
+-- param, so an unqualified `id` in the gate would be ambiguous (42702 at execution
+-- — code-style.md §5(c) deferred-validation). Re-grant EXECUTE for explicitness.
+
+CREATE OR REPLACE FUNCTION public.get_session_reports(
+  p_sort  TEXT DEFAULT 'started_at',
+  p_dir   TEXT DEFAULT 'desc',
+  p_limit INT DEFAULT 10,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id               UUID,
+  mode             TEXT,
+  total_questions  INT,
+  correct_count    INT,
+  score_percentage NUMERIC,
+  started_at       TIMESTAMPTZ,
+  ended_at         TIMESTAMPTZ,
+  subject_id       UUID,
+  subject_name     TEXT,
+  total_count      BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid UUID;
+  v_sort TEXT;
+  v_dir  TEXT;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Active-user gate (#883): a soft-deleted account with a live JWT must not keep
+  -- reading its historical session reports. Mirrors check_quiz_answer (mig 117) and
+  -- get_report_correct_options (mig 114). Alias `users u` — the RETURNS TABLE declares
+  -- an `id` OUT param, so an unqualified `id` here would be ambiguous (42702, §5(c)).
+  PERFORM 1 FROM users u WHERE u.id = v_uid AND u.deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  CASE p_sort
+    WHEN 'started_at'       THEN v_sort := 'qs.started_at';
+    WHEN 'score_percentage'  THEN v_sort := 'qs.score_percentage';
+    WHEN 'subject_name'      THEN v_sort := 'es.name';
+    ELSE v_sort := 'qs.started_at';
+  END CASE;
+
+  IF lower(p_dir) = 'asc' THEN
+    v_dir := 'ASC';
+  ELSE
+    v_dir := 'DESC';
+  END IF;
+
+  RETURN QUERY EXECUTE format(
+    'SELECT
+       qs.id,
+       qs.mode::TEXT,
+       qs.total_questions,
+       qs.correct_count,
+       qs.score_percentage,
+       qs.started_at,
+       qs.ended_at,
+       qs.subject_id,
+       es.name AS subject_name,
+       count(*) OVER() AS total_count
+     FROM quiz_sessions qs
+     LEFT JOIN easa_subjects es ON es.id = qs.subject_id
+     WHERE qs.student_id = $1
+       AND qs.ended_at IS NOT NULL
+       AND qs.deleted_at IS NULL
+       AND qs.mode <> ''internal_exam''
+     ORDER BY %s %s NULLS LAST, qs.id ASC
+     LIMIT $2 OFFSET $3',
+    v_sort, v_dir
+  )
+  USING v_uid, p_limit, p_offset;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_session_reports(TEXT, TEXT, INT, INT) TO authenticated;

--- a/supabase/migrations/20260623000100_get_session_reports_active_user_gate.sql
+++ b/supabase/migrations/20260623000100_get_session_reports_active_user_gate.sql
@@ -1,0 +1,98 @@
+-- Migration 122: add the active-user (soft-deleted-caller) gate to get_session_reports (#883).
+--
+-- get_session_reports (mig 091) had the auth.uid() null-check + per-session
+-- deleted_at filter, but NOT the active-user gate that all its newer SECURITY
+-- DEFINER siblings enforce (check_quiz_answer mig 117, get_report_correct_options
+-- mig 114, submit_quiz_answer mig 095c/110). A student soft-deleted via
+-- toggle-student-status (users.deleted_at = now()) holding a still-valid JWT
+-- (up to ~1h until expiry) could keep reading their historical session list —
+-- deactivation does not cascade to quiz_sessions, so the per-session ownership
+-- filter still matches. This gate closes that window: a soft-deleted caller
+-- fails closed before the session read.
+--
+-- The return type is unchanged, so CREATE OR REPLACE suffices (no DROP). The gate
+-- aliases `users u` and references `u.id`: the RETURNS TABLE declares an `id` OUT
+-- param, so an unqualified `id` in the gate would be ambiguous (42702 at execution
+-- — code-style.md §5(c) deferred-validation). Re-grant EXECUTE for explicitness.
+
+CREATE OR REPLACE FUNCTION public.get_session_reports(
+  p_sort  TEXT DEFAULT 'started_at',
+  p_dir   TEXT DEFAULT 'desc',
+  p_limit INT DEFAULT 10,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id               UUID,
+  mode             TEXT,
+  total_questions  INT,
+  correct_count    INT,
+  score_percentage NUMERIC,
+  started_at       TIMESTAMPTZ,
+  ended_at         TIMESTAMPTZ,
+  subject_id       UUID,
+  subject_name     TEXT,
+  total_count      BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid UUID;
+  v_sort TEXT;
+  v_dir  TEXT;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Active-user gate (#883): a soft-deleted account with a live JWT must not keep
+  -- reading its historical session reports. Mirrors check_quiz_answer (mig 117) and
+  -- get_report_correct_options (mig 114). Alias `users u` — the RETURNS TABLE declares
+  -- an `id` OUT param, so an unqualified `id` here would be ambiguous (42702, §5(c)).
+  PERFORM 1 FROM users u WHERE u.id = v_uid AND u.deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'user not found or inactive';
+  END IF;
+
+  CASE p_sort
+    WHEN 'started_at'       THEN v_sort := 'qs.started_at';
+    WHEN 'score_percentage'  THEN v_sort := 'qs.score_percentage';
+    WHEN 'subject_name'      THEN v_sort := 'es.name';
+    ELSE v_sort := 'qs.started_at';
+  END CASE;
+
+  IF lower(p_dir) = 'asc' THEN
+    v_dir := 'ASC';
+  ELSE
+    v_dir := 'DESC';
+  END IF;
+
+  RETURN QUERY EXECUTE format(
+    'SELECT
+       qs.id,
+       qs.mode::TEXT,
+       qs.total_questions,
+       qs.correct_count,
+       qs.score_percentage,
+       qs.started_at,
+       qs.ended_at,
+       qs.subject_id,
+       es.name AS subject_name,
+       count(*) OVER() AS total_count
+     FROM quiz_sessions qs
+     LEFT JOIN easa_subjects es ON es.id = qs.subject_id
+     WHERE qs.student_id = $1
+       AND qs.ended_at IS NOT NULL
+       AND qs.deleted_at IS NULL
+       AND qs.mode <> ''internal_exam''
+     ORDER BY %s %s NULLS LAST, qs.id ASC
+     LIMIT $2 OFFSET $3',
+    v_sort, v_dir
+  )
+  USING v_uid, p_limit, p_offset;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_session_reports(TEXT, TEXT, INT, INT) TO authenticated;


### PR DESCRIPTION
## Summary

Closes #883.

`get_session_reports` (mig 091) was the **last of four legacy read-RPCs** missing the active-user (soft-deleted-caller) gate that its newer SECURITY DEFINER siblings already enforce. A student soft-deleted via toggle-student-status, still holding a valid JWT (~1h until expiry), could keep reading their historical session list — deactivation does not cascade to `quiz_sessions`, so the per-session ownership filter still matched. **Migration 122** closes that window: a soft-deleted caller fails closed before the session read.

This completes the `docs/security.md` rule-12 promotion sweep. All four RPCs are now gated:

| RPC | Migration | Issue |
|-----|-----------|-------|
| `check_quiz_answer` | 117 | #823 |
| `get_report_correct_options` | 114 | #856 |
| `get_quiz_questions` | 118 | #925 Phase 2 |
| **`get_session_reports`** | **122** | **#883 (this PR)** |

## Implementation notes

- The gate aliases `users u` / references `u.id` — the function's `RETURNS TABLE` declares an `id` OUT param, so an unqualified `id` would throw `42702 column reference "id" is ambiguous` **at execution** (code-style.md §5(c) deferred-validation). This is a *necessary deviation* from siblings mig 114/117, whose `RETURNS TABLE` has no `id` column.
- Return type unchanged → `CREATE OR REPLACE` (no DROP). Body is a faithful reproduction of mig 091 with **only** the gate block added (semantic-reviewer Opus diff-confirmed).
- Both migration mirrors (`packages/db/migrations/122_*` ≡ `supabase/migrations/20260623000100_*`) are byte-identical.

## Verification

- ✅ Local: migration applies clean, function executes with **no 42702**, rejects soft-deleted/not-found callers.
- ✅ `reports.integration.test.ts` 7/7 green — incl. a **non-vacuous** rejection test (B sees 3 sessions while active → 0 after soft-delete) asserting the raw RAISE is sanitized to the generic `'Failed to load reports'` (no leak).
- ✅ Full unit suite 4133/4133, lint, type-check (forced), build all green.
- ✅ Post-commit fleet (code-reviewer, semantic-reviewer Opus, doc-updater, test-writer, red-team, coderabbit-sync) + impl-critic Opus: **all clean**.
- ✅ CodeRabbit-local: 3 consecutive clean rounds (security-path floor).
- ✅ Red-team: vector EM registered (integration-layer covered), CL1/CL2/CL3 E2E specs unaffected.

⚠️ **Migration auto-deploys to prod on merge** via `db-deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reports are now inaccessible to deactivated user accounts, ensuring only active users can retrieve their session reports.

* **Tests**
  * Added integration test to verify report access is properly restricted for deactivated accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->