### PR TITLE
chore(vercel): on-demand previews only, keep production auto-deploy

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "master": true,
+      "**": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Cuts Vercel build spend (~€150/mo last month) by stopping Vercel from auto-building a **preview** deployment on every branch push — the dominant cost driver at **~161 pushes/month** with no prior `vercel.json` (Vercel was on full defaults, building a deployment per push to every branch).

Adds `apps/web/vercel.json` with `git.deploymentEnabled`:
- `master: true` → **production keeps auto-deploying** on merge (live site unaffected).
- `**: false` → every other branch (`feat/*`, `chore/*`, `dependabot/*`, any depth) **no longer auto-builds**. `master` still builds via Vercel's "if any matching rule is `true`, deploy" semantics.

Previews become **on-demand**: `npx vercel deploy` (CLI/deploy-hook deploys remain allowed for git-disabled branches per Vercel docs).

## Why this is the cheapest option that keeps production automatic

- Preview deployments were being built on every push and never opened (manual eval is done locally with seeds), so they were pure waste.
- `git.deploymentEnabled` is purpose-built: it blocks only the git auto-trigger and leaves CLI/deploy-hook deploys working — unlike an `ignoreCommand`, which would also suppress the on-demand `vercel deploy` we want to keep.

## Verification

- ✅ Pre-commit gates: biome, type-check, commitlint
- ✅ Pre-push: security-auditor APPROVED (0 critical/high/medium), dependency audit
- ✅ semantic-reviewer: 0 CRITICAL / 0 ISSUE / 4 GOOD — confirmed `master` still deploys under any-true-wins, `**` covers slash-containing branches, no conflicting Vercel config in repo, and file placement matches the existing `apps/web` Root Directory (inferred from commit 2ac32863)
- ✅ CodeRabbit local: 2 clean rounds, no findings
- Mechanism verified against Vercel's official `git.deploymentEnabled` docs (minimatch, default `true` for unlisted branches, CLI/hooks still allowed when disabled)

## Rollout notes

- Takes effect only once on `master` (Vercel reads `vercel.json` from the deployed commit).
- Expected & harmless: this PR itself won't get an auto preview — that's the feature working.

## One-time manual confirmation (non-blocking)

Confirm Vercel → Project → Settings → General → **Root Directory** reads `apps/web`. If it's ever blank/`.`, the file must move to the repo root (one-line `git mv`). All evidence (prior commits, existing successful prod deploys) indicates it is `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment settings so the app can be deployed from the main branch while preventing deployments from other branches.
  * Added configuration metadata to improve platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->