### PR TITLE
chore(agents): sync security-auditor checklist with security.md rules (#1101)

### DIFF
--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -17,12 +17,14 @@ Read the staged diff and check it against `docs/security.md`. Catch issues befor
 ## Inputs
 
 You receive:
-- `git diff origin/main...HEAD` — all changes being pushed
+- `git diff @{upstream}...HEAD` (fallback `origin/master`) — the changes being pushed, as computed by `.claude/hooks/run-security-auditor.sh`
 - `docs/security.md` — security rules
 - `docs/database.md` — database rules (soft delete, immutability, RPC conventions)
 - `.claude/agent-memory/security-auditor/findings.md` — your running log of past findings and patterns
 
 ## What to Check
+
+> This enumerated checklist mirrors the binding rules in `docs/security.md`. When a new security rule is promoted, a matching check is added here — enforced by `.claude/rules/agent-learner.md` §Sweep-On-Rule-Promotion (downstream-enforcer sync). You have `Read` access (see Inputs): use it to consult `docs/security.md`, `docs/database.md`, `packages/db/src/types.ts`, and the referenced migrations when a check calls for it.
 
 ### CRITICAL (always blocking)
 
@@ -88,13 +90,35 @@ You receive:
 15. **Audit log gaps**
     - New features involving student logins, quiz sessions, or exam completions that do not write to `audit_events`
 
+16. **Missing soft-delete filter in a SECURITY DEFINER SELECT** (docs/security.md §15 "Soft-delete in RPCs")
+    - A SELECT inside a new or modified `SECURITY DEFINER` function body **in this diff** reads a soft-deletable table without `AND deleted_at IS NULL`.
+    - Fires ONLY on genuinely soft-deletable tables — consult the `docs/database.md` §3 soft-delete matrix (or the seven no-`deleted_at` tables in `code-style.md` §5). Never flag `easa_subjects`, `easa_topics`, `easa_subtopics`, `quiz_session_answers`, `student_responses`, `audit_events`, `quiz_drafts`.
+    - Exception (a): the SELECT retrieves rows by IDs from an immutable write-once column AND the function is documented in `docs/security.md` §15 as doing so (covers both the frozen `quiz_sessions.config.question_ids` boundary and the `quiz_session_answers.question_id` report boundary). Read §15 to confirm membership — do NOT rely on a memorised list.
+    - Exception (b): an admin/restore RPC that intentionally surfaces soft-deleted rows (trash/undelete view) with documented inline intent.
+17. **Audit-event INSERT subquery missing soft-delete filter** (docs/security.md §11c "Audit-subquery soft-delete" row; canonical text `.claude/rules/security.md` rule 10)
+    - An `INSERT INTO audit_events (...)` in a new/modified DEFINER function whose `actor_id` / `actor_role` / session-derived subqueries omit `deleted_at IS NULL` on the user/session/question/membership FK lookup. The outer auth guard does not cover these independent subqueries.
+18. **Per-caller RPC over-scoped by multiple-permissive RLS** (docs/security.md §3 "Multiple Permissive SELECT Policies")
+    - A new/modified per-caller (non-admin) **SECURITY INVOKER or SECURITY DEFINER** function SELECTs from a table with multiple permissive SELECT policies — `student_responses`, `quiz_sessions`, `exam_configs`, `audit_events` — without owner scoping (`WHERE <owner> = auth.uid()` or an `auth.uid() = p_student_id` identity guard). RLS alone over-scopes to the broader instructor/admin policy (this bites SECURITY INVOKER too — the promoting bug `get_student_mastery_stats` was INVOKER).
+    - Exception: ownership already established by an earlier `auth.uid()` / `p_student_id` check on the owner row that scopes the later reads (subsequent SELECTs need not repeat the predicate); admin/org-wide RPCs behind `is_admin()`.
+19. **New start-session RPC missing the single-active-session guard** (docs/security.md §11d "Single-Active-Session Invariant")
+    - A new/modified DEFINER function INSERTs a `quiz_sessions` row (any mode) as active (`ended_at IS NULL`) without enforcing the invariant. Accept EITHER an explicit `RAISE ... another_session_active` pre-check OR reliance on the global partial unique index `uq_one_active_session_per_student` (mig 136) via a `unique_violation` exception handler.
+    - Exception: INSERTs that set `ended_at` non-null (backfills / already-ended rows) are not subject to the invariant.
+    - Advisory: per §11d, a start RPC should also soft-delete the caller's own abandoned `discovery` row BEFORE the `another_session_active` check — otherwise the student's own stale discovery row trips the invariant on their next start. Note if this step is absent.
+
 ### MEDIUM (warn, not blocking)
 
-16. `as SomeType` casts on unvalidated external data
-17. `console.log` statements that might print user data or tokens
-18. Missing `'use server'` directive on Server Actions
-19. Missing `'use client'` / `'use server'` boundary violations
-20. Dependencies added without a comment explaining why they're trusted
+20. **Sibling SECURITY DEFINER guard-set parity** (docs/security.md §11c) — advisory, never blocking
+    - When the diff adds/modifies a DEFINER RPC, note: verify its guard set (auth.uid() null-check, active-user/soft-deleted-caller gate, soft-delete filter, audit-subquery filter, `SET search_path`) against ALL sibling RPCs in the same feature family. The auditor cannot see siblings, so this is advisory — the universal guards are already enforced HIGH by check 8, and whether a function requires the active-user gate is a sibling determination made upstream by semantic-reviewer / implementation-critic.
+    - Exempt: admin/org-wide RPCs behind `is_admin()` (ownership); a function reading no soft-deletable table (soft-delete filter); a function with no `audit_events` INSERT (audit-subquery).
+21. `as SomeType` casts on unvalidated external data
+22. `console.log` statements that might print user data or tokens
+23. Missing `'use server'` directive on Server Actions
+24. Missing `'use client'` / `'use server'` boundary violations
+25. Dependencies added without a comment explaining why they're trusted
+
+### Pre-Flag Verification — trace the CREATE OR REPLACE chain (checks 16–20)
+
+Before flagging a missing guard/filter on a Postgres function (checks 16–20), trace the `CREATE OR REPLACE FUNCTION` chain to the LATEST definition. A `CREATE OR REPLACE` re-emits the ENTIRE body, so a one-line widening re-presents an already-approved function as all-new `+` lines — do NOT re-flag a guard that a later migration already added. Use your `Read` access to confirm the current definition, §15 membership, and the soft-delete matrix before emitting a finding. Account for the two-directory migration mirror (`packages/db/NNN_* ≡ supabase/timestamp_*`); neither directory is authoritative.
 
 ## Output Format
 
@@ -158,6 +182,14 @@ Update your memory file at `.claude/agent-memory/security-auditor/findings.md`:
    4. **JSDoc waiver present** — the Server Action has a comment documenting why auth delegation is safe (e.g., `// Delegated auth: Zod-validated input, RPC has SECURITY DEFINER + auth.uid(), non-sensitive response`)
 
    If ANY condition is missing, flag it. A missing waiver comment is MEDIUM; missing Zod validation or missing RPC auth is HIGH.
+
+8. **Do NOT flag check 16 on functions documented in `docs/security.md` §15** as reading a table by an immutable write-once column. Read §15 for the authoritative, current set of exempt functions — do NOT rely on a memorised or hardcoded list (§15 enumerates them and is kept current).
+
+9. **Do NOT flag check 18** on admin/org-wide RPCs behind `is_admin()`, nor when caller ownership was already established by an earlier `auth.uid()` / `p_student_id` check on the owner row that scopes the later reads.
+
+10. **Checks 16–20 apply ONLY to SECURITY INVOKER / SECURITY DEFINER function bodies present in the diff** (checks 16, 17, 19, 20 are DEFINER-specific by their own wording; check 18 also covers SECURITY INVOKER). The absence of such a function body is never itself a finding (`ALTER TABLE`, `CREATE INDEX`, and Server-Action-only migrations never trip them). These checks do NOT inherit item 7's "flag HIGH when the migration is unverifiable" default — that default is scoped to the auth-delegation check only.
+
+11. **Do NOT flag check 16 on an admin/restore RPC** that intentionally reads soft-deleted rows with documented inline intent (trash/undelete views).
 
 ## Tone
 

--- a/.claude/rules/agent-learner.md
+++ b/.claude/rules/agent-learner.md
@@ -38,6 +38,13 @@ The learner proposes, the orchestrator decides. Apply a change when:
 ## Sweep On Rule Promotion
 When a pattern is promoted to a hard rule (the count≥2 threshold above triggers a write to `security.md`, `code-style.md`, or `biome.json`), the orchestrator must schedule a one-time repo sweep for all existing instances of the pattern — not only the call sites that triggered the promotion. The sweep produces either same-session fixes (≤10 lines per site) or GitHub Issues for each remaining offender. Without this step, the rule is enforced on new code while pre-existing offenders silently linger (e.g., issue #573 — `start_quiz_session` audit subquery missed when security.md §10 was promoted via #550 at count=3).
 
+### Downstream-enforcer sync (in addition to the code sweep)
+The code sweep above fixes existing *call sites*. It does NOT keep the **static rule mirrors** current. When a promotion writes to `docs/security.md` or `.claude/rules/security.md`, the orchestrator must also audit the enforcers that carry a hand-maintained mirror of those rules and add a matching entry **in the same session**:
+- **`.claude/agents/security-auditor.md`** — the pre-push gate's enumerated checklist. It does not auto-track `docs/security.md`; a promoted rule with no matching check is enforced everywhere *except* the final pre-push defense. (Observed drift: `docs/security.md` soft-delete-in-RPC / audit-subquery / multiple-permissive / sibling-guard-parity / single-active rules had no auditor checks until they were back-filled.)
+- **`.coderabbit.yaml`** — already owned by coderabbit-sync (triggers on `security.md`/`code-style.md` changes); named here only so the full mirror set is visible in one place.
+
+This is the enforcer analogue of the call-site sweep: both close the "rule promoted, downstream lagging" gap. A promotion is not complete until every static mirror carries the rule.
+
 ---
 
 *Last updated: 2026-04-28*

--- a/.claude/rules/agent-security-auditor.md
+++ b/.claude/rules/agent-security-auditor.md
@@ -40,7 +40,12 @@ Final defense before code reaches the remote. Scans the push diff for security v
 - SECURITY DEFINER RPCs: missing `auth.uid()` check, missing `SET search_path = public`
 - Input validation: Server Actions or API routes without Zod `.parse()`
 - Security headers: CSP, HSTS, X-Frame-Options in `next.config.ts`
+- Soft-delete filter in SECURITY DEFINER SELECTs (docs/security.md §15); audit-event INSERT subquery soft-delete (§11c); per-caller RPC multiple-permissive-RLS scoping (§3); single-active-session start guard (§11d); sibling guard-set parity (§11c, advisory/MEDIUM)
+
+## Checklist ↔ security.md sync
+
+The auditor's enumerated checklist (`.claude/agents/security-auditor.md`) is a hand-maintained mirror of the binding rules in `docs/security.md`; it does not auto-track the doc. When a security rule is promoted, a matching check must be added to the auditor **in the same session** — enforced by `.claude/rules/agent-learner.md` §Sweep-On-Rule-Promotion (Downstream-enforcer sync). This note keeps the obligation discoverable from the auditor's own rules file.
 
 ---
 
-*Last updated: 2026-03-12*
+*Last updated: 2026-07-08 (added downstream-sync note + auditor checks for docs/security.md soft-delete-in-RPC / audit-subquery / multiple-permissive / single-active / sibling-parity rules).*


### PR DESCRIPTION
## What
Closes #1101. Syncs the pre-push `security-auditor` agent with the five `docs/security.md` rules it was silently under-enforcing, and installs a promotion-time trigger so it can't drift again.

**`.claude/agents/security-auditor.md`** — adds checks 16–19 (HIGH) + 20 (MEDIUM/advisory):
- 16 soft-delete filter in SECURITY DEFINER SELECTs (§15)
- 17 audit-event INSERT subquery soft-delete (§11c)
- 18 per-caller multiple-permissive-RLS scoping (§3 — SECURITY INVOKER *or* DEFINER)
- 19 single-active-session start guard (§11d)
- 20 sibling guard-set parity (§11c) — advisory, never blocking (the diff-only auditor can't see siblings)

Each carries the documented exception clauses + a CREATE-OR-REPLACE pre-flag-trace note (the auditor has `Read` access). Also fixes the stale `origin/main` diff-base doc line to `@{upstream}`/`origin/master`.

**`.claude/rules/agent-learner.md`** — extends §Sweep-On-Rule-Promotion with a **Downstream-enforcer sync** step (the drift root cause: no rule owned re-syncing this static mirror). **`.claude/rules/agent-security-auditor.md`** — discoverability note.

## Why
Weekly /insights found the auditor checklist mapped only rules 1–8; rules 9–13 (all promoted at count≥2–3) had no check, so the *final* pre-push defense under-enforced the most exploit-relevant rules.

## Scope / safety
Docs/agent-def only — **no code, migrations, or schema; no prod deploy.** Defense-in-depth ADD only (cannot weaken security). The blocking checks are keyed to diff-visible signals with exception clauses to avoid false-blocking legit migrations.

## Review
3 Opus plan-critic rounds (2 coverage + 1 stability) pre-approval; post-commit code-reviewer/doc-updater clean, semantic-reviewer 2 ISSUEs fixed → re-review CLEAN, impl-critic clean; CR-local 2 rounds no findings.

The /insights learner-memory curation is **deferred** to a separate pass (needs proper archive relocation first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified security-review guidance with stricter checks for soft-delete filtering, audit-event inserts, RPC scope, and single-active-session handling.
  * Added a verification step to reduce duplicate findings and improve consistency in audit results.

* **Chores**
  * Improved sync rules so security guidance updates are mirrored across related checklists in the same session.
  * Updated reference notes to reflect the latest documented security review practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->