### PR TITLE
feat(elp): §2 Picture Description — image stimulus in the section runner (draft)

### DIFF
--- a/apps/web/app/app/elp/prompts.test.ts
+++ b/apps/web/app/app/elp/prompts.test.ts
@@ -9,10 +9,12 @@ describe('getSectionPrompt', () => {
     expect(prompt.audioSrc).toBe('/elp/prompts/interview-1.mp3')
   })
 
-  it('returns a labelled placeholder prompt with no audio for the picture type', () => {
+  it('returns the picture-description prompt with its illustration and no audio', () => {
     const prompt = getSectionPrompt('picture')
     expect(prompt.label).toBe('§2 Picture Description')
-    expect(prompt.text).toContain('[practice placeholder]')
+    expect(prompt.text).not.toContain('[practice placeholder]')
+    expect(prompt.text).toContain('describe')
+    expect(prompt.imageSrc).toBe('/elp/prompts/picture-1.svg')
     expect(prompt.audioSrc).toBeUndefined()
   })
 

--- a/apps/web/app/app/elp/prompts.ts
+++ b/apps/web/app/app/elp/prompts.ts
@@ -1,10 +1,10 @@
 /**
- * Per-section prompt registry, keyed by the oral-exam section `type`. Only the
- * §1 Interview has a pre-generated mp3 (`audioSrc` points at a file under
- * `apps/web/public/elp/prompts/` — see `apps/web/scripts/generate-elp-prompts.ts`
- * for how the audio is produced from `text`). The remaining section types show a
- * clearly-labelled practice placeholder with no audio until their real per-type
- * capture UIs land in later slices.
+ * Per-section prompt registry, keyed by the oral-exam section `type`. §1 Interview
+ * has a pre-generated mp3 (`audioSrc` — see `apps/web/scripts/generate-elp-prompts.ts`),
+ * and §2 Picture Description carries a hand-authored placeholder image (`imageSrc` →
+ * `public/elp/prompts/picture-1.svg`) to be replaced by a licensed aviation photo
+ * later. The remaining section types (comms/listening/video) remain text-only
+ * practice placeholders until their real capture UIs land in later slices.
  */
 
 export type SectionPrompt = {
@@ -12,6 +12,7 @@ export type SectionPrompt = {
   label: string
   text: string
   audioSrc?: string
+  imageSrc?: string
 }
 
 export const SECTION_PROMPTS: Record<string, SectionPrompt> = {
@@ -24,7 +25,8 @@ export const SECTION_PROMPTS: Record<string, SectionPrompt> = {
   picture: {
     id: 'picture-1',
     label: '§2 Picture Description',
-    text: '[practice placeholder] Describe an aviation scene in detail — the real picture-description task with an image arrives in a later slice.',
+    text: 'Look at the picture and describe it in as much detail as you can. Talk about the setting, the aircraft or equipment, any people and what they are doing, and anything that looks unusual or important. Speak for about ninety seconds.',
+    imageSrc: '/elp/prompts/picture-1.svg',
   },
   comms: {
     id: 'comms-1',

--- a/apps/web/app/app/elp/session/[id]/_components/oral-section-runner.test.tsx
+++ b/apps/web/app/app/elp/session/[id]/_components/oral-section-runner.test.tsx
@@ -44,7 +44,8 @@ const PROMPT = {
 const PLACEHOLDER_PROMPT = {
   id: 'picture-1',
   label: '§2 Picture Description',
-  text: '[practice placeholder] Describe an aviation scene in detail.',
+  text: 'Look at the picture and describe it in as much detail as you can. Talk about the setting, the aircraft or equipment, any people and what they are doing, and anything that looks unusual or important. Speak for about ninety seconds.',
+  imageSrc: '/elp/prompts/picture-1.svg',
 }
 
 function idleRecorder(overrides: Partial<Record<string, unknown>> = {}) {
@@ -74,12 +75,17 @@ describe('OralSectionRunner — prompt', () => {
     render(<OralSectionRunner session={SESSION} section={SECTION} prompt={PROMPT} />)
     expect(screen.getByText(PROMPT.text)).toBeInTheDocument()
     expect(screen.getByLabelText('Interview question')).toHaveAttribute('src', PROMPT.audioSrc)
+    expect(screen.queryByRole('link', { name: /open image in new tab/i })).not.toBeInTheDocument()
   })
 
-  it('renders the prompt text but no audio player when the prompt has no audio', () => {
+  it('renders the prompt text and its illustration but no audio player when the prompt has no audio', () => {
     render(<OralSectionRunner session={SESSION} section={SECTION} prompt={PLACEHOLDER_PROMPT} />)
     expect(screen.getByText(PLACEHOLDER_PROMPT.text)).toBeInTheDocument()
     expect(screen.queryByLabelText('Interview question')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /open image in new tab/i })).toHaveAttribute(
+      'href',
+      PLACEHOLDER_PROMPT.imageSrc,
+    )
   })
 
   it('labels the heading with the section label and Practice for a practice-mode session', () => {

--- a/apps/web/app/app/elp/session/[id]/_components/oral-section-runner.tsx
+++ b/apps/web/app/app/elp/session/[id]/_components/oral-section-runner.tsx
@@ -40,6 +40,7 @@ export function OralSectionRunner({ session, section, prompt }: Props) {
       modeLabel={modeLabel}
       sectionPosition={sectionPosition}
       audioSrc={prompt.audioSrc}
+      imageSrc={prompt.imageSrc}
       promptText={prompt.text}
       recorder={toRecorderProps(recorder)}
       submit={toSubmitProps({ recorder, submit, submitting, error: submitError })}

--- a/apps/web/app/app/elp/session/[id]/_components/section-runner-layout.tsx
+++ b/apps/web/app/app/elp/session/[id]/_components/section-runner-layout.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ZoomableImage } from '../../../../_components/zoomable-image'
 import { AudioPromptPlayer } from '../../../_components/audio-prompt-player'
 import type { AudioRecorderStatus } from '../../../_hooks/use-audio-recorder'
 import { RecorderControls } from './recorder-controls'
@@ -10,6 +11,7 @@ type Props = Readonly<{
   modeLabel: string
   sectionPosition: string | null
   audioSrc?: string
+  imageSrc?: string
   promptText: string
   recorder: Readonly<{
     status: AudioRecorderStatus
@@ -35,6 +37,7 @@ export function SectionRunnerLayout({
   modeLabel,
   sectionPosition,
   audioSrc,
+  imageSrc,
   promptText,
   recorder,
   submit,
@@ -49,6 +52,9 @@ export function SectionRunnerLayout({
 
       {audioSrc && <AudioPromptPlayer src={audioSrc} label="Interview question" />}
       <p className="text-base">{promptText}</p>
+      {imageSrc && (
+        <ZoomableImage src={imageSrc} alt={`${label} illustration`} className="max-h-80" />
+      )}
 
       <RecorderControls
         status={recorder.status}

--- a/apps/web/app/app/elp/session/[id]/_components/section-runner-layout.tsx
+++ b/apps/web/app/app/elp/session/[id]/_components/section-runner-layout.tsx
@@ -51,10 +51,12 @@ export function SectionRunnerLayout({
       {sectionPosition && <p className="text-sm text-muted-foreground">{sectionPosition}</p>}
 
       {audioSrc && <AudioPromptPlayer src={audioSrc} label="Interview question" />}
-      <p className="text-base">{promptText}</p>
+      {/* Picture-description stimulus renders above its instruction so the prompt
+          text ("Look at the picture…") references an image already on screen. */}
       {imageSrc && (
         <ZoomableImage src={imageSrc} alt={`${label} illustration`} className="max-h-80" />
       )}
+      <p className="text-base">{promptText}</p>
 
       <RecorderControls
         status={recorder.status}

--- a/apps/web/public/elp/prompts/picture-1.svg
+++ b/apps/web/public/elp/prompts/picture-1.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" role="img" aria-label="Placeholder aviation scene">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#bcd4e6"/>
+      <stop offset="100%" stop-color="#eef4f8"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#sky)"/>
+  <rect y="380" width="800" height="120" fill="#c9c2b6"/>
+  <polygon points="330,500 470,500 430,385 370,385" fill="#8a8a8a"/>
+  <rect x="398" y="392" width="4" height="18" fill="#f4f4f4"/>
+  <rect x="398" y="424" width="4" height="18" fill="#f4f4f4"/>
+  <rect x="398" y="456" width="4" height="22" fill="#f4f4f4"/>
+  <g fill="#3a4a5a">
+    <ellipse cx="400" cy="250" rx="150" ry="26"/>
+    <polygon points="300,250 250,238 300,232"/>
+    <polygon points="470,250 545,244 470,258"/>
+    <polygon points="400,232 360,190 385,232"/>
+    <polygon points="400,232 440,190 415,232"/>
+    <rect x="392" y="224" width="16" height="30"/>
+  </g>
+  <text x="400" y="120" text-anchor="middle" font-family="sans-serif" font-size="30" font-weight="700" fill="#2a3642">Picture Description</text>
+  <text x="400" y="150" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#5a6672">Placeholder image — licensed aviation photo to follow</text>
+</svg>


### PR DESCRIPTION
## ⚠️ Do-not-merge draft — stacked on #1081

Fifth PR in the ICAO ELP stack: **Slice 0** (#1075) ← **Slice 1** (#1058) ← **Slice 2** (#1080) ← **audio-MIME close-out** (#1081) ← **this (§2 Picture Description)**. Base branch is `fix/icao-elp-audio-mime` (the #1081 tip), so the diff shows only these two commits. Do not merge until the full ELP feature is ready and manual eval passes.

## What this adds: §2 Picture Description renders an image stimulus

The oral-exam section runner is **section-type-agnostic** — `nextUnsubmittedSection()` → `getSectionPrompt(type)` → the same `OralSectionRunner` for every section — and §2 `picture` already existed as a mock-plan entry + a placeholder prompt. So the spine (capture, submit, grade, report) needed **no change**; this slice only adds the image slot + real content:

- **`prompts.ts`** — `SectionPrompt` gains an optional `imageSrc?: string`; the `picture` entry gets a real ICAO-style describe-the-scene instruction (placeholder token dropped) + `imageSrc: '/elp/prompts/picture-1.svg'`.
- **`section-runner-layout.tsx`** — renders `{imageSrc && <ZoomableImage … />}` (mirrors `QuestionCard`), placed **above** the instruction text so "Look at the picture…" references a stimulus already on screen (ICAO stimulus-first).
- **`oral-section-runner.tsx`** — threads `prompt.imageSrc` through.
- **`public/elp/prompts/picture-1.svg`** — a hand-authored **placeholder** aviation-scene SVG. Swapping in a real licensed photo later is a one-file change — the render path is permanent.

### Scope decisions (best-judgment MVP; open to change — nothing merged)
- **Image = placeholder SVG now**, real licensed photo later. (Alternatives considered: you supply an image; a randomized pool + media bucket — heavier.)
- **Grading = language-only.** The grader / `rubric.ts` / RPCs are **untouched** — the picture is a speaking stimulus, matching how real ICAO ELP scores picture-description (language, not content accuracy).
- **Single recording per section** — already enforced by `oral_exam_section_responses UNIQUE(session_id, section_no)`.

### Not touched
No migration, no RPC, no schema, no grader change → app-layer only, no prod deploy on eventual merge.

## Review pipeline (all green)
plan-critic 5 rounds (2 coverage + stability round B caught a real test-fixture-mislabel ISSUE → fixed → N=2 clean floor met); impl-critic ×2 APPROVED; code-reviewer clean; semantic-reviewer 0 CRITICAL/0 ISSUE/**5 GOOD** + 1 SUGGESTION applied (image-above-text, commit `b9112dd7`); PR-level semantic sweep 0/0/0/5 GOOD; doc-updater no-op; test-writer adequate (22 tests, both image branches covered); CR-local M=2 both clean. `pnpm lint`, `pnpm check-types`, `pnpm build` all clean; security-auditor pre-push APPROVED. Not security-path (no migrations/db/auth/quiz-actions/proxy) → no red-team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
